### PR TITLE
fix(starr): DTS-HD MA regex and add example

### DIFF
--- a/docs/json/radarr/cf/dts-hd-ma.json
+++ b/docs/json/radarr/cf/dts-hd-ma.json
@@ -6,6 +6,7 @@
     "sqp-1-1080p": -10000,
     "sqp-1-2160p": -10000
   },
+  "trash_regex": "https://regex101.com/r/U1asQG/1",
   "name": "DTS-HD MA",
   "includeCustomFormatWhenRenaming": false,
   "specifications": [
@@ -15,7 +16,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\b(dts[-_. ]?(ma|hd([-_. ]?ma)?|xll))\\b"
+        "value": "\\b(dts[-_. ]?(ma|hd([-_. ]?ma)?|xll))(\\b|\\d)"
       }
     },
     {

--- a/docs/json/radarr/cf/dts.json
+++ b/docs/json/radarr/cf/dts.json
@@ -6,6 +6,7 @@
     "sqp-1-1080p": 0,
     "sqp-1-2160p": 0
   },
+  "trash_regex": "https://regex101.com/r/U1asQG/1",
   "name": "DTS",
   "includeCustomFormatWhenRenaming": false,
   "specifications": [{
@@ -23,7 +24,7 @@
           "negate": true,
           "required": true,
           "fields": {
-              "value": "\\b(dts[-_. ]?(ma|hd([-_. ]?ma)?|xll))\\b"
+              "value": "\\b(dts[-_. ]?(ma|hd([-_. ]?ma)?|xll))(\\b|\\d)"
           }
       },
       {

--- a/docs/json/sonarr/cf/dts-hd-ma.json
+++ b/docs/json/sonarr/cf/dts-hd-ma.json
@@ -4,6 +4,7 @@
   "trash_scores": {
     "default": 2500
   },
+  "trash_regex": "https://regex101.com/r/U1asQG/1",
   "name": "DTS-HD MA",
   "includeCustomFormatWhenRenaming": false,
   "specifications": [
@@ -13,7 +14,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\b(dts[-_. ]?(ma|hd([-_. ]?ma)?|xll))\\b"
+        "value": "\\b(dts[-_. ]?(ma|hd([-_. ]?ma)?|xll))(\\b|\\d)"
       }
     },
     {

--- a/docs/json/sonarr/cf/dts.json
+++ b/docs/json/sonarr/cf/dts.json
@@ -4,6 +4,7 @@
   "trash_scores": {
     "default": 1250
   },
+  "trash_regex": "https://regex101.com/r/U1asQG/1",
   "name": "DTS",
   "includeCustomFormatWhenRenaming": false,
   "specifications": [{
@@ -21,7 +22,7 @@
           "negate": true,
           "required": true,
           "fields": {
-              "value": "\\b(dts[-_. ]?(ma|hd([-_. ]?ma)?|xll))\\b"
+              "value": "\\b(dts[-_. ]?(ma|hd([-_. ]?ma)?|xll))(\\b|\\d)"
           }
       },
       {


### PR DESCRIPTION
# Pull Request

## Purpose

Fixes #1558 

## Approach

Adjusted the `DTS-HD MA` regex to match more accurately and added a regex example.

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
