### PR TITLE
fix(starr): Remove RlsGrps from CF TrueHD and TrueHD Atmos

### DIFF
--- a/docs/json/radarr/cf/atmos-undefined.json
+++ b/docs/json/radarr/cf/atmos-undefined.json
@@ -73,15 +73,6 @@
       }
     },
     {
-      "name": "Not RlsGrp (Atmos Only)",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": true,
-      "required": true,
-      "fields": {
-        "value": "W4NK3R|HQMUX"
-      }
-    },
-    {
       "name": "Not TrueHD",
       "implementation": "ReleaseTitleSpecification",
       "negate": true,

--- a/docs/json/radarr/cf/truehd-atmos.json
+++ b/docs/json/radarr/cf/truehd-atmos.json
@@ -15,7 +15,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "True[ .-]?HD|W4NK3R|HQMUX"
+        "value": "True[ .-]?HD"
       }
     },
     {
@@ -24,7 +24,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\b(ATMOS|W4NK3R|DON)(\\b|\\d)"
+        "value": "\\bATMOS(\\b|\\d)"
       }
     },
     {

--- a/docs/json/radarr/cf/truehd.json
+++ b/docs/json/radarr/cf/truehd.json
@@ -62,15 +62,6 @@
       "fields": {
         "value": "\\bDD[^a-z+]|(?<!e)ac3"
       }
-    },
-    {
-      "name": "Not RlsGrp (TrueHD only)",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": true,
-      "required": true,
-      "fields": {
-        "value": "CtrlHD|W4NK3R|\\bDON\\b"
-      }
     }
   ]
 }

--- a/docs/json/sonarr/cf/atmos-undefined.json
+++ b/docs/json/sonarr/cf/atmos-undefined.json
@@ -71,15 +71,6 @@
       }
     },
     {
-      "name": "Not RlsGrp (Atmos Only)",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": true,
-      "required": true,
-      "fields": {
-        "value": "W4NK3R|HQMUX"
-      }
-    },
-    {
       "name": "Not TrueHD",
       "implementation": "ReleaseTitleSpecification",
       "negate": true,

--- a/docs/json/sonarr/cf/truehd-atmos.json
+++ b/docs/json/sonarr/cf/truehd-atmos.json
@@ -22,7 +22,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\b(ATMOS)(\\b|\\d)"
+        "value": "\\bATMOS(\\b|\\d)"
       }
     },
     {

--- a/docs/json/sonarr/cf/truehd.json
+++ b/docs/json/sonarr/cf/truehd.json
@@ -60,15 +60,6 @@
       "fields": {
         "value": "\\bDD[^a-z+]|(?<!e)ac3"
       }
-    },
-    {
-      "name": "Not RlsGrp (TrueHD only)",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": true,
-      "required": true,
-      "fields": {
-        "value": "CtrlHD|W4NK3R|\\bDON\\b"
-      }
     }
   ]
 }


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->

Fix: #1552 
- #1552 

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

- [x] Remove RlsGrps from Radarr `TrueHD`
- [x]  Remove RlsGrps from Radarr `TrueHD Atmos`
- [x]  Remove RlsGrps from Radarr `ATMOS (undefined)`
- [x] Remove RlsGrps from Sonarr `TrueHD`
- [x]  Remove RlsGrps from Sonarr `TrueHD Atmos`
- [x]  Remove RlsGrps from Sonarr `ATMOS (undefined)`

## Open Questions and Pre-Merge TODOs

- [x] Test changes in local test setup

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer.

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
