### PR TITLE
fix(radarr): 24xHD regex in LQ CF

### DIFF
--- a/docs/json/radarr/cf/lq.json
+++ b/docs/json/radarr/cf/lq.json
@@ -13,7 +13,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "^((Subs-)?24xHD)$"
+        "value": "\\b(24xHD)\\b"
       }
     },
     {


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->
Fix #1509 

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->
Adjust `24xHD` in LQ CF.

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
