### PR TITLE
Updated: Lowered scoring of CF [HDR]+[HDR (undefined)]

### DIFF
--- a/docs/json/radarr/hdr-undefined.json
+++ b/docs/json/radarr/hdr-undefined.json
@@ -1,6 +1,6 @@
 {
   "trash_id": "2a4d9069cc1fe3242ff9bdaebed239bb",
-  "trash_score": "900",
+  "trash_score": "850",
   "name": "HDR (undefined)",
   "includeCustomFormatWhenRenaming": false,
   "specifications": [

--- a/docs/json/radarr/hdr.json
+++ b/docs/json/radarr/hdr.json
@@ -1,6 +1,6 @@
 {
   "trash_id": "e61e28db95d22bedcadf030b8f156d96",
-  "trash_score": "900",
+  "trash_score": "850",
   "name": "HDR",
   "includeCustomFormatWhenRenaming": false,
   "specifications": [


### PR DESCRIPTION
Updated: CF [HDR]
- Changed: Score from 900 to 850, This should fix the few cases where HDR would be preferred over DoVi
Updated: CF [HDR (undefined)]
- Changed: Score from 900 to 850, This should fix the few cases where HDR would be preferred over DoVi