### PR TITLE
fix(guides): Add Extras CF to Radarr HD/UHD unwanted

### DIFF
--- a/docs/updates.txt
+++ b/docs/updates.txt
@@ -1,3 +1,6 @@
+# 2023-09-11 17:15
+- [fix(guides): Add Extras CF to Radarr HD/UHD unwanted](https://github.com/TRaSH-Guides/Guides/pull/1565)
+
 # 2023-09-11 18:15
 - [fix(radarr): copy /paste error in naming scheme](https://github.com/TRaSH-Guides/Guides/pull/1549)
 - [fix(radarr): explain how original language is determined](https://github.com/TRaSH-Guides/Guides/pull/1543)

--- a/docs/updates.txt
+++ b/docs/updates.txt
@@ -1,4 +1,11 @@
 # 2023-09-22 17:15
+- [fix(starr): Remove RlsGrps from CF TrueHD and TrueHD Atmos](https://github.com/TRaSH-Guides/Guides/pull/1553)
+- [fix(starr): inaccurate Pahe regex](https://github.com/TRaSH-Guides/Guides/pull/1554)
+- [feat(guides): revise truenas core NFSv4 section](https://github.com/TRaSH-Guides/Guides/pull/1555)
+- [feat(radarr): add jennaortega to LQ CF](https://github.com/TRaSH-Guides/Guides/pull/1557)
+- [fix(starr): DTS-HD MA regex and add example](https://github.com/TRaSH-Guides/Guides/pull/1560)
+- [fix(guide): tmp fix for emby naming scheme](https://github.com/TRaSH-Guides/Guides/pull/1561)
+- [feat(sonarr): add d3g to LQ](https://github.com/TRaSH-Guides/Guides/pull/1562)
 - [fix(guides): Add Extras CF to Radarr HD/UHD unwanted](https://github.com/TRaSH-Guides/Guides/pull/1565)
 
 # 2023-09-11 18:15

--- a/docs/updates.txt
+++ b/docs/updates.txt
@@ -1,4 +1,4 @@
-# 2023-09-22 17:15
+# 2023-09-22 18:15
 - [fix(starr): Remove RlsGrps from CF TrueHD and TrueHD Atmos](https://github.com/TRaSH-Guides/Guides/pull/1553)
 - [fix(starr): inaccurate Pahe regex](https://github.com/TRaSH-Guides/Guides/pull/1554)
 - [feat(guides): revise truenas core NFSv4 section](https://github.com/TRaSH-Guides/Guides/pull/1555)

--- a/docs/updates.txt
+++ b/docs/updates.txt
@@ -1,4 +1,4 @@
-# 2023-09-11 17:15
+# 2023-09-22 17:15
 - [fix(guides): Add Extras CF to Radarr HD/UHD unwanted](https://github.com/TRaSH-Guides/Guides/pull/1565)
 
 # 2023-09-11 18:15

--- a/includes/cf/radarr-unwanted-uhd.md
+++ b/includes/cf/radarr-unwanted-uhd.md
@@ -6,6 +6,7 @@
     | [{{ radarr['cf']['x265-hd']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#x265-hd) :warning: | {{ radarr['cf']['x265-hd']['trash_scores']['default'] }}  | {{ radarr['cf']['x265-hd']['trash_id'] }}  |
     | [{{ radarr['cf']['3d']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#3d)                     |    {{ radarr['cf']['3d']['trash_scores']['default'] }}    | {{ radarr['cf']['3d']['trash_id'] }}       |
     | [{{ radarr['cf']['upscaled']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#upscaled)         | {{ radarr['cf']['upscaled']['trash_scores']['default'] }} | {{ radarr['cf']['upscaled']['trash_id'] }} |
+    | [{{ radarr['cf']['extras']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#extras)             |  {{ radarr['cf']['extras']['trash_scores']['default'] }}  | {{ radarr['cf']['extras']['trash_id'] }}   |
 
     ------
 
@@ -19,3 +20,4 @@
 
     - **{{ radarr['cf']['3d']['name'] }}:** Is 3D still a thing for home use ?
     - **{{ radarr['cf']['upscaled']['name'] }}:** A custom format to prevent Radarr from grabbing upscaled releases.
+    - **{{ radarr['cf']['extras']['name'] }}:** Blocks releases that only contain extras

--- a/includes/cf/radarr-unwanted.md
+++ b/includes/cf/radarr-unwanted.md
@@ -5,6 +5,7 @@
     | [{{ radarr['cf']['lq']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#lq)                     |   {{ radarr['cf']['lq']['trash_scores']['default'] }}    | {{ radarr['cf']['lq']['trash_id'] }}      |
     | [{{ radarr['cf']['x265-hd']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#x265-hd) :warning: | {{ radarr['cf']['x265-hd']['trash_scores']['default'] }} | {{ radarr['cf']['x265-hd']['trash_id'] }} |
     | [{{ radarr['cf']['3d']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#3d)                     |   {{ radarr['cf']['3d']['trash_scores']['default'] }}    | {{ radarr['cf']['3d']['trash_id'] }}      |
+    | [{{ radarr['cf']['extras']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#extras)             | {{ radarr['cf']['extras']['trash_scores']['default'] }}  | {{ radarr['cf']['extras']['trash_id'] }}  |
 
     ------
 
@@ -17,3 +18,4 @@
         !!! Danger "Don't use this together with [{{ radarr['cf']['x265-no-hdrdv']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#x265-no-hdrdv), Only ever include one of them :warning:"
 
     - **{{ radarr['cf']['3d']['name'] }}:** Is 3D still a thing for home use ?
+    - **{{ radarr['cf']['extras']['name'] }}:** Blocks releases that only contain extras


### PR DESCRIPTION
# Pull Request

## Purpose

Amend guide profiles to block 'Extras' releases by default

## Approach

- Add the Extras CF to Radarr HD/UHD unwanted tables and descriptions

## Open Questions and Pre-Merge TODOs

None

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer.

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
