### PR TITLE
feat(guides): revise truenas core NFSv4 section

### DIFF
--- a/docs/Hardlinks/How-to-setup-for/TrueNAS-Core.md
+++ b/docs/Hardlinks/How-to-setup-for/TrueNAS-Core.md
@@ -102,7 +102,7 @@ Click `Submit` once complete.
 
 Navigate to Services and click the edit icon under `Actions` on the `NFS` row.
 
-Enabling `NFSv4` is optional, but I generally prefer it since NFSv4 has some improvements over NFSv3. Make sure to check `Allow non-root mount` under `Other Options`.
+Enabling `NFSv4` is optional. If you wish to do so you will need to ensure that your NAS and host are on the same domain (verify with `hostname -d`), otherwise you'll run into permission issues (indicated by `nobody:4294967294` when checking files). Alternatively, enable `NFSv3 ownership model for NFSv4` to avoid the domain requirements. Make sure to check `Allow non-root mount` under `Other Options`.
 
 One of the most important options here is the `Number of servers` setting. If you click on the help icon you'll see the help text for this setting, which indicates that you should keep this less than or equal to the number of CPUs reported by `sysctl -n kern.smp.cpus` to limit CPU context switching.
 


### PR DESCRIPTION
# Pull Request

## Purpose

Updated the `Configure and enable NFS service` section to cover a common issue seen when enabling NFSv4. Unless the NAS and the host are on the same domain (or setup with idmapping, which is no longer recommended) users will observe `nobody:4294967294` when doing a `ls` on the files in the mount. Enabling `NFSv3 ownership model for NFSv4` solves that issue without the domain requirement if desired.

## Approach

Closes #1476 by revising documentation to clarify NFSv4 gotcha.

## Open Questions and Pre-Merge TODOs

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
