### PR TITLE
ci: Fix markdown lint

### DIFF
--- a/.github/workflows/lint-markdown.yml
+++ b/.github/workflows/lint-markdown.yml
@@ -12,5 +12,5 @@ jobs:
           docker run --rm \
             -v "${GITHUB_WORKSPACE}":/data \
             markdownlint/markdownlint \
-            -c "/data/.markdownlint.jsonc" \
+            -r ~MD013,~MD033,~MD034,~MD046,~MD002,~MD041 \
             .

--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -1,8 +1,0 @@
-{
-  "default": true,
-  "MD013": false,
-  "MD033": false,
-  "MD024": false,
-  "MD028": false,
-  "MD046": fenced
-}


### PR DESCRIPTION
Commit fb6b49f9 introduced a regression in the markdown lint workflow by converting the inline configuration options to a `.markdownlint.jsonc` file. However, this file is not used by the Ruby version of markdownlint (which is used here). It is used by the Node version instead. The correct file would have been `.mdlrc`.

This commit simply restores the inline options as they were before that job was refactored out into its own file. This gets the lint logic working again without much fuss.
