### PR TITLE
feat(guides): SQP-1 score change for DTS-ES Custom Format

### DIFF
--- a/docs/json/radarr/cf/dts-es.json
+++ b/docs/json/radarr/cf/dts-es.json
@@ -3,8 +3,8 @@
   "trash_score": 1500,
   "trash_scores": {
     "default": 1500,
-    "sqp-1-1080p": -10000,
-    "sqp-1-2160p": -10000
+    "sqp-1-1080p": 0,
+    "sqp-1-2160p": 0
   },
   "name": "DTS-ES",
   "includeCustomFormatWhenRenaming": false,

--- a/includes/sqp/1-4k-cf-scoring-sqp1.md
+++ b/includes/sqp/1-4k-cf-scoring-sqp1.md
@@ -20,7 +20,7 @@
 
     !!! warning "Scores marked with a :warning: warning :warning: are different to those used in the main public guide"
 
-    !!! danger "The CF with `0` you can choose to add with a score of `0` or just don't add them.<br>The reason why we score them this low is to prevent transcoding as much as possible.<br>The reason why `DTS` has a score of `0` is to make sure, that you don't limit yourself too much."
+    !!! danger "The CF with `0` you can choose to add with a score of `0` or just don't add them.<br>The reason why we score them this low is to prevent transcoding as much as possible.<br>The reason why `DTS` and `DTS-ES` have a score of `0` is to make sure that you don't limit yourself too much."
 
 ??? abstract "All HDR Formats + DV (WEBDL) - [Click to show/hide]"
     | Custom Format                                                                                             |                             Score                              | Trash ID                                        |

--- a/includes/sqp/1-cf-scoring.md
+++ b/includes/sqp/1-cf-scoring.md
@@ -20,7 +20,7 @@
 
     !!! warning "Scores marked with a :warning: warning :warning: are different to those used in the main public guide"
 
-    !!! danger "The CF with `0` you can choose to add with a score of `0` or just don't add them.<br>The reason why we score them this low is to prevent transcoding as much as possible.<br>The reason why `DTS` has a score of `0` is to make sure, that you don't limit yourself too much."
+    !!! danger "The CF with `0` you can choose to add with a score of `0` or just don't add them.<br>The reason why we score them this low is to prevent transcoding as much as possible.<br>The reason why `DTS` and `DTS-ES` have a score of `0` is to make sure that you don't limit yourself too much."
 
 ??? abstract "Movie Versions - [Click to show/hide]"
     | Custom Format                                                                                                           |                                 Score                                 | Trash ID                                               |


### PR DESCRIPTION
# Pull Request

## Purpose

To allow DTS-ES releases under SQP-1 (1080p/2160p), and prevent some download loops

## Approach

- Amend the DTS-ES score for both SQP-1 variants to 0 so that these releases are not blocked, and to prevent download loops resultant from mis-naming. DTS-ES contains a DTS core, so will fall back to this on non-compatible systems.

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer.

<!-- ## Learning

None

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
