### PR TITLE
feat(starr): Add DVD5 and DVD9 to BR-DISK CFs

### DIFF
--- a/docs/json/radarr/cf/br-disk.json
+++ b/docs/json/radarr/cf/br-disk.json
@@ -17,21 +17,12 @@
       }
     },
     {
-      "name": "DVD5",
+      "name": "DVD5 or DVD9",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,
       "required": false,
       "fields": {
-        "value": "\\\\bDVD5\\\\b"
-      }
-    },
-    {
-      "name": "DVD9",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "\\\\bDVD9\\\\b"
+        "value": "\\b(DVD[59])\\b"
       }
     }
   ]

--- a/docs/json/radarr/cf/br-disk.json
+++ b/docs/json/radarr/cf/br-disk.json
@@ -11,9 +11,27 @@
       "name": "BR-DISK",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,
-      "required": true,
+      "required": false,
       "fields": {
         "value": "^(?!.*\\b((?<!HD[._ -]|HD)DVD|BDRip|MKV|XviD|WMV|d3g|BDREMUX|REMUX|^(?=.*1080p)(?=.*HEVC)|[xh][-_. ]?26[45]|German.*DL|((?<=\\d{4}).*German.*(DL)?)(?=.*\\b(AVC|HEVC|VC[-_. ]?1|MVC|MPEG[-_. ]?2)\\b))\\b)(((?=.*\\b(Blu[-_. ]?ray|BD|HD[-_. ]?DVD)\\b)(?=.*\\b(AVC|HEVC|VC[-_. ]?1|MVC|MPEG[-_. ]?2|BDMV|ISO)\\b))|^((?=.*\\b(^((?=.*\\b((.*_)?COMPLETE.*|Dis[ck])\\b)(?=.*(Blu[-_. ]?ray|HD[-_. ]?DVD)))|3D[-_. ]?BD|BR[-_. ]?DISK|Full[-_. ]?Blu[-_. ]?ray|^((?=.*((BD|UHD)[-_. ]?(25|50|66|100|ISO)))))))).*"
+      }
+    },
+    {
+      "name": "DVD5",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\\\bDVD5\\\\b"
+      }
+    },
+    {
+      "name": "DVD9",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\\\bDVD9\\\\b"
       }
     }
   ]

--- a/docs/json/sonarr/cf/br-disk.json
+++ b/docs/json/sonarr/cf/br-disk.json
@@ -17,21 +17,12 @@
       }
     },
     {
-      "name": "DVD5",
+      "name": "DVD5 or DVD9",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,
       "required": false,
       "fields": {
-        "value": "\\\\bDVD5\\\\b"
-      }
-    },
-    {
-      "name": "DVD9",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "\\\\bDVD9\\\\b"
+        "value": "\\b(DVD[59])\\b"
       }
     }
   ]

--- a/docs/json/sonarr/cf/br-disk.json
+++ b/docs/json/sonarr/cf/br-disk.json
@@ -11,9 +11,27 @@
       "name": "BR-DISK",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,
-      "required": true,
+      "required": false,
       "fields": {
         "value": "^(?!.*\\b((?<!HD[._ -]|HD)DVD|BDRip|MKV|XviD|WMV|d3g|BDREMUX|REMUX|^(?=.*1080p)(?=.*HEVC)|[xh][-_. ]?26[45]|German.*DL|((?<=\\d{4}).*German.*(DL)?)(?=.*\\b(AVC|HEVC|VC[-_. ]?1|MVC|MPEG[-_. ]?2)\\b))\\b)(((?=.*\\b(Blu[-_. ]?ray|BD|HD[-_. ]?DVD)\\b)(?=.*\\b(AVC|HEVC|VC[-_. ]?1|MVC|MPEG[-_. ]?2|BDMV|ISO)\\b))|^((?=.*\\b(^((?=.*\\b((.*_)?COMPLETE.*|Dis[ck])\\b)(?=.*(Blu[-_. ]?ray|HD[-_. ]?DVD)))|3D[-_. ]?BD|BR[-_. ]?DISK|Full[-_. ]?Blu[-_. ]?ray|^((?=.*((BD|UHD)[-_. ]?(25|50|66|100|ISO)))))))).*"
+      }
+    },
+    {
+      "name": "DVD5",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\\\bDVD5\\\\b"
+      }
+    },
+    {
+      "name": "DVD9",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\\\bDVD9\\\\b"
       }
     }
   ]


### PR DESCRIPTION
# Pull Request

## Purpose

Add `DVD5` and `DVD9` to the `BR-DISK` CFs to avoid unwanted full DVD images.

## Approach

Add additional conditions to `BR-DISK` CF, remove requirement on current single condition

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer.

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
