### PR TITLE
fix(radarr): add rlsgrp `41RGB` to `LQ`

### DIFF
--- a/docs/json/radarr/cf/lq.json
+++ b/docs/json/radarr/cf/lq.json
@@ -17,6 +17,15 @@
       }
     },
     {
+      "name": "41RGB",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(41RGB)$"
+      }
+    },
+    {
       "name": "4K4U",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,


### PR DESCRIPTION
# Pull Request

## Purpose

Fix: #1519 
- #1519 

## Approach

Added rlsgrp `41RGB` to `LQ`

## Open Questions and Pre-Merge TODOs

- [x] Added RlsGrp to excel sheet with reason
- [x] Sorted JSON alpha 
- [x] Test changes in local test setup

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer.

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
