### PR TITLE
fix(radarr): Update UHD Bluray Tier scores

### DIFF
--- a/docs/json/radarr/cf/uhd-bluray-tier-01.json
+++ b/docs/json/radarr/cf/uhd-bluray-tier-01.json
@@ -1,6 +1,6 @@
 {
   "trash_id": "4d74ac4c4db0b64bff6ce0cffef99bf0",
-  "trash_score": "2300",
+  "trash_score": "1800",
   "name": "UHD Bluray Tier 01",
   "includeCustomFormatWhenRenaming": false,
   "specifications": [

--- a/docs/json/radarr/cf/uhd-bluray-tier-02.json
+++ b/docs/json/radarr/cf/uhd-bluray-tier-02.json
@@ -1,6 +1,6 @@
 {
   "trash_id": "a58f517a70193f8e578056642178419d",
-  "trash_score": "2200",
+  "trash_score": "1750",
   "name": "UHD Bluray Tier 02",
   "includeCustomFormatWhenRenaming": false,
   "specifications": [

--- a/docs/json/radarr/cf/uhd-bluray-tier-03.json
+++ b/docs/json/radarr/cf/uhd-bluray-tier-03.json
@@ -1,6 +1,6 @@
 {
   "trash_id": "e71939fae578037e7aed3ee219bbe7c1",
-  "trash_score": "2100",
+  "trash_score": "1700",
   "name": "UHD Bluray Tier 03",
   "includeCustomFormatWhenRenaming": false,
   "specifications": [

--- a/docs/updates.txt
+++ b/docs/updates.txt
@@ -1,9 +1,13 @@
-# 2023-07-XX
+# 2023-07-15 14:45
 **[Fixed]**
 - [Radarr] The default scores for UHD Bluray Tier 1-3 custom formats have been amended to match the HD Bluray Tier 1-3 custom formats, so that they are compatible with the main guide.
   *Note - this is a breaking change for users using sync tools to sync SQP-2 and SQP-5 profiles. You will need to amend your configurations.*
 - [Guide] Added manual scores for UHD Bluray Tier 1-3 custom formats in SQP-2 and SQP-5. These manual scores are the same as the previous default scores, but now have to be set manually to override the new default scores.
 - [Guide] Added Remux Tier 03 custom format to the SQP-5 guide page
+- [Downloaders + Starr] Fix the EZTV regex to also match a dot or dash instead of a space character
+- [Guide] Updated the torguard affiliate code to be unique (50% OFF)
+- [Radarr] Add VISIONPLUSHDR to LQ group as they do fake HDR releases
+- [Radarr] Change regrade filter to match re-grade and regrade
 
 # 2023-07-09 12:40
 **[Updated]**

--- a/docs/updates.txt
+++ b/docs/updates.txt
@@ -1,3 +1,10 @@
+# 2023-07-XX
+**[Fixed]**
+- [Radarr] The default scores for UHD Bluray Tier 1-3 custom formats have been amended to match the HD Bluray Tier 1-3 custom formats, so that they are compatible with the main guide.
+  *Note - this is a breaking change for users using sync tools to sync SQP-2 and SQP-5 profiles. You will need to amend your configurations.*
+- [Guide] Added manual scores for UHD Bluray Tier 1-3 custom formats in SQP-2 and SQP-5. These manual scores are the same as the previous default scores, but now have to be set manually to override the new default scores.
+- [Guide] Added Remux Tier 03 custom format to the SQP-5 guide page
+
 # 2023-07-09 12:40
 **[Updated]**
 - [Sonarr] Add OViD streaming service CF

--- a/includes/sqp/1-4k-cf-scoring-sqp1.md
+++ b/includes/sqp/1-4k-cf-scoring-sqp1.md
@@ -5,20 +5,22 @@
 
     | Custom Format                                                                                                 |                                                Score | Trash ID                                          |
     | ------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------: | ------------------------------------------------- |
-    | [{{ radarr['cf']['truehd-atmos']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#truehd-atmos)       |                                     :warning: -10000 | {{ radarr['cf']['truehd-atmos']['trash_id'] }}    |
-    | [{{ radarr['cf']['dts-x']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#dts-x)                     |                                     :warning: -10000 | {{ radarr['cf']['dts-x']['trash_id'] }}           |
+    | [{{ radarr['cf']['truehd-atmos']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#truehd-atmos)       | :warning: -10000 :warning:                           | {{ radarr['cf']['truehd-atmos']['trash_id'] }}    |
+    | [{{ radarr['cf']['dts-x']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#dts-x)                     | :warning: -10000 :warning:                           | {{ radarr['cf']['dts-x']['trash_id'] }}           |
     | [{{ radarr['cf']['atmos-undefined']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#atmos-undefined) | {{ radarr['cf']['atmos-undefined']['trash_score'] }} | {{ radarr['cf']['atmos-undefined']['trash_id'] }} |
     | [{{ radarr['cf']['ddplus-atmos']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#ddplus-atmos)       |    {{ radarr['cf']['ddplus-atmos']['trash_score'] }} | {{ radarr['cf']['ddplus-atmos']['trash_id'] }}    |
-    | [{{ radarr['cf']['truehd']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#truehd)                   |                                     :warning: -10000 | {{ radarr['cf']['truehd']['trash_id'] }}          |
-    | [{{ radarr['cf']['dts-hd-ma']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#dts-hd-ma)             |                                     :warning: -10000 | {{ radarr['cf']['dts-hd-ma']['trash_id'] }}       |
-    | [{{ radarr['cf']['flac']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#flac)                       |                                          :warning: 0 | {{ radarr['cf']['flac']['trash_id'] }}            |
-    | [{{ radarr['cf']['pcm']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#pcm)                         |                                          :warning: 0 | {{ radarr['cf']['pcm']['trash_id'] }}             |
-    | [{{ radarr['cf']['dts-hd-hra']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#dts-hd-hra)           |                                     :warning: -10000 | {{ radarr['cf']['dts-hd-hra']['trash_id'] }}      |
+    | [{{ radarr['cf']['truehd']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#truehd)                   | :warning: -10000 :warning:                           | {{ radarr['cf']['truehd']['trash_id'] }}          |
+    | [{{ radarr['cf']['dts-hd-ma']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#dts-hd-ma)             | :warning: -10000 :warning:                           | {{ radarr['cf']['dts-hd-ma']['trash_id'] }}       |
+    | [{{ radarr['cf']['flac']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#flac)                       | :warning: 0 :warning:                                | {{ radarr['cf']['flac']['trash_id'] }}            |
+    | [{{ radarr['cf']['pcm']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#pcm)                         | :warning: 0 :warning:                                | {{ radarr['cf']['pcm']['trash_id'] }}             |
+    | [{{ radarr['cf']['dts-hd-hra']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#dts-hd-hra)           | :warning: -10000 :warning:                           | {{ radarr['cf']['dts-hd-hra']['trash_id'] }}      |
     | [{{ radarr['cf']['ddplus']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#ddplus)                   |          {{ radarr['cf']['ddplus']['trash_score'] }} | {{ radarr['cf']['ddplus']['trash_id'] }}          |
-    | [{{ radarr['cf']['dts-es']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#dts-es)                   |                                     :warning: -10000 | {{ radarr['cf']['dts-es']['trash_id'] }}          |
-    | [{{ radarr['cf']['dts']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#dts)                         |                                          :warning: 0 | {{ radarr['cf']['dts']['trash_id'] }}             |
-    | [{{ radarr['cf']['aac']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#aac)                         |                                          :warning: 0 | {{ radarr['cf']['aac']['trash_id'] }}             |
+    | [{{ radarr['cf']['dts-es']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#dts-es)                   | :warning: -10000 :warning:                           | {{ radarr['cf']['dts-es']['trash_id'] }}          |
+    | [{{ radarr['cf']['dts']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#dts)                         | :warning: 0 :warning:                                | {{ radarr['cf']['dts']['trash_id'] }}             |
+    | [{{ radarr['cf']['aac']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#aac)                         | :warning: 0 :warning:                                | {{ radarr['cf']['aac']['trash_id'] }}             |
     | [{{ radarr['cf']['dd']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#dd)                           |              {{ radarr['cf']['dd']['trash_score'] }} | {{ radarr['cf']['dd']['trash_id'] }}              |
+
+    !!! warning "Scores marked with a :warning: warning :warning: are different to those used in the main guide"
 
 ??? abstract "All HDR Formats + DV (WEBDL) - [CLICK TO EXPAND]"
 
@@ -69,9 +71,11 @@
     | [{{ radarr['cf']['web-tier-01']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#web-tier-01)                                | {{ radarr['cf']['web-tier-01']['trash_score'] }} | {{ radarr['cf']['web-tier-01']['trash_id'] }}       |
     | [{{ radarr['cf']['web-tier-02']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#web-tier-02)                                | {{ radarr['cf']['web-tier-02']['trash_score'] }} | {{ radarr['cf']['web-tier-02']['trash_id'] }}       |
     | [{{ radarr['cf']['web-tier-03']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#web-tier-03)                                | {{ radarr['cf']['web-tier-03']['trash_score'] }} | {{ radarr['cf']['web-tier-03']['trash_id'] }}       |
-    | [{{ radarr['cf']['hd-bluray-tier-01']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#hd-bluray-tier-01)                    |                                   :warning: 1100 | {{ radarr['cf']['hd-bluray-tier-01']['trash_id'] }} |
-    | [{{ radarr['cf']['hd-bluray-tier-02']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#hd-bluray-tier-02)                    |                                   :warning: 1050 | {{ radarr['cf']['hd-bluray-tier-02']['trash_id'] }} |
-    | [{{ radarr['cf']['hd-bluray-tier-03']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#hd-bluray-tier-03)                    |                                   :warning: 1000 | {{ radarr['cf']['hd-bluray-tier-03']['trash_id'] }} |
+    | [{{ radarr['cf']['hd-bluray-tier-01']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#hd-bluray-tier-01)                    | :warning: 1100 :warning:                         | {{ radarr['cf']['hd-bluray-tier-01']['trash_id'] }} |
+    | [{{ radarr['cf']['hd-bluray-tier-02']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#hd-bluray-tier-02)                    | :warning: 1050 :warning:                         | {{ radarr['cf']['hd-bluray-tier-02']['trash_id'] }} |
+    | [{{ radarr['cf']['hd-bluray-tier-03']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#hd-bluray-tier-03)                    | :warning: 1000 :warning:                         | {{ radarr['cf']['hd-bluray-tier-03']['trash_id'] }} |
+
+    !!! warning "Scores marked with a :warning: warning :warning: are different to those used in the main guide"
 
 {! include-markdown "../../includes/cf/radarr-misc.md" !}
 

--- a/includes/sqp/1-4k-cf-scoring.md
+++ b/includes/sqp/1-4k-cf-scoring.md
@@ -5,20 +5,22 @@
 
     | Custom Format                                                                                                 |                                                Score | Trash ID                                          |
     | ------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------: | ------------------------------------------------- |
-    | [{{ radarr['cf']['truehd-atmos']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#truehd-atmos)       |                                     :warning: -10000 | {{ radarr['cf']['truehd-atmos']['trash_id'] }}    |
-    | [{{ radarr['cf']['dts-x']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#dts-x)                     |                                     :warning: -10000 | {{ radarr['cf']['dts-x']['trash_id'] }}           |
+    | [{{ radarr['cf']['truehd-atmos']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#truehd-atmos)       | :warning: -10000 :warning:                           | {{ radarr['cf']['truehd-atmos']['trash_id'] }}    |
+    | [{{ radarr['cf']['dts-x']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#dts-x)                     | :warning: -10000 :warning:                           | {{ radarr['cf']['dts-x']['trash_id'] }}           |
     | [{{ radarr['cf']['atmos-undefined']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#atmos-undefined) | {{ radarr['cf']['atmos-undefined']['trash_score'] }} | {{ radarr['cf']['atmos-undefined']['trash_id'] }} |
     | [{{ radarr['cf']['ddplus-atmos']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#ddplus-atmos)       |    {{ radarr['cf']['ddplus-atmos']['trash_score'] }} | {{ radarr['cf']['ddplus-atmos']['trash_id'] }}    |
-    | [{{ radarr['cf']['truehd']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#truehd)                   |                                     :warning: -10000 | {{ radarr['cf']['truehd']['trash_id'] }}          |
-    | [{{ radarr['cf']['dts-hd-ma']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#dts-hd-ma)             |                                     :warning: -10000 | {{ radarr['cf']['dts-hd-ma']['trash_id'] }}       |
-    | [{{ radarr['cf']['flac']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#flac)                       |                                          :warning: 0 | {{ radarr['cf']['flac']['trash_id'] }}            |
-    | [{{ radarr['cf']['pcm']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#pcm)                         |                                          :warning: 0 | {{ radarr['cf']['pcm']['trash_id'] }}             |
-    | [{{ radarr['cf']['dts-hd-hra']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#dts-hd-hra)           |                                     :warning: -10000 | {{ radarr['cf']['dts-hd-hra']['trash_id'] }}      |
+    | [{{ radarr['cf']['truehd']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#truehd)                   | :warning: -10000 :warning:                           | {{ radarr['cf']['truehd']['trash_id'] }}          |
+    | [{{ radarr['cf']['dts-hd-ma']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#dts-hd-ma)             | :warning: -10000 :warning:                           | {{ radarr['cf']['dts-hd-ma']['trash_id'] }}       |
+    | [{{ radarr['cf']['flac']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#flac)                       | :warning: 0 :warning:                                | {{ radarr['cf']['flac']['trash_id'] }}            |
+    | [{{ radarr['cf']['pcm']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#pcm)                         | :warning: 0 :warning:                                | {{ radarr['cf']['pcm']['trash_id'] }}             |
+    | [{{ radarr['cf']['dts-hd-hra']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#dts-hd-hra)           | :warning: -10000 :warning:                           | {{ radarr['cf']['dts-hd-hra']['trash_id'] }}      |
     | [{{ radarr['cf']['ddplus']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#ddplus)                   |          {{ radarr['cf']['ddplus']['trash_score'] }} | {{ radarr['cf']['ddplus']['trash_id'] }}          |
-    | [{{ radarr['cf']['dts-es']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#dts-es)                   |                                     :warning: -10000 | {{ radarr['cf']['dts-es']['trash_id'] }}          |
-    | [{{ radarr['cf']['dts']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#dts)                         |                                          :warning: 0 | {{ radarr['cf']['dts']['trash_id'] }}             |
-    | [{{ radarr['cf']['aac']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#aac)                         |                                          :warning: 0 | {{ radarr['cf']['aac']['trash_id'] }}             |
+    | [{{ radarr['cf']['dts-es']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#dts-es)                   | :warning: -10000 :warning:                           | {{ radarr['cf']['dts-es']['trash_id'] }}          |
+    | [{{ radarr['cf']['dts']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#dts)                         | :warning: 0 :warning:                                | {{ radarr['cf']['dts']['trash_id'] }}             |
+    | [{{ radarr['cf']['aac']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#aac)                         | :warning: 0 :warning:                                | {{ radarr['cf']['aac']['trash_id'] }}             |
     | [{{ radarr['cf']['dd']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#dd)                           |              {{ radarr['cf']['dd']['trash_score'] }} | {{ radarr['cf']['dd']['trash_id'] }}              |
+
+    !!! warning "Scores marked with a :warning: warning :warning: are different to those used in the main guide"
 
 ??? abstract "All HDR Formats + DV (WEBDL) - [CLICK TO EXPAND]"
 
@@ -69,9 +71,11 @@
     | [{{ radarr['cf']['web-tier-01']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#web-tier-01)                                | {{ radarr['cf']['web-tier-01']['trash_score'] }} | {{ radarr['cf']['web-tier-01']['trash_id'] }}       |
     | [{{ radarr['cf']['web-tier-02']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#web-tier-02)                                | {{ radarr['cf']['web-tier-02']['trash_score'] }} | {{ radarr['cf']['web-tier-02']['trash_id'] }}       |
     | [{{ radarr['cf']['web-tier-03']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#web-tier-03)                                | {{ radarr['cf']['web-tier-03']['trash_score'] }} | {{ radarr['cf']['web-tier-03']['trash_id'] }}       |
-    | [{{ radarr['cf']['hd-bluray-tier-01']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#hd-bluray-tier-01)                    |                                   :warning: 1100 | {{ radarr['cf']['hd-bluray-tier-01']['trash_id'] }} |
-    | [{{ radarr['cf']['hd-bluray-tier-02']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#hd-bluray-tier-02)                    |                                   :warning: 1050 | {{ radarr['cf']['hd-bluray-tier-02']['trash_id'] }} |
-    | [{{ radarr['cf']['hd-bluray-tier-03']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#hd-bluray-tier-03)                    |                                   :warning: 1000 | {{ radarr['cf']['hd-bluray-tier-03']['trash_id'] }} |
+    | [{{ radarr['cf']['hd-bluray-tier-01']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#hd-bluray-tier-01)                    | :warning: 1100 :warning:                         | {{ radarr['cf']['hd-bluray-tier-01']['trash_id'] }} |
+    | [{{ radarr['cf']['hd-bluray-tier-02']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#hd-bluray-tier-02)                    | :warning: 1050 :warning:                         | {{ radarr['cf']['hd-bluray-tier-02']['trash_id'] }} |
+    | [{{ radarr['cf']['hd-bluray-tier-03']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#hd-bluray-tier-03)                    | :warning: 1000 :warning:                         | {{ radarr['cf']['hd-bluray-tier-03']['trash_id'] }} |
+
+    !!! warning "Scores marked with a :warning: warning :warning: are different to those used in the main guide"
 
 {! include-markdown "../../includes/cf/radarr-misc.md" !}
 

--- a/includes/sqp/1-cf-scoring.md
+++ b/includes/sqp/1-cf-scoring.md
@@ -3,22 +3,24 @@
 ??? abstract "Audio - [CLICK TO EXPAND]"
     !!! danger "The CF with `0` you can choose to add with a score of `0` or just don't add them.<br>The reason why we score them this low is to prevent transcoding as much as possible<br>The reason why `DTS` has a score of `0` is to make sure you don't limit your self to much."
 
-    | Custom Format                                                                                                 |            Score | Trash ID                                          |
-    | ------------------------------------------------------------------------------------------------------------- | ---------------: | ------------------------------------------------- |
-    | [{{ radarr['cf']['truehd-atmos']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#truehd-atmos)       | :warning: -10000 | {{ radarr['cf']['truehd-atmos']['trash_id'] }}    |
-    | [{{ radarr['cf']['dts-x']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#dts-x)                     | :warning: -10000 | {{ radarr['cf']['dts-x']['trash_id'] }}           |
-    | [{{ radarr['cf']['atmos-undefined']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#atmos-undefined) |      :warning: 0 | {{ radarr['cf']['atmos-undefined']['trash_id'] }} |
-    | [{{ radarr['cf']['ddplus-atmos']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#ddplus-atmos)       |      :warning: 0 | {{ radarr['cf']['ddplus-atmos']['trash_id'] }}    |
-    | [{{ radarr['cf']['truehd']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#truehd)                   | :warning: -10000 | {{ radarr['cf']['truehd']['trash_id'] }}          |
-    | [{{ radarr['cf']['dts-hd-ma']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#dts-hd-ma)             | :warning: -10000 | {{ radarr['cf']['dts-hd-ma']['trash_id'] }}       |
-    | [{{ radarr['cf']['flac']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#flac)                       |      :warning: 0 | {{ radarr['cf']['flac']['trash_id'] }}            |
-    | [{{ radarr['cf']['pcm']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#pcm)                         |      :warning: 0 | {{ radarr['cf']['pcm']['trash_id'] }}             |
-    | [{{ radarr['cf']['dts-hd-hra']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#dts-hd-hra)           | :warning: -10000 | {{ radarr['cf']['dts-hd-hra']['trash_id'] }}      |
-    | [{{ radarr['cf']['ddplus']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#ddplus)                   |      :warning: 0 | {{ radarr['cf']['ddplus']['trash_id'] }}          |
-    | [{{ radarr['cf']['dts-es']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#dts-es)                   | :warning: -10000 | {{ radarr['cf']['dts-es']['trash_id'] }}          |
-    | [{{ radarr['cf']['dts']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#dts)                         |      :warning: 0 | {{ radarr['cf']['dts']['trash_id'] }}             |
-    | [{{ radarr['cf']['aac']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#aac)                         |      :warning: 0 | {{ radarr['cf']['aac']['trash_id'] }}             |
-    | [{{ radarr['cf']['dd']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#dd)                           |      :warning: 0 | {{ radarr['cf']['dd']['trash_id'] }}              |
+    | Custom Format                                                                                                 |            Score           | Trash ID                                          |
+    | ------------------------------------------------------------------------------------------------------------- | -------------------------: | ------------------------------------------------- |
+    | [{{ radarr['cf']['truehd-atmos']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#truehd-atmos)       | :warning: -10000 :warning: | {{ radarr['cf']['truehd-atmos']['trash_id'] }}    |
+    | [{{ radarr['cf']['dts-x']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#dts-x)                     | :warning: -10000 :warning: | {{ radarr['cf']['dts-x']['trash_id'] }}           |
+    | [{{ radarr['cf']['atmos-undefined']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#atmos-undefined) | :warning: 0 :warning:      | {{ radarr['cf']['atmos-undefined']['trash_id'] }} |
+    | [{{ radarr['cf']['ddplus-atmos']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#ddplus-atmos)       | :warning: 0 :warning:      | {{ radarr['cf']['ddplus-atmos']['trash_id'] }}    |
+    | [{{ radarr['cf']['truehd']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#truehd)                   | :warning: -10000 :warning: | {{ radarr['cf']['truehd']['trash_id'] }}          |
+    | [{{ radarr['cf']['dts-hd-ma']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#dts-hd-ma)             | :warning: -10000 :warning: | {{ radarr['cf']['dts-hd-ma']['trash_id'] }}       |
+    | [{{ radarr['cf']['flac']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#flac)                       | :warning: 0 :warning:      | {{ radarr['cf']['flac']['trash_id'] }}            |
+    | [{{ radarr['cf']['pcm']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#pcm)                         | :warning: 0 :warning:      | {{ radarr['cf']['pcm']['trash_id'] }}             |
+    | [{{ radarr['cf']['dts-hd-hra']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#dts-hd-hra)           | :warning: -10000 :warning: | {{ radarr['cf']['dts-hd-hra']['trash_id'] }}      |
+    | [{{ radarr['cf']['ddplus']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#ddplus)                   | :warning: 0 :warning:      | {{ radarr['cf']['ddplus']['trash_id'] }}          |
+    | [{{ radarr['cf']['dts-es']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#dts-es)                   | :warning: -10000 :warning: | {{ radarr['cf']['dts-es']['trash_id'] }}          |
+    | [{{ radarr['cf']['dts']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#dts)                         | :warning: 0 :warning:      | {{ radarr['cf']['dts']['trash_id'] }}             |
+    | [{{ radarr['cf']['aac']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#aac)                         | :warning: 0 :warning:      | {{ radarr['cf']['aac']['trash_id'] }}             |
+    | [{{ radarr['cf']['dd']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#dd)                           | :warning: 0 :warning:      | {{ radarr['cf']['dd']['trash_id'] }}              |
+
+    !!! warning "Scores marked with a :warning: warning :warning: are different to those used in the main guide"
 
 ??? abstract "Movie Versions - [CLICK TO EXPAND]"
 
@@ -51,9 +53,11 @@
     | [{{ radarr['cf']['web-tier-01']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#web-tier-01)                                | {{ radarr['cf']['web-tier-01']['trash_score'] }} | {{ radarr['cf']['web-tier-01']['trash_id'] }}       |
     | [{{ radarr['cf']['web-tier-02']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#web-tier-02)                                | {{ radarr['cf']['web-tier-02']['trash_score'] }} | {{ radarr['cf']['web-tier-02']['trash_id'] }}       |
     | [{{ radarr['cf']['web-tier-03']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#web-tier-03)                                | {{ radarr['cf']['web-tier-03']['trash_score'] }} | {{ radarr['cf']['web-tier-03']['trash_id'] }}       |
-    | [{{ radarr['cf']['hd-bluray-tier-01']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#hd-bluray-tier-01)                    |                                   :warning: 1100 | {{ radarr['cf']['hd-bluray-tier-01']['trash_id'] }} |
-    | [{{ radarr['cf']['hd-bluray-tier-02']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#hd-bluray-tier-02)                    |                                   :warning: 1050 | {{ radarr['cf']['hd-bluray-tier-02']['trash_id'] }} |
-    | [{{ radarr['cf']['hd-bluray-tier-03']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#hd-bluray-tier-03)                    |                                   :warning: 1000 | {{ radarr['cf']['hd-bluray-tier-03']['trash_id'] }} |
+    | [{{ radarr['cf']['hd-bluray-tier-01']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#hd-bluray-tier-01)                    | :warning: 1100 :warning:                         | {{ radarr['cf']['hd-bluray-tier-01']['trash_id'] }} |
+    | [{{ radarr['cf']['hd-bluray-tier-02']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#hd-bluray-tier-02)                    | :warning: 1050 :warning:                         | {{ radarr['cf']['hd-bluray-tier-02']['trash_id'] }} |
+    | [{{ radarr['cf']['hd-bluray-tier-03']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#hd-bluray-tier-03)                    | :warning: 1000 :warning:                         | {{ radarr['cf']['hd-bluray-tier-03']['trash_id'] }} |
+
+    !!! warning "Scores marked with a :warning: warning :warning: are different to those used in the main guide"
 
 {! include-markdown "../../includes/cf/radarr-misc.md" !}
 

--- a/includes/sqp/2-cf-scoring.md
+++ b/includes/sqp/2-cf-scoring.md
@@ -12,15 +12,14 @@
     | [{{ radarr['cf']['remux-tier-01']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#remux-tier-01)           | {{ radarr['cf']['remux-tier-01']['trash_score'] }}      | {{ radarr['cf']['remux-tier-01']['trash_id'] }}      |
     | [{{ radarr['cf']['remux-tier-02']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#remux-tier-02)           | {{ radarr['cf']['remux-tier-02']['trash_score'] }}      | {{ radarr['cf']['remux-tier-02']['trash_id'] }}      |
     | [{{ radarr['cf']['remux-tier-03']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#remux-tier-03)           | {{ radarr['cf']['remux-tier-03']['trash_score'] }}      | {{ radarr['cf']['remux-tier-03']['trash_id'] }}      |
-    | [{{ radarr['cf']['uhd-bluray-tier-01']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#uhd-bluray-tier-01) |                                          :warning: 2300 | {{ radarr['cf']['uhd-bluray-tier-01']['trash_id'] }} |
-    | [{{ radarr['cf']['uhd-bluray-tier-02']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#uhd-bluray-tier-02) |                                          :warning: 2200 | {{ radarr['cf']['uhd-bluray-tier-02']['trash_id'] }} |
-    | [{{ radarr['cf']['uhd-bluray-tier-03']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#uhd-bluray-tier-03) |                                          :warning: 2100 | {{ radarr['cf']['uhd-bluray-tier-03']['trash_id'] }} |
+    | [{{ radarr['cf']['uhd-bluray-tier-01']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#uhd-bluray-tier-01) | :warning: 2300 :warning:                                | {{ radarr['cf']['uhd-bluray-tier-01']['trash_id'] }} |
+    | [{{ radarr['cf']['uhd-bluray-tier-02']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#uhd-bluray-tier-02) | :warning: 2200 :warning:                                | {{ radarr['cf']['uhd-bluray-tier-02']['trash_id'] }} |
+    | [{{ radarr['cf']['uhd-bluray-tier-03']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#uhd-bluray-tier-03) | :warning: 2100 :warning:                                | {{ radarr['cf']['uhd-bluray-tier-03']['trash_id'] }} |
     | [{{ radarr['cf']['web-tier-01']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#web-tier-01)               | {{ radarr['cf']['web-tier-01']['trash_score'] }}        | {{ radarr['cf']['web-tier-01']['trash_id'] }}        |
     | [{{ radarr['cf']['web-tier-02']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#web-tier-02)               | {{ radarr['cf']['web-tier-02']['trash_score'] }}        | {{ radarr['cf']['web-tier-02']['trash_id'] }}        |
     | [{{ radarr['cf']['web-tier-03']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#web-tier-03)               | {{ radarr['cf']['web-tier-03']['trash_score'] }}        | {{ radarr['cf']['web-tier-03']['trash_id'] }}        |
 
-    !!! warning "Custom Scores"
-    Scores marked with a :warning: warning :warning: are different to those used in the main guide.
+    !!! warning "Scores marked with a :warning: warning :warning: are different to those used in the main guide"
 
 {! include-markdown "../../includes/sqp/uhd-radarr-misc.md" !}
 

--- a/includes/sqp/2-cf-scoring.md
+++ b/includes/sqp/2-cf-scoring.md
@@ -12,12 +12,15 @@
     | [{{ radarr['cf']['remux-tier-01']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#remux-tier-01)           | {{ radarr['cf']['remux-tier-01']['trash_score'] }}      | {{ radarr['cf']['remux-tier-01']['trash_id'] }}      |
     | [{{ radarr['cf']['remux-tier-02']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#remux-tier-02)           | {{ radarr['cf']['remux-tier-02']['trash_score'] }}      | {{ radarr['cf']['remux-tier-02']['trash_id'] }}      |
     | [{{ radarr['cf']['remux-tier-03']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#remux-tier-03)           | {{ radarr['cf']['remux-tier-03']['trash_score'] }}      | {{ radarr['cf']['remux-tier-03']['trash_id'] }}      |
-    | [{{ radarr['cf']['uhd-bluray-tier-01']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#uhd-bluray-tier-01) | {{ radarr['cf']['uhd-bluray-tier-01']['trash_score'] }} | {{ radarr['cf']['uhd-bluray-tier-01']['trash_id'] }} |
-    | [{{ radarr['cf']['uhd-bluray-tier-02']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#uhd-bluray-tier-02) | {{ radarr['cf']['uhd-bluray-tier-02']['trash_score'] }} | {{ radarr['cf']['uhd-bluray-tier-02']['trash_id'] }} |
-    | [{{ radarr['cf']['uhd-bluray-tier-03']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#uhd-bluray-tier-03) | {{ radarr['cf']['uhd-bluray-tier-03']['trash_score'] }} | {{ radarr['cf']['uhd-bluray-tier-03']['trash_id'] }} |
+    | [{{ radarr['cf']['uhd-bluray-tier-01']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#uhd-bluray-tier-01) |                                          :warning: 2300 | {{ radarr['cf']['uhd-bluray-tier-01']['trash_id'] }} |
+    | [{{ radarr['cf']['uhd-bluray-tier-02']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#uhd-bluray-tier-02) |                                          :warning: 2200 | {{ radarr['cf']['uhd-bluray-tier-02']['trash_id'] }} |
+    | [{{ radarr['cf']['uhd-bluray-tier-03']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#uhd-bluray-tier-03) |                                          :warning: 2100 | {{ radarr['cf']['uhd-bluray-tier-03']['trash_id'] }} |
     | [{{ radarr['cf']['web-tier-01']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#web-tier-01)               | {{ radarr['cf']['web-tier-01']['trash_score'] }}        | {{ radarr['cf']['web-tier-01']['trash_id'] }}        |
     | [{{ radarr['cf']['web-tier-02']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#web-tier-02)               | {{ radarr['cf']['web-tier-02']['trash_score'] }}        | {{ radarr['cf']['web-tier-02']['trash_id'] }}        |
     | [{{ radarr['cf']['web-tier-03']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#web-tier-03)               | {{ radarr['cf']['web-tier-03']['trash_score'] }}        | {{ radarr['cf']['web-tier-03']['trash_id'] }}        |
+
+    !!! warning "Custom Scores"
+    Scores marked with a :warning: warning :warning: are different to those used in the main guide.
 
 {! include-markdown "../../includes/sqp/uhd-radarr-misc.md" !}
 

--- a/includes/sqp/5-cf-scoring.md
+++ b/includes/sqp/5-cf-scoring.md
@@ -12,15 +12,14 @@
     | [{{ radarr['cf']['remux-tier-01']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#remux-tier-01)           | {{ radarr['cf']['remux-tier-01']['trash_score'] }}      | {{ radarr['cf']['remux-tier-01']['trash_id'] }}      |
     | [{{ radarr['cf']['remux-tier-02']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#remux-tier-02)           | {{ radarr['cf']['remux-tier-02']['trash_score'] }}      | {{ radarr['cf']['remux-tier-02']['trash_id'] }}      |
     | [{{ radarr['cf']['remux-tier-03']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#remux-tier-03)           | {{ radarr['cf']['remux-tier-03']['trash_score'] }}      | {{ radarr['cf']['remux-tier-03']['trash_id'] }}      |
-    | [{{ radarr['cf']['uhd-bluray-tier-01']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#uhd-bluray-tier-01) |                                          :warning: 2300 | {{ radarr['cf']['uhd-bluray-tier-01']['trash_id'] }} |
-    | [{{ radarr['cf']['uhd-bluray-tier-02']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#uhd-bluray-tier-02) |                                          :warning: 2200 | {{ radarr['cf']['uhd-bluray-tier-02']['trash_id'] }} |
-    | [{{ radarr['cf']['uhd-bluray-tier-03']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#uhd-bluray-tier-03) |                                          :warning: 2100 | {{ radarr['cf']['uhd-bluray-tier-03']['trash_id'] }} |
+    | [{{ radarr['cf']['uhd-bluray-tier-01']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#uhd-bluray-tier-01) | :warning: 2300 :warning:                                | {{ radarr['cf']['uhd-bluray-tier-01']['trash_id'] }} |
+    | [{{ radarr['cf']['uhd-bluray-tier-02']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#uhd-bluray-tier-02) | :warning: 2200 :warning:                                | {{ radarr['cf']['uhd-bluray-tier-02']['trash_id'] }} |
+    | [{{ radarr['cf']['uhd-bluray-tier-03']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#uhd-bluray-tier-03) | :warning: 2100 :warning:                                | {{ radarr['cf']['uhd-bluray-tier-03']['trash_id'] }} |
     | [{{ radarr['cf']['web-tier-01']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#web-tier-01)               | {{ radarr['cf']['web-tier-01']['trash_score'] }}        | {{ radarr['cf']['web-tier-01']['trash_id'] }}        |
     | [{{ radarr['cf']['web-tier-02']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#web-tier-02)               | {{ radarr['cf']['web-tier-02']['trash_score'] }}        | {{ radarr['cf']['web-tier-02']['trash_id'] }}        |
     | [{{ radarr['cf']['web-tier-03']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#web-tier-03)               | {{ radarr['cf']['web-tier-03']['trash_score'] }}        | {{ radarr['cf']['web-tier-03']['trash_id'] }}        |
 
-    !!! warning "Custom Scores"
-    Scores marked with a :warning: warning :warning: are different to those used in the main guide.
+    !!! warning "Scores marked with a :warning: warning :warning: are different to those used in the main guide"
 
 {! include-markdown "../../includes/sqp/uhd-radarr-misc.md" !}
 

--- a/includes/sqp/5-cf-scoring.md
+++ b/includes/sqp/5-cf-scoring.md
@@ -11,12 +11,16 @@
     | ------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- | ---------------------------------------------------- |
     | [{{ radarr['cf']['remux-tier-01']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#remux-tier-01)           | {{ radarr['cf']['remux-tier-01']['trash_score'] }}      | {{ radarr['cf']['remux-tier-01']['trash_id'] }}      |
     | [{{ radarr['cf']['remux-tier-02']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#remux-tier-02)           | {{ radarr['cf']['remux-tier-02']['trash_score'] }}      | {{ radarr['cf']['remux-tier-02']['trash_id'] }}      |
-    | [{{ radarr['cf']['uhd-bluray-tier-01']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#uhd-bluray-tier-01) | {{ radarr['cf']['uhd-bluray-tier-01']['trash_score'] }} | {{ radarr['cf']['uhd-bluray-tier-01']['trash_id'] }} |
-    | [{{ radarr['cf']['uhd-bluray-tier-02']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#uhd-bluray-tier-02) | {{ radarr['cf']['uhd-bluray-tier-02']['trash_score'] }} | {{ radarr['cf']['uhd-bluray-tier-02']['trash_id'] }} |
-    | [{{ radarr['cf']['uhd-bluray-tier-03']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#uhd-bluray-tier-03) | {{ radarr['cf']['uhd-bluray-tier-03']['trash_score'] }} | {{ radarr['cf']['uhd-bluray-tier-03']['trash_id'] }} |
+    | [{{ radarr['cf']['remux-tier-03']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#remux-tier-03)           | {{ radarr['cf']['remux-tier-03']['trash_score'] }}      | {{ radarr['cf']['remux-tier-03']['trash_id'] }}      |
+    | [{{ radarr['cf']['uhd-bluray-tier-01']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#uhd-bluray-tier-01) |                                          :warning: 2300 | {{ radarr['cf']['uhd-bluray-tier-01']['trash_id'] }} |
+    | [{{ radarr['cf']['uhd-bluray-tier-02']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#uhd-bluray-tier-02) |                                          :warning: 2200 | {{ radarr['cf']['uhd-bluray-tier-02']['trash_id'] }} |
+    | [{{ radarr['cf']['uhd-bluray-tier-03']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#uhd-bluray-tier-03) |                                          :warning: 2100 | {{ radarr['cf']['uhd-bluray-tier-03']['trash_id'] }} |
     | [{{ radarr['cf']['web-tier-01']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#web-tier-01)               | {{ radarr['cf']['web-tier-01']['trash_score'] }}        | {{ radarr['cf']['web-tier-01']['trash_id'] }}        |
     | [{{ radarr['cf']['web-tier-02']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#web-tier-02)               | {{ radarr['cf']['web-tier-02']['trash_score'] }}        | {{ radarr['cf']['web-tier-02']['trash_id'] }}        |
     | [{{ radarr['cf']['web-tier-03']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#web-tier-03)               | {{ radarr['cf']['web-tier-03']['trash_score'] }}        | {{ radarr['cf']['web-tier-03']['trash_id'] }}        |
+
+    !!! warning "Custom Scores"
+    Scores marked with a :warning: warning :warning: are different to those used in the main guide.
 
 {! include-markdown "../../includes/sqp/uhd-radarr-misc.md" !}
 

--- a/includes/sqp/uhd-radarr-misc.md
+++ b/includes/sqp/uhd-radarr-misc.md
@@ -3,7 +3,9 @@
     | -------------------------------------------------------------------------------------------------------- | -------------------------------------------------: | ----------------------------------------------- |
     | [{{ radarr['cf']['repack-proper']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#repackproper) | {{ radarr['cf']['repack-proper']['trash_score'] }} | {{ radarr['cf']['repack-proper']['trash_id'] }} |
     | [{{ radarr['cf']['repack2']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#repack2)            | {{ radarr['cf']['repack2']['trash_score'] }}       | {{ radarr['cf']['repack2']['trash_id'] }}       |
-    | [{{ radarr['cf']['x264']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#x264)                  | :warning: -10000                                   | {{ radarr['cf']['x264']['trash_id'] }}          |
+    | [{{ radarr['cf']['x264']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#x264)                  | :warning: -10000 :warning:                         | {{ radarr['cf']['x264']['trash_id'] }}          |
+
+    !!! warning "Scores marked with a :warning: warning :warning: are different to those used in the main guide"
 
     ------
     Breakdown and Why

--- a/includes/sqp/uhd-radarr-resolution.md
+++ b/includes/sqp/uhd-radarr-resolution.md
@@ -2,4 +2,6 @@
     | Custom Format                                                                                                                | Score                                      | Trash ID                                |
     | ---------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------ | --------------------------------------- |
     | [{{ radarr['cf']['1080p']['name'] }}](https://raw.githubusercontent.com/TRaSH-/Guides/master/docs/json/radarr/cf/1080p.json) | {{ radarr['cf']['1080p']['trash_score'] }} | {{ radarr['cf']['1080p']['trash_id'] }} |
-    | [{{ radarr['cf']['2160p']['name'] }}](https://raw.githubusercontent.com/TRaSH-/Guides/master/docs/json/radarr/cf/2160p.json) | 151 | {{ radarr['cf']['2160p']['trash_id'] }} |
+    | [{{ radarr['cf']['2160p']['name'] }}](https://raw.githubusercontent.com/TRaSH-/Guides/master/docs/json/radarr/cf/2160p.json) | :warning: 151 :warning:                    | {{ radarr['cf']['2160p']['trash_id'] }} |
+
+    !!! warning "Scores marked with a :warning: warning :warning: are different to those used in the main guide"


### PR DESCRIPTION
# Pull Request

## Purpose

To make the UHD Tier CFs compatible with the main guides

## Approach

- [x] Amend default UHD Bluray Tier CF scores to match HD Bluray Tier scores
- [x] Add custom scores (with warning) for UHD Bluray Tiers in SQPs 2+5
- [x] Add Remux Tier 03 to SQP5
- [x] Test changes in local test setup
- [x] Update notifiarr flowchart (@TRaSH-) 
- [x] Pre Warned SQP-2 and SQP-5
- [x] **Added Changelog after review and approve** 

Planned date and time to merge: Saturday 15 July 2023 around 12:00 GMT+2 <https://everytimezone.com/s/ad03ff37>

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer.
None

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
