### PR TITLE
Radarr-CF-UHD-WEBDV

### DIFF
--- a/docs/json/radarr/uhd-webdv.json
+++ b/docs/json/radarr/uhd-webdv.json
@@ -1,0 +1,53 @@
+{
+  "trash_id": "ac49fdbf6a662d380556f40ff4856f29",
+  "trash_score": "3000",
+  "name": "UHD (WEBDV)",
+  "includeCustomFormatWhenRenaming": false,
+  "specifications": [
+    {
+      "name": "REMUX-WEBDV",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": true,
+      "fields": {
+        "value": "\\bWEBDV\\b"
+      }
+    },
+    {
+      "name": "Not WEBDL",
+      "implementation": "SourceSpecification",
+      "negate": true,
+      "required": true,
+      "fields": {
+        "value": 7
+      }
+    },
+    {
+      "name": "Not WEBRIP",
+      "implementation": "SourceSpecification",
+      "negate": true,
+      "required": true,
+      "fields": {
+        "value": 8
+      }
+    },
+    {
+      "name": "2160p",
+      "implementation": "ResolutionSpecification",
+      "negate": false,
+      "required": true,
+      "fields": {
+        "value": 2160
+      }
+    },
+    {
+      "name": "Not SDR",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": true,
+      "required": true,
+      "fields": {
+        "value": "\\bSDR\\b"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Created: [UHD (WEBDV)] with a score of 3000, This is a hybrid release with the DV metadata from the webdl, cut, synced and added in missing metadata to make it fit for the Blu-ray! Will fallback to HDR if your device is not capable of DV.