### PR TITLE
fix(guide): tmp fix for emby naming scheme

### DIFF
--- a/docs/Radarr/Radarr-recommended-naming-scheme.md
+++ b/docs/Radarr/Radarr-recommended-naming-scheme.md
@@ -15,7 +15,7 @@ The Tokens not available in the release won't be used/shown.
 
 ## Standard Movie Format
 
-This naming scheme is made to be compatible with the [New Plex Agent](https://forums.plex.tv/t/new-plex-media-server-movie-scanner-and-agent-preview/593269/517) that now supports IMDb and TMDb IDs in filenames, if you don't need it or want it just remove `{imdb-{ImdbId}}`
+This naming scheme is made to be compatible with the [New Plex Agent](https://forums.plex.tv/t/new-plex-media-server-movie-scanner-and-agent-preview/593269/517){:target="_blank" rel="noopener noreferrer"} that now supports IMDb and TMDb IDs in filenames, if you don't need it or want it just remove `{imdb-{ImdbId}}`
 
 !!! warning "Starting from v4.2.2.6489, Radarr now supports Plex Multiple Edition tags in naming."
 
@@ -25,6 +25,8 @@ This naming scheme is made to be compatible with the [New Plex Agent](https://fo
 
     !!! danger "Only use `{edition-{Edition Tags}}` if you are prepared to have movies separated by edition<br>when using a merged Plex library - e.g., you keep both 1080p and 2160p versions of one movie.<br><br>For example if you have the `Directors Cut` and the `Extended Cut` for one movie, those will show up as two separate movies in your library.<br><br>Note that not using `{edition-{Edition Tags}}` will prevent Plex from recognizing the edition."
 
+### Plex
+
 ```bash
 {{ radarr['naming']['radarr-naming']['file']['default'] }}
 ```
@@ -33,17 +35,7 @@ This naming scheme is made to be compatible with the [New Plex Agent](https://fo
 
     `The Movie Title (2010) {imdb-tt0066921} {edition-Ultimate Extended Edition} [IMAX HYBRID][Bluray-1080p Proper][3D][DV HDR10][DTS 5.1][x264]-EVOLVE`
 
-For Jellyfin/Emby:
-
-```bash
-{{ radarr['naming']['radarr-naming']['file']['emby'] }}
-```
-
-??? abstract "RESULTS: - [Click to show/hide]"
-
-    `The Movie Title (2010) [imdbid-tt0066921] {edition-Ultimate Extended Edition} [IMAX HYBRID][Bluray-1080p Proper][3D][DV HDR10][DTS 5.1][x264]-EVOLVE`
-
-If you do Anime
+#### Plex Anime
 
 ```bash
 {{ radarr['naming']['radarr-naming']['file']['anime'] }}
@@ -53,7 +45,19 @@ If you do Anime
 
     `The Movie Title (2010) {imdb-tt0066921} {edition-Ultimate Extended Edition} [Surround Sound x264][Bluray-1080p Proper][3D][DTS 5.1][DE][10bit][AVC]-EVOLVE`
 
-For Jellyfin/Emby:
+### Emby
+
+!!! warning "Emby is the only one who uses `=` for their ID, which isn't supported by the Starr apps at the moment.<br>Keep a eye on the following [PR#1386](https://github.com/TRaSH-Guides/Guides/pull/1386){:target="_blank" rel="noopener noreferrer"} when it does support it"
+
+```bash
+{{ radarr['naming']['radarr-naming']['file']['emby'] }}
+```
+
+??? abstract "RESULTS: - [Click to show/hide]"
+
+    `The Movie Title (2010) - {edition-Ultimate Extended Edition} [IMAX HYBRID][Bluray-1080p Proper][3D][DV HDR10][DTS 5.1][x264]-EVOLVE`
+
+#### Emby Anime
 
 ```bash
 {{ radarr['naming']['radarr-naming']['file']['anime-emby'] }}
@@ -61,7 +65,27 @@ For Jellyfin/Emby:
 
 ??? abstract "RESULTS: - [Click to show/hide]"
 
-    `The Movie Title (2010) [imdbid-tt0066921] {edition-Ultimate Extended Edition} [Surround Sound x264][Bluray-1080p Proper][3D][DTS 5.1][DE][10bit][AVC]-EVOLVE`
+    `The Movie Title (2010) [imdbid-tt0066921] - {edition-Ultimate Extended Edition} [Surround Sound x264][Bluray-1080p Proper][3D][DTS 5.1][DE][10bit][AVC]-EVOLVE`
+
+### Jellyfin
+
+```bash
+{{ radarr['naming']['radarr-naming']['file']['jellyfin'] }}
+```
+
+??? abstract "RESULTS: - [Click to show/hide]"
+
+    `The Movie Title (2010) [imdbid-tt0066921] - {edition-Ultimate Extended Edition} [IMAX HYBRID][Bluray-1080p Proper][3D][DV HDR10][DTS 5.1][x264]-EVOLVE`
+
+#### Jellyfin Anime
+
+```bash
+{{ radarr['naming']['radarr-naming']['file']['anime-jellyfin'] }}
+```
+
+??? abstract "RESULTS: - [Click to show/hide]"
+
+    `The Movie Title (2010) [imdbid-tt0066921] - {edition-Ultimate Extended Edition} [Surround Sound x264][Bluray-1080p Proper][3D][DTS 5.1][DE][10bit][AVC]-EVOLVE`
 
 ------
 
@@ -99,9 +123,7 @@ The filename can be Obscured where the Release naming isn't, especially when you
 {{ radarr['naming']['radarr-naming']['folder']['default'] }}
 ```
 
-RESULT:
-
-`The Movie Title (2010)`
+<small>RESULT:</small> `The Movie Title (2010)`
 
 ------
 
@@ -114,29 +136,35 @@ RESULT:
 
         TMDb is usually better as it guarantees a match, IMDb only gets matched if the TMDb entry has the correct IMDb ID association. We don't actually talk to IMDb.
 
-#### Optional Movies Folder Format for the Plex Movies Scanner and Jellyfin/Emby
+#### Optional Movies Folder Format
 
 This naming scheme is made to be compatible with the new [Plex TV Series Scanner](https://forums.plex.tv/t/beta-new-plex-tv-series-scanner/696242){:target="_blank" rel="noopener noreferrer"} that now support IMDB and TVDB IDs in file names.
 
-For Plex:
+##### Optional Plex
 
 ```bash
 {{ radarr['naming']['radarr-naming']['folder']['plex'] }}
 ```
 
-RESULT:
+<small>RESULT:</small> `The Movie Title (2010) {imdb-tt1520211}`
 
-`The Movie Title (2010) {imdb-tt1520211}`
+##### Optional Emby
 
-For Jellyfin/Emby:
+!!! warning "Emby is the only one who uses `=` for their ID, which isn't supported by the Starr apps at the moment.<br>Keep a eye on the following [PR#1386](https://github.com/TRaSH-Guides/Guides/pull/1386){:target="_blank" rel="noopener noreferrer"} when it does support it"
 
 ```bash
 {{ radarr['naming']['radarr-naming']['folder']['emby'] }}
 ```
 
-RESULT:
+<small>RESULT:</small> `The Movie Title (2010)`
 
-`The Movie Title (2010) [imdbid-tt1520211]`
+##### Optional Jellyfin
+
+```bash
+{{ radarr['naming']['radarr-naming']['folder']['jellyfin'] }}
+```
+
+<small>RESULT:</small> `The Movie Title (2010) [imdbid-tt1520211]`
 
 !!! tip
     IMDb IDs are going to be very accurate and rarely change, TVDB/TMDB IDs, on the other hand, do change or are removed more frequently.

--- a/docs/Sonarr/Sonarr-recommended-naming-scheme.md
+++ b/docs/Sonarr/Sonarr-recommended-naming-scheme.md
@@ -85,33 +85,37 @@ it gets imported correctly and isn't incorrectly matched as HDTV or WEB-DL etc.
 {{ sonarr['naming']['sonarr-naming']['series']['default'] }}
 ```
 
-RESULT:
+<small>RESULT:</small> `The Series Title! (2010)`
 
-`The Series Title! (2010)`
-
-#### Optional Series Folder Format for the Plex TV Series Scanner and Jellyfin/Emby
+#### Optional Series Folder Format
 
 This naming scheme is made to be compatible with the new [Plex TV Series Scanner](https://forums.plex.tv/t/beta-new-plex-tv-series-scanner/696242){:target="_blank" rel="noopener noreferrer"} that now support IMDB and TVDB IDs in file names.
 
-For Plex:
+##### Optional Plex
 
 ```bash
 {{ sonarr['naming']['sonarr-naming']['series']['plex'] }}
 ```
 
-RESULT:
+<small>RESULT:</small> `The Series Title! (2010) {imdb-tt1520211}`
 
-`The Series Title! (2010) {imdb-tt1520211}`
+##### Optional Emby
 
-For Jellyfin/Emby:
+!!! warning "Emby is the only one who uses `=` for their ID, which isn't supported by the Starr apps at the moment.<br>Keep a eye on the following [PR#1386](https://github.com/TRaSH-Guides/Guides/pull/1386){:target="_blank" rel="noopener noreferrer"} when it does support it"
 
 ```bash
 {{ sonarr['naming']['sonarr-naming']['series']['emby'] }}
 ```
 
-RESULT:
+<small>RESULT:</small> `The Series Title! (2010)`
 
-`The Series Title! (2010) [tvdbid-tt1520211]`
+##### Optional Jellyfin
+
+```bash
+{{ sonarr['naming']['sonarr-naming']['series']['jellyfin'] }}
+```
+
+<small>RESULT:</small> `The Series Title! (2010) [tvdbid-tt1520211]`
 
 !!! tip
     IMDb IDs are going to be very accurate and rarely change, TVDB/TMDB IDs, on the other hand, do change or are removed more frequently.
@@ -126,9 +130,7 @@ For this there's only one real option to use in my opinion.
 Season {season:00}
 ```
 
-RESULT:
-
-`Season 01`
+RESULT: `Season 01`
 
 ------
 

--- a/docs/json/radarr/naming/radarr-naming.json
+++ b/docs/json/radarr/naming/radarr-naming.json
@@ -2,15 +2,15 @@
   "folder": {
       "default": "{Movie CleanTitle} ({Release Year})",
       "plex": "{Movie CleanTitle} ({Release Year}) {imdb-{ImdbId}}",
-      "emby": "{Movie CleanTitle} ({Release Year}) [imdbid-{ImdbId}]",
+      "emby": "{Movie CleanTitle} ({Release Year})",
       "jellyfin": "{Movie CleanTitle} ({Release Year}) [imdbid-{ImdbId}]"
   },
   "file": {
       "default": "{Movie CleanTitle} {(Release Year)} {imdb-{ImdbId}} {edition-{Edition Tags}} {[Custom Formats]}{[Quality Full]}{[MediaInfo 3D]}{[MediaInfo VideoDynamicRangeType]}{[Mediainfo AudioCodec}{ Mediainfo AudioChannels]}[{Mediainfo VideoCodec}]{-Release Group}",
-      "emby": "{Movie CleanTitle} {(Release Year)} [imdbid-{ImdbId}] - {Edition Tags }{[Custom Formats]}{[Quality Full]}{[MediaInfo 3D]}{[MediaInfo VideoDynamicRangeType]}{[Mediainfo AudioCodec}{ Mediainfo AudioChannels]}[{Mediainfo VideoCodec}]{-Release Group}",
+      "emby": "{Movie CleanTitle} {(Release Year)} - {Edition Tags }{[Custom Formats]}{[Quality Full]}{[MediaInfo 3D]}{[MediaInfo VideoDynamicRangeType]}{[Mediainfo AudioCodec}{ Mediainfo AudioChannels]}[{Mediainfo VideoCodec}]{-Release Group}",
       "jellyfin": "{Movie CleanTitle} {(Release Year)} [imdbid-{ImdbId}] - {Edition Tags }{[Custom Formats]}{[Quality Full]}{[MediaInfo 3D]}{[MediaInfo VideoDynamicRangeType]}{[Mediainfo AudioCodec}{ Mediainfo AudioChannels]}[{Mediainfo VideoCodec}]{-Release Group}",
       "anime": "{Movie CleanTitle} {(Release Year)} {imdb-{ImdbId}} {edition-{Edition Tags}} {[Custom Formats]}{[Quality Full]}{[MediaInfo 3D]}{[MediaInfo VideoDynamicRangeType]}{[Mediainfo AudioCodec}{ Mediainfo AudioChannels]}{MediaInfo AudioLanguages}[{MediaInfo VideoBitDepth}bit][{Mediainfo VideoCodec}]{-Release Group}",
-      "anime-emby": "{Movie CleanTitle} {(Release Year)} [imdbid-{ImdbId}] - {Edition Tags }{[Custom Formats]}{[Quality Full]}{[MediaInfo 3D]}{[MediaInfo VideoDynamicRangeType]}{[Mediainfo AudioCodec}{ Mediainfo AudioChannels]}{MediaInfo AudioLanguages}[{MediaInfo VideoBitDepth}bit][{Mediainfo VideoCodec}]{-Release Group}",
+      "anime-emby": "{Movie CleanTitle} {(Release Year)} - {Edition Tags }{[Custom Formats]}{[Quality Full]}{[MediaInfo 3D]}{[MediaInfo VideoDynamicRangeType]}{[Mediainfo AudioCodec}{ Mediainfo AudioChannels]}{MediaInfo AudioLanguages}[{MediaInfo VideoBitDepth}bit][{Mediainfo VideoCodec}]{-Release Group}",
       "anime-jellyfin": "{Movie CleanTitle} {(Release Year)} [imdbid-{ImdbId}] - {Edition Tags }{[Custom Formats]}{[Quality Full]}{[MediaInfo 3D]}{[MediaInfo VideoDynamicRangeType]}{[Mediainfo AudioCodec}{ Mediainfo AudioChannels]}{MediaInfo AudioLanguages}[{MediaInfo VideoBitDepth}bit][{Mediainfo VideoCodec}]{-Release Group}",
       "original": "{Original Title}"
     }

--- a/docs/json/sonarr/naming/sonarr-naming.json
+++ b/docs/json/sonarr/naming/sonarr-naming.json
@@ -5,7 +5,7 @@
   "series": {
       "default": "{Series TitleYear}",
       "plex": "{Series TitleYear} {imdb-{ImdbId}}",
-      "emby": "{Series TitleYear} [tvdbid-{TvdbId}]",
+      "emby": "{Series TitleYear}",
       "jellyfin": "{Series TitleYear} [tvdbid-{TvdbId}]"
   },
   "episodes": {


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->

This is a tmp fix for: #1371 till #1386 can be merged that's waiting for Radarr/Sonarr to support `=` for ID when https://github.com/Radarr/Radarr/pull/8730 get's merged

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

tmp removed the Emby ID suggestions in the Radarr and Sonarr naming scheme guide

## Open Questions and Pre-Merge TODOs

- [x] Test changes in local test setup

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer.

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
