### PR TITLE
fix(sqp-1): boost audio scores DD, DDP and DDPA

### DIFF
--- a/docs/json/radarr/cf/dd.json
+++ b/docs/json/radarr/cf/dd.json
@@ -3,8 +3,8 @@
   "trash_score": 750,
   "trash_scores": {
     "default": 750,
-    "sqp-1-1080p": 15,
-    "sqp-1-2160p": 15
+    "sqp-1-1080p": 115,
+    "sqp-1-2160p": 115
   },
   "name": "DD",
   "includeCustomFormatWhenRenaming": false,

--- a/docs/json/radarr/cf/ddplus-atmos.json
+++ b/docs/json/radarr/cf/ddplus-atmos.json
@@ -3,8 +3,8 @@
   "trash_score": 3000,
   "trash_scores": {
     "default": 3000,
-    "sqp-1-1080p": 35,
-    "sqp-1-2160p": 35
+    "sqp-1-1080p": 135,
+    "sqp-1-2160p": 135
   },
   "name": "DD+ ATMOS",
   "includeCustomFormatWhenRenaming": false,

--- a/docs/json/radarr/cf/ddplus.json
+++ b/docs/json/radarr/cf/ddplus.json
@@ -3,8 +3,8 @@
   "trash_score": 1750,
   "trash_scores": {
     "default": 1750,
-    "sqp-1-1080p": 25,
-    "sqp-1-2160p": 25
+    "sqp-1-1080p": 125,
+    "sqp-1-2160p": 125
   },
   "name": "DD+",
   "includeCustomFormatWhenRenaming": false,

--- a/includes/sqp/1-cf-scoring.md
+++ b/includes/sqp/1-cf-scoring.md
@@ -1,22 +1,22 @@
 #### Custom Formats and scores
 
 ??? abstract "Audio - [Click to show/hide]"
-    | Custom Format                                                                                                 |           Score            | Trash ID                                          |
-    | ------------------------------------------------------------------------------------------------------------- | :------------------------: | ------------------------------------------------- |
-    | [{{ radarr['cf']['truehd-atmos']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#truehd-atmos)       | :warning: -10000 :warning: | {{ radarr['cf']['truehd-atmos']['trash_id'] }}    |
-    | [{{ radarr['cf']['dts-x']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#dts-x)                     | :warning: -10000 :warning: | {{ radarr['cf']['dts-x']['trash_id'] }}           |
-    | [{{ radarr['cf']['atmos-undefined']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#atmos-undefined) |   :warning: 0 :warning:    | {{ radarr['cf']['atmos-undefined']['trash_id'] }} |
-    | [{{ radarr['cf']['ddplus-atmos']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#ddplus-atmos)       |   :warning: 35 :warning:   | {{ radarr['cf']['ddplus-atmos']['trash_id'] }}    |
-    | [{{ radarr['cf']['truehd']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#truehd)                   | :warning: -10000 :warning: | {{ radarr['cf']['truehd']['trash_id'] }}          |
-    | [{{ radarr['cf']['dts-hd-ma']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#dts-hd-ma)             | :warning: -10000 :warning: | {{ radarr['cf']['dts-hd-ma']['trash_id'] }}       |
-    | [{{ radarr['cf']['flac']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#flac)                       |   :warning: 0 :warning:    | {{ radarr['cf']['flac']['trash_id'] }}            |
-    | [{{ radarr['cf']['pcm']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#pcm)                         |   :warning: 0 :warning:    | {{ radarr['cf']['pcm']['trash_id'] }}             |
-    | [{{ radarr['cf']['dts-hd-hra']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#dts-hd-hra)           | :warning: -10000 :warning: | {{ radarr['cf']['dts-hd-hra']['trash_id'] }}      |
-    | [{{ radarr['cf']['ddplus']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#ddplus)                   |   :warning: 25 :warning:   | {{ radarr['cf']['ddplus']['trash_id'] }}          |
-    | [{{ radarr['cf']['dts-es']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#dts-es)                   | :warning: -10000 :warning: | {{ radarr['cf']['dts-es']['trash_id'] }}          |
-    | [{{ radarr['cf']['dts']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#dts)                         |   :warning: 0 :warning:    | {{ radarr['cf']['dts']['trash_id'] }}             |
-    | [{{ radarr['cf']['aac']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#aac)                         |   :warning: 0 :warning:    | {{ radarr['cf']['aac']['trash_id'] }}             |
-    | [{{ radarr['cf']['dd']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#dd)                           |   :warning: 15 :warning:   | {{ radarr['cf']['dd']['trash_id'] }}              |
+    | Custom Format                                                                                                 |                                          Score                                           | Trash ID                                          |
+    | ------------------------------------------------------------------------------------------------------------- | :--------------------------------------------------------------------------------------: | ------------------------------------------------- |
+    | [{{ radarr['cf']['truehd-atmos']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#truehd-atmos)       |  :warning: {{ radarr['cf']['truehd-atmos']['trash_scores']['sqp-1-1080p'] }} :warning:   | {{ radarr['cf']['truehd-atmos']['trash_id'] }}    |
+    | [{{ radarr['cf']['dts-x']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#dts-x)                     |      :warning: {{ radarr['cf']['dts-x']['trash_scores']['sqp-1-1080p'] }} :warning:      | {{ radarr['cf']['dts-x']['trash_id'] }}           |
+    | [{{ radarr['cf']['atmos-undefined']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#atmos-undefined) | :warning: {{ radarr['cf']['atmos-undefined']['trash_scores']['sqp-1-1080p'] }} :warning: | {{ radarr['cf']['atmos-undefined']['trash_id'] }} |
+    | [{{ radarr['cf']['ddplus-atmos']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#ddplus-atmos)       |  :warning: {{ radarr['cf']['ddplus-atmos']['trash_scores']['sqp-1-1080p'] }} :warning:   | {{ radarr['cf']['ddplus-atmos']['trash_id'] }}    |
+    | [{{ radarr['cf']['truehd']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#truehd)                   |     :warning: {{ radarr['cf']['truehd']['trash_scores']['sqp-1-1080p'] }} :warning:      | {{ radarr['cf']['truehd']['trash_id'] }}          |
+    | [{{ radarr['cf']['dts-hd-ma']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#dts-hd-ma)             |    :warning: {{ radarr['cf']['dts-hd-ma']['trash_scores']['sqp-1-1080p'] }} :warning:    | {{ radarr['cf']['dts-hd-ma']['trash_id'] }}       |
+    | [{{ radarr['cf']['flac']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#flac)                       |      :warning: {{ radarr['cf']['flac']['trash_scores']['sqp-1-1080p'] }} :warning:       | {{ radarr['cf']['flac']['trash_id'] }}            |
+    | [{{ radarr['cf']['pcm']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#pcm)                         |       :warning: {{ radarr['cf']['pcm']['trash_scores']['sqp-1-1080p'] }} :warning:       | {{ radarr['cf']['pcm']['trash_id'] }}             |
+    | [{{ radarr['cf']['dts-hd-hra']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#dts-hd-hra)           |   :warning: {{ radarr['cf']['dts-hd-hra']['trash_scores']['sqp-1-1080p'] }} :warning:    | {{ radarr['cf']['dts-hd-hra']['trash_id'] }}      |
+    | [{{ radarr['cf']['ddplus']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#ddplus)                   |     :warning: {{ radarr['cf']['ddplus']['trash_scores']['sqp-1-1080p'] }} :warning:      | {{ radarr['cf']['ddplus']['trash_id'] }}          |
+    | [{{ radarr['cf']['dts-es']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#dts-es)                   |     :warning: {{ radarr['cf']['dts-es']['trash_scores']['sqp-1-1080p'] }} :warning:      | {{ radarr['cf']['dts-es']['trash_id'] }}          |
+    | [{{ radarr['cf']['dts']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#dts)                         |       :warning: {{ radarr['cf']['dts']['trash_scores']['sqp-1-1080p'] }} :warning:       | {{ radarr['cf']['dts']['trash_id'] }}             |
+    | [{{ radarr['cf']['aac']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#aac)                         |       :warning: {{ radarr['cf']['aac']['trash_scores']['sqp-1-1080p'] }} :warning:       | {{ radarr['cf']['aac']['trash_id'] }}             |
+    | [{{ radarr['cf']['dd']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#dd)                           |       :warning: {{ radarr['cf']['dd']['trash_scores']['sqp-1-1080p'] }} :warning:        | {{ radarr['cf']['dd']['trash_id'] }}              |
 
     !!! warning "Scores marked with a :warning: warning :warning: are different to those used in the main public guide"
 


### PR DESCRIPTION
# Pull Request

## Purpose

Boost the audio scores DD, DDP and DDPA. So they are preferred over DTS.

Fix the following GHI:

- #1498

## Approach

- [x] Boost `DD` with 100 points to 115
- [x] Boost `DD+` with 100 points to 125
- [x] Boost `DD+ Atmos` with 100 points to 135

## Open Questions and Pre-Merge TODOs

- [x] Test changes in local test setup

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
