### PR TITLE
fix(radarr): `SQP-1 (2160p)` PR#1473

### DIFF
--- a/includes/sqp/1-4k-cf-scoring-sqp1.md
+++ b/includes/sqp/1-4k-cf-scoring-sqp1.md
@@ -51,9 +51,9 @@
 
     !!! info
         - If you prefer 1080p/2160p WEBDL with IMAX-E then add [{{ radarr['cf']['imax-enhanced']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#imax-enhanced) with the default scores.
-        - The reason why we don't add [{{ radarr['cf']['imax']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#imax) is because BHDStudio doesn't add it to their release name. Their motto is: If the source has IMAX then the encode will have it as well.
+        - The reason why we don't add [{{ radarr['cf']['imax']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#imax) is because BHDStudio didn't add IMAX to their filename before 2023-07-27.
 
-        !!! danger "Adding `IMAX`/`IMAX Enhanced` will replace the BHDStudio release :warning:"
+        !!! danger "Adding `IMAX`/`IMAX Enhanced` will replace in most cases the BHDStudio release :warning:"
 
 ??? abstract "HQ Release Groups - [Click to show/hide]"
     | Custom Format                                                                                                                        |                      Score                       | Trash ID                                            |
@@ -71,9 +71,9 @@
     !!! tip
         If you use SQP-1 (1080p) as your main/second Radarr you want to remove the following HQ Release Groups
 
-        - `[{{ radarr['cf']['hd-bluray-tier-01']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#hd-bluray-tier-01)`
-        - `[{{ radarr['cf']['hd-bluray-tier-02']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#hd-bluray-tier-02)`
-        - `[{{ radarr['cf']['hd-bluray-tier-03']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#hd-bluray-tier-03)`
+        - [{{ radarr['cf']['hd-bluray-tier-01']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#hd-bluray-tier-01)
+        - [{{ radarr['cf']['hd-bluray-tier-02']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#hd-bluray-tier-02)
+        - [{{ radarr['cf']['hd-bluray-tier-03']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#hd-bluray-tier-03)
 
 {! include-markdown "../../includes/cf/radarr-misc.md" !}
 
@@ -91,6 +91,7 @@
     | [{{ radarr['cf']['scene']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#scene)                           |      {{ radarr['cf']['scene']['trash_score'] }}      | {{ radarr['cf']['scene']['trash_id'] }}           |
     | [{{ radarr['cf']['x265-no-hdrdv']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#x265-no-hdrdv) :warning: |  {{ radarr['cf']['x265-no-hdrdv']['trash_score'] }}  | {{ radarr['cf']['x265-no-hdrdv']['trash_id'] }}   |
     | [{{ radarr['cf']['av1']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#av1)                               |              :warning: -10000 :warning:              | {{ radarr['cf']['av1']['trash_id'] }}             |
+    | [{{ radarr['cf']['sdr']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#sdr)                               |       {{ radarr['cf']['sdr']['trash_score'] }}       | {{ radarr['cf']['sdr']['trash_id'] }}             |
 
     !!! tip "I recommend to use the the following Custom Formats"
         - `x265 (no HDR/DV)` over the `x265 (HD)`, Read the Why below and don't forget to read the warning,<br>:warning: Only ever include one of them :warning:

--- a/includes/sqp/1-4k-cf-scoring-sqp1.md
+++ b/includes/sqp/1-4k-cf-scoring-sqp1.md
@@ -53,7 +53,7 @@
         - If you prefer 1080p/2160p WEBDL with IMAX-E then add [{{ radarr['cf']['imax-enhanced']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#imax-enhanced) with the default scores.
         - The reason why we don't add [{{ radarr['cf']['imax']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#imax) is because BHDStudio didn't add IMAX to their filename before 2023-07-27.
 
-        !!! danger "Adding `IMAX`/`IMAX Enhanced` will replace in most cases the BHDStudio release :warning:"
+        !!! danger "Adding `IMAX`/`IMAX Enhanced` will replace the BHDStudio release in most cases :warning:"
 
 ??? abstract "HQ Release Groups - [Click to show/hide]"
     | Custom Format                                                                                                                        |                      Score                       | Trash ID                                            |

--- a/includes/sqp/1-4k-merge-qualities-sqp1.md
+++ b/includes/sqp/1-4k-merge-qualities-sqp1.md
@@ -15,6 +15,6 @@ and merge the following 2160p ones in a new group
 - WEBDL-2160p
 - WEBRip-2160p
 
-and name it what ever you want I used: `WEB-2160p`
+and name it: `WEB-2160p`
 
 ![!Merge the following Qualities together](/SQP/images/1-4k-merge-qualities-sqp1.png)

--- a/includes/sqp/1-4k-select-qualities-sqp1.md
+++ b/includes/sqp/1-4k-select-qualities-sqp1.md
@@ -18,4 +18,4 @@
     If you prefer 2160p WEBDL with IMAX-E merge the following qualities
 
     - `Bluray-2160p`
-    - The merged quality profile: `WEB-2160p`
+    - The merged quality group: `WEB-2160p`

--- a/includes/sqp/1-4k-select-qualities-sqp1.md
+++ b/includes/sqp/1-4k-select-qualities-sqp1.md
@@ -14,3 +14,8 @@
 
     - The merged quality profile: `Bluray|WEB-1080p`
     - `Bluray-720p`
+
+    If you prefer 2160p WEBDL with IMAX-E merge the following qualities
+
+    - `Bluray-2160p`
+    - The merged quality profile: `WEB-2160p`

--- a/includes/sqp/1-cf-scoring.md
+++ b/includes/sqp/1-cf-scoring.md
@@ -36,7 +36,7 @@
         - If you prefer 1080p WEBDL with IMAX-E then add [{{ radarr['cf']['imax-enhanced']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#imax-enhanced) with the default scores.
         - The reason why we don't add [{{ radarr['cf']['imax']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#imax) is because BHDStudio didn't add IMAX to their filename before 2023-07-27.
 
-        !!! danger "Adding `IMAX`/`IMAX Enhanced` will replace in most cases the BHDStudio release :warning:"
+        !!! danger "Adding `IMAX`/`IMAX Enhanced` will replace the BHDStudio release in most cases :warning:"
 
 ??? abstract "HQ Release Groups - [Click to show/hide]"
     | Custom Format                                                                                                                        |                                            Score | Trash ID                                            |

--- a/includes/sqp/1-cf-scoring.md
+++ b/includes/sqp/1-cf-scoring.md
@@ -34,9 +34,9 @@
 
     !!! info
         - If you prefer 1080p WEBDL with IMAX-E then add [{{ radarr['cf']['imax-enhanced']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#imax-enhanced) with the default scores.
-        - The reason why we don't add [{{ radarr['cf']['imax']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#imax) is because BHDStudio doesn't add it to their release name. Their motto is: If the source has IMAX then the encode will have it as well.
+        - The reason why we don't add [{{ radarr['cf']['imax']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#imax) is because BHDStudio didn't add IMAX to their filename before 2023-07-27.
 
-        !!! danger "Adding `IMAX`/`IMAX Enhanced` will replace the BHDStudio release :warning:"
+        !!! danger "Adding `IMAX`/`IMAX Enhanced` will replace in most cases the BHDStudio release :warning:"
 
 ??? abstract "HQ Release Groups - [Click to show/hide]"
     | Custom Format                                                                                                                        |                                            Score | Trash ID                                            |

--- a/includes/starr/move-quality-to-top.md
+++ b/includes/starr/move-quality-to-top.md
@@ -1,4 +1,4 @@
-!!! tip
+!!! info
 
     The order listed in the profile matters even if a quality is not checked, for example if you have a 1080p version but wanted the SD version, Radarr will reject all SD results because 1080p is listed higher than SD even though 1080p was not checked.
 


### PR DESCRIPTION
# Pull Request

## Purpose

Fix the following GHI:

- #1483
- #1484
- #1485

## Approach

- Add CF `SDR` to table
- Add tip if you prefer 2160p Imax-E
- Updated BHDStudio Imax info
- Removed Code block `HD-Bluray-Tier-xx`

## Open Questions and Pre-Merge TODOs

- [x] #1483
- [x] #1484
- [x] #1485
- [x] Test changes in local test setup

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
