### PR TITLE
fix(starr): remove rlsgrp `CtrlHD` from CF `TrueHD Atmos`

### DIFF
--- a/docs/json/radarr/cf/truehd-atmos.json
+++ b/docs/json/radarr/cf/truehd-atmos.json
@@ -24,7 +24,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\b(ATMOS|CtrlHD|W4NK3R|DON)(\\b|\\d)"
+        "value": "\\b(ATMOS|W4NK3R|DON)(\\b|\\d)"
       }
     },
     {

--- a/docs/json/sonarr/cf/truehd-atmos.json
+++ b/docs/json/sonarr/cf/truehd-atmos.json
@@ -13,7 +13,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "True[ .-]?HD|W4NK3R|HQMUX"
+        "value": "True[ .-]?HD"
       }
     },
     {
@@ -22,7 +22,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\b(ATMOS|CtrlHD|W4NK3R|DON)(\\b|\\d)"
+        "value": "\\b(ATMOS)(\\b|\\d)"
       }
     },
     {


### PR DESCRIPTION
# Pull Request

## Purpose

Fix: #1528
- #1528 

## Approach

Remove rlsgrp `CtrlHD` from CF `TrueHD Atmos`

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

## Open Questions and Pre-Merge TODOs

- [x] Test changes in local test setup

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer.

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
