### PR TITLE
fix(starr): naming scheme for Emby

### DIFF
--- a/docs/Radarr/Radarr-recommended-naming-scheme.md
+++ b/docs/Radarr/Radarr-recommended-naming-scheme.md
@@ -15,7 +15,7 @@ The Tokens not available in the release won't be used/shown.
 
 ## Standard Movie Format
 
-This naming scheme is made to be compatible with the [New Plex Agent](https://forums.plex.tv/t/new-plex-media-server-movie-scanner-and-agent-preview/593269/517) that now supports IMDb and TMDb IDs in filenames, if you don't need it or want it just remove `{imdb-{ImdbId}}`
+This naming scheme is made to be compatible with the new [Plex Agent](https://forums.plex.tv/t/new-plex-media-server-movie-scanner-and-agent-preview/593269/517){:target="_blank" rel="noopener noreferrer"} that now supports IMDb and TMDb IDs in filenames, if you don't need it or want it just remove `{imdb-{ImdbId}}`
 
 !!! warning "Starting from v4.2.2.6489, Radarr now supports Plex Multiple Edition tags in naming."
 
@@ -138,7 +138,7 @@ RESULT:
 
 #### Optional Movies Folder Format with ID
 
-This naming scheme is made to be compatible with the new [Plex TV Series Scanner](https://forums.plex.tv/t/beta-new-plex-tv-series-scanner/696242){:target="_blank" rel="noopener noreferrer"} that now support IMDB and TVDB IDs in file names.
+This naming scheme is made to be compatible with the new [Plex Agent](https://forums.plex.tv/t/new-plex-media-server-movie-scanner-and-agent-preview/593269/517){:target="_blank" rel="noopener noreferrer"} that now support IMDB and TVDB IDs in file names.
 Emby/Jellyfin also support ID in the folder name.
 
 ##### Plex Optional Movies Folder Format

--- a/docs/Radarr/Radarr-recommended-naming-scheme.md
+++ b/docs/Radarr/Radarr-recommended-naming-scheme.md
@@ -25,6 +25,8 @@ This naming scheme is made to be compatible with the [New Plex Agent](https://fo
 
     !!! danger "Only use `{edition-{Edition Tags}}` if you are prepared to have movies separated by edition<br>when using a merged Plex library - e.g., you keep both 1080p and 2160p versions of one movie.<br><br>For example if you have the `Directors Cut` and the `Extended Cut` for one movie, those will show up as two separate movies in your library.<br><br>Note that not using `{edition-{Edition Tags}}` will prevent Plex from recognizing the edition."
 
+### Plex Standard Movie Format
+
 ```bash
 {{ radarr['naming']['radarr-naming']['file']['default'] }}
 ```
@@ -33,7 +35,7 @@ This naming scheme is made to be compatible with the [New Plex Agent](https://fo
 
     `The Movie Title (2010) {imdb-tt0066921} {edition-Ultimate Extended Edition} [IMAX HYBRID][Bluray-1080p Proper][3D][DV HDR10][DTS 5.1][x264]-EVOLVE`
 
-For Emby:
+### Emby Standard Movie Format
 
 ```bash
 {{ radarr['naming']['radarr-naming']['file']['emby'] }}
@@ -43,7 +45,7 @@ For Emby:
 
     `The Movie Title (2010) [imdbid=tt0066921] {edition-Ultimate Extended Edition} [IMAX HYBRID][Bluray-1080p Proper][3D][DV HDR10][DTS 5.1][x264]-EVOLVE`
 
-For Emby:
+### Jellyfin Standard Movie Format
 
 ```bash
 {{ radarr['naming']['radarr-naming']['file']['jellyfin'] }}
@@ -53,7 +55,7 @@ For Emby:
 
     `The Movie Title (2010) [imdbid-tt0066921] {edition-Ultimate Extended Edition} [IMAX HYBRID][Bluray-1080p Proper][3D][DV HDR10][DTS 5.1][x264]-EVOLVE`
 
-If you do Anime
+### Plex for Anime
 
 ```bash
 {{ radarr['naming']['radarr-naming']['file']['anime'] }}
@@ -63,7 +65,7 @@ If you do Anime
 
     `The Movie Title (2010) {imdb-tt0066921} {edition-Ultimate Extended Edition} [Surround Sound x264][Bluray-1080p Proper][3D][DTS 5.1][DE][10bit][AVC]-EVOLVE`
 
-For Emby:
+### Emby for Anime
 
 ```bash
 {{ radarr['naming']['radarr-naming']['file']['anime-emby'] }}
@@ -73,7 +75,7 @@ For Emby:
 
     `The Movie Title (2010) [imdbid=tt0066921] {edition-Ultimate Extended Edition} [Surround Sound x264][Bluray-1080p Proper][3D][DTS 5.1][DE][10bit][AVC]-EVOLVE`
 
-For Jellyfin:
+### Jellyfin for Anime
 
 ```bash
 {{ radarr['naming']['radarr-naming']['file']['anime-jellyfin'] }}
@@ -134,11 +136,12 @@ RESULT:
 
         TMDb is usually better as it guarantees a match, IMDb only gets matched if the TMDb entry has the correct IMDb ID association. We don't actually talk to IMDb.
 
-#### Optional Movies Folder Format for the Plex Movies Scanner and Jellyfin/Emby
+#### Optional Movies Folder Format with ID
 
 This naming scheme is made to be compatible with the new [Plex TV Series Scanner](https://forums.plex.tv/t/beta-new-plex-tv-series-scanner/696242){:target="_blank" rel="noopener noreferrer"} that now support IMDB and TVDB IDs in file names.
+Emby/Jellyfin also support ID in the folder name.
 
-For Plex:
+##### Plex Optional Movies Folder Format
 
 ```bash
 {{ radarr['naming']['radarr-naming']['folder']['plex'] }}
@@ -148,7 +151,7 @@ RESULT:
 
 `The Movie Title (2010) {imdb-tt1520211}`
 
-For Emby:
+##### Emby Optional Movies Folder Format
 
 ```bash
 {{ radarr['naming']['radarr-naming']['folder']['emby'] }}
@@ -158,7 +161,7 @@ RESULT:
 
 `The Movie Title (2010) [imdbid=tt1520211]`
 
-For Jellyfin:
+##### Jellyfin Optional Movies Folder Format
 
 ```bash
 {{ radarr['naming']['radarr-naming']['folder']['jellyfin'] }}

--- a/docs/Radarr/Radarr-recommended-naming-scheme.md
+++ b/docs/Radarr/Radarr-recommended-naming-scheme.md
@@ -33,10 +33,20 @@ This naming scheme is made to be compatible with the [New Plex Agent](https://fo
 
     `The Movie Title (2010) {imdb-tt0066921} {edition-Ultimate Extended Edition} [IMAX HYBRID][Bluray-1080p Proper][3D][DV HDR10][DTS 5.1][x264]-EVOLVE`
 
-For Jellyfin/Emby:
+For Emby:
 
 ```bash
 {{ radarr['naming']['radarr-naming']['file']['emby'] }}
+```
+
+??? abstract "RESULTS: - [CLICK TO EXPAND]"
+
+    `The Movie Title (2010) [imdbid=tt0066921] {edition-Ultimate Extended Edition} [IMAX HYBRID][Bluray-1080p Proper][3D][DV HDR10][DTS 5.1][x264]-EVOLVE`
+
+For Emby:
+
+```bash
+{{ radarr['naming']['radarr-naming']['file']['jellyfin'] }}
 ```
 
 ??? abstract "RESULTS: - [CLICK TO EXPAND]"
@@ -53,10 +63,20 @@ If you do Anime
 
     `The Movie Title (2010) {imdb-tt0066921} {edition-Ultimate Extended Edition} [Surround Sound x264][Bluray-1080p Proper][3D][DTS 5.1][DE][10bit][AVC]-EVOLVE`
 
-For Jellyfin/Emby:
+For Emby:
 
 ```bash
 {{ radarr['naming']['radarr-naming']['file']['anime-emby'] }}
+```
+
+??? abstract "RESULTS: - [CLICK TO EXPAND]"
+
+    `The Movie Title (2010) [imdbid=tt0066921] {edition-Ultimate Extended Edition} [Surround Sound x264][Bluray-1080p Proper][3D][DTS 5.1][DE][10bit][AVC]-EVOLVE`
+
+For Jellyfin:
+
+```bash
+{{ radarr['naming']['radarr-naming']['file']['anime-jellyfin'] }}
 ```
 
 ??? abstract "RESULTS: - [CLICK TO EXPAND]"
@@ -128,10 +148,20 @@ RESULT:
 
 `The Movie Title (2010) {imdb-tt1520211}`
 
-For Jellyfin/Emby:
+For Emby:
 
 ```bash
 {{ radarr['naming']['radarr-naming']['folder']['emby'] }}
+```
+
+RESULT:
+
+`The Movie Title (2010) [imdbid=tt1520211]`
+
+For Jellyfin:
+
+```bash
+{{ radarr['naming']['radarr-naming']['folder']['jellyfin'] }}
 ```
 
 RESULT:

--- a/docs/Sonarr/Sonarr-recommended-naming-scheme.md
+++ b/docs/Sonarr/Sonarr-recommended-naming-scheme.md
@@ -44,6 +44,7 @@ it gets imported correctly and isn't incorrectly matched as HDTV or WEB-DL etc.
 ## Daily Episode Format
 
 ### v3 Daily Episode Format
+
 ```bash
 {{ sonarr['naming']['sonarr-naming']['episodes']['daily']['default:3'] }}
 ```

--- a/docs/Sonarr/Sonarr-recommended-naming-scheme.md
+++ b/docs/Sonarr/Sonarr-recommended-naming-scheme.md
@@ -103,10 +103,20 @@ RESULT:
 
 `The Series Title! (2010) {imdb-tt1520211}`
 
-For Jellyfin/Emby:
+For Emby:
 
 ```bash
 {{ sonarr['naming']['sonarr-naming']['series']['emby'] }}
+```
+
+RESULT:
+
+`The Series Title! (2010) [tvdbid=tt1520211]`
+
+For Jellyfin:
+
+```bash
+{{ sonarr['naming']['sonarr-naming']['series']['jellyfin'] }}
 ```
 
 RESULT:

--- a/docs/Sonarr/Sonarr-recommended-naming-scheme.md
+++ b/docs/Sonarr/Sonarr-recommended-naming-scheme.md
@@ -15,15 +15,19 @@ it gets imported correctly and isn't incorrectly matched as HDTV or WEB-DL etc.
 
 ## Standard Episode Format
 
+### v3 Standard Episode Format
+
 ```bash
 {{ sonarr['naming']['sonarr-naming']['episodes']['standard']['default:3'] }}
 ```
 
-!!! warning "Sonarr V4 - Is now using Custom Formats instead of Release Profiles. Use the below naming scheme instead :warning:"
+### v4 Standard Episode Format
 
-    ```bash
-    {{ sonarr['naming']['sonarr-naming']['episodes']['standard']['default:4'] }}
-    ```
+!!! warning "Sonarr V4 - Is now using Custom Formats instead of Release Profiles(Preferred Words).<br>Use the below naming scheme instead :warning:"
+
+```bash
+{{ sonarr['naming']['sonarr-naming']['episodes']['standard']['default:4'] }}
+```
 
 ??? abstract "RESULTS: - [CLICK TO EXPAND]"
 
@@ -39,15 +43,18 @@ it gets imported correctly and isn't incorrectly matched as HDTV or WEB-DL etc.
 
 ## Daily Episode Format
 
+### v3 Daily Episode Format
 ```bash
 {{ sonarr['naming']['sonarr-naming']['episodes']['daily']['default:3'] }}
 ```
 
-!!! warning "Sonarr V4 - Is now using Custom Formats instead of Release Profiles. Use the below naming scheme instead :warning:"
+### v4 Daily Episode Format
 
-    ```bash
-    {{ sonarr['naming']['sonarr-naming']['episodes']['daily']['default:4'] }}
-    ```
+!!! warning "Sonarr V4 - Is now using Custom Formats instead of Release Profiles(Preferred Words).<br>Use the below naming scheme instead :warning:"
+
+```bash
+{{ sonarr['naming']['sonarr-naming']['episodes']['daily']['default:4'] }}
+```
 
 ??? abstract "RESULTS: - [CLICK TO EXPAND]"
 
@@ -57,15 +64,19 @@ it gets imported correctly and isn't incorrectly matched as HDTV or WEB-DL etc.
 
 ## Anime Episode Format
 
+### v3 Anime Episode Format
+
 ```bash
 {{ sonarr['naming']['sonarr-naming']['episodes']['anime']['default:3'] }}
 ```
 
-!!! warning "Sonarr V4 - Is now using Custom Formats instead of Release Profiles. Use the below naming scheme instead :warning:"
+### v4 Anime Episode Format
 
-    ```bash
-    {{ sonarr['naming']['sonarr-naming']['episodes']['anime']['default:4'] }}
-    ```
+!!! warning "Sonarr V4 - Is now using Custom Formats instead of Release Profiles(Preferred Words).<br>Use the below naming scheme instead :warning:"
+
+```bash
+{{ sonarr['naming']['sonarr-naming']['episodes']['anime']['default:4'] }}
+```
 
 ??? abstract "RESULTS: - [CLICK TO EXPAND]"
 
@@ -89,11 +100,12 @@ RESULT:
 
 `The Series Title! (2010)`
 
-#### Optional Series Folder Format for the Plex TV Series Scanner and Jellyfin/Emby
+#### Optional Series Folder Format with ID
 
 This naming scheme is made to be compatible with the new [Plex TV Series Scanner](https://forums.plex.tv/t/beta-new-plex-tv-series-scanner/696242){:target="_blank" rel="noopener noreferrer"} that now support IMDB and TVDB IDs in file names.
+Emby/Jellyfin also support ID in the folder name.
 
-For Plex:
+##### Plex Optional Series Folder Format
 
 ```bash
 {{ sonarr['naming']['sonarr-naming']['series']['plex'] }}
@@ -103,7 +115,7 @@ RESULT:
 
 `The Series Title! (2010) {imdb-tt1520211}`
 
-For Emby:
+##### Emby Optional Series Folder Format
 
 ```bash
 {{ sonarr['naming']['sonarr-naming']['series']['emby'] }}
@@ -111,9 +123,9 @@ For Emby:
 
 RESULT:
 
-`The Series Title! (2010) [tvdbid=tt1520211]`
+`The Series Title! (2010) [tvdbid=1520211]`
 
-For Jellyfin:
+##### Jellyfin Optional Series Folder Format
 
 ```bash
 {{ sonarr['naming']['sonarr-naming']['series']['jellyfin'] }}
@@ -121,7 +133,7 @@ For Jellyfin:
 
 RESULT:
 
-`The Series Title! (2010) [tvdbid-tt1520211]`
+`The Series Title! (2010) [tvdbid-1520211]`
 
 !!! tip
     IMDb IDs are going to be very accurate and rarely change, TVDB/TMDB IDs, on the other hand, do change or are removed more frequently.

--- a/docs/json/radarr/naming/radarr-naming.json
+++ b/docs/json/radarr/naming/radarr-naming.json
@@ -2,15 +2,15 @@
   "folder": {
       "default": "{Movie CleanTitle} ({Release Year})",
       "plex": "{Movie CleanTitle} ({Release Year}) {imdb-{ImdbId}}",
-      "emby": "{Movie CleanTitle} ({Release Year}) [imdbid-{ImdbId}]",
+      "emby": "{Movie CleanTitle} ({Release Year}) [imdbid={ImdbId}]",
       "jellyfin": "{Movie CleanTitle} ({Release Year}) [imdbid-{ImdbId}]"
   },
   "file": {
       "default": "{Movie CleanTitle} {(Release Year)} {imdb-{ImdbId}} {edition-{Edition Tags}} {[Custom Formats]}{[Quality Full]}{[MediaInfo 3D]}{[MediaInfo VideoDynamicRangeType]}{[Mediainfo AudioCodec}{ Mediainfo AudioChannels}][{Mediainfo VideoCodec}]{-Release Group}",
-      "emby": "{Movie CleanTitle} {(Release Year)} [imdbid-{ImdbId}] - {Edition Tags }{[Custom Formats]}{[Quality Full]}{[MediaInfo 3D]}{[MediaInfo VideoDynamicRangeType]}{[Mediainfo AudioCodec}{ Mediainfo AudioChannels}][{Mediainfo VideoCodec}]{-Release Group}",
+      "emby": "{Movie CleanTitle} {(Release Year)} [imdbid={ImdbId}] - {Edition Tags }{[Custom Formats]}{[Quality Full]}{[MediaInfo 3D]}{[MediaInfo VideoDynamicRangeType]}{[Mediainfo AudioCodec}{ Mediainfo AudioChannels}][{Mediainfo VideoCodec}]{-Release Group}",
       "jellyfin": "{Movie CleanTitle} {(Release Year)} [imdbid-{ImdbId}] - {Edition Tags }{[Custom Formats]}{[Quality Full]}{[MediaInfo 3D]}{[MediaInfo VideoDynamicRangeType]}{[Mediainfo AudioCodec}{ Mediainfo AudioChannels}][{Mediainfo VideoCodec}]{-Release Group}",
       "anime": "{Movie CleanTitle} {(Release Year)} {imdb-{ImdbId}} {edition-{Edition Tags}} {[Custom Formats]}{[Quality Full]}{[MediaInfo 3D]}{[MediaInfo VideoDynamicRangeType]}{[Mediainfo AudioCodec}{ Mediainfo AudioChannels}]{MediaInfo AudioLanguages}[{MediaInfo VideoBitDepth}bit][{Mediainfo VideoCodec}]{-Release Group}",
-      "anime-emby": "{Movie CleanTitle} {(Release Year)} [imdbid-{ImdbId}] - {Edition Tags }{[Custom Formats]}{[Quality Full]}{[MediaInfo 3D]}{[MediaInfo VideoDynamicRangeType]}{[Mediainfo AudioCodec}{ Mediainfo AudioChannels}]{MediaInfo AudioLanguages}[{MediaInfo VideoBitDepth}bit][{Mediainfo VideoCodec}]{-Release Group}",
+      "anime-emby": "{Movie CleanTitle} {(Release Year)} [imdbid={ImdbId}] - {Edition Tags }{[Custom Formats]}{[Quality Full]}{[MediaInfo 3D]}{[MediaInfo VideoDynamicRangeType]}{[Mediainfo AudioCodec}{ Mediainfo AudioChannels}]{MediaInfo AudioLanguages}[{MediaInfo VideoBitDepth}bit][{Mediainfo VideoCodec}]{-Release Group}",
       "anime-jellyfin": "{Movie CleanTitle} {(Release Year)} [imdbid-{ImdbId}] - {Edition Tags }{[Custom Formats]}{[Quality Full]}{[MediaInfo 3D]}{[MediaInfo VideoDynamicRangeType]}{[Mediainfo AudioCodec}{ Mediainfo AudioChannels}]{MediaInfo AudioLanguages}[{MediaInfo VideoBitDepth}bit][{Mediainfo VideoCodec}]{-Release Group}",
       "original": "{Original Title}"
     }

--- a/docs/json/sonarr/naming/sonarr-naming.json
+++ b/docs/json/sonarr/naming/sonarr-naming.json
@@ -5,7 +5,7 @@
   "series": {
       "default": "{Series TitleYear}",
       "plex": "{Series TitleYear} {imdb-{ImdbId}}",
-      "emby": "{Series TitleYear} [tvdbid-{TvdbId}]",
+      "emby": "{Series TitleYear} [tvdbid={TvdbId}]",
       "jellyfin": "{Series TitleYear} [tvdbid-{TvdbId}]"
   },
   "episodes": {


### PR DESCRIPTION
# Pull request

**Purpose**
Fix #1371

**Approach**
Separate Emby from Jellyfin from the naming scheme for both Sonarr and Radarr. Changed `-` to `=`

**Requirements**
Check all boxes as they are completed
- [x] check Radarr in local test setup
- [x] check Sonarr in local test setup
- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-/Guides/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
