### PR TITLE
feat(radarr): Add MainFrame to UHD Bluray Tier 02

### DIFF
--- a/docs/json/radarr/cf/uhd-bluray-tier-02.json
+++ b/docs/json/radarr/cf/uhd-bluray-tier-02.json
@@ -19,6 +19,15 @@
       }
     },
     {
+      "name": "MainFrame",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(MainFrame)$"
+      }
+    },
+    {
       "name": "2160p",
       "implementation": "ResolutionSpecification",
       "negate": false,


### PR DESCRIPTION
# Pull Request

## Purpose

To add the MainFrame rlsgrp to UHD Bluray Tier 02

## Approach

Modify the UHD Bluray Tier 02 custom format to add in the MainFrame release group as a new optional Release Group condition

## Open Questions and Pre-Merge TODOs

None

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
