### PR TITLE
fix(radarr): Word boundaries not applying to 3d regex

### DIFF
--- a/docs/json/radarr/cf/3d.json
+++ b/docs/json/radarr/cf/3d.json
@@ -13,7 +13,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "\\b3d|sbs|half[ .-]ou|half[ .-]sbs\\b"
+        "value": "\\b(3d|sbs|half[ .-]ou|half[ .-]sbs)\\b"
       }
     },
     {


### PR DESCRIPTION
# Pull Request

## Purpose

Word boundaries don't apply to both sides of all values in 3d regex

## Approach

Add parenthesis to prevent false positives

![image](https://github.com/TRaSH-Guides/Guides/assets/376117/102257d9-50ae-4d72-a007-5f5e59bee1f8)


## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer.

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
