### PR TITLE
fix(radarr): Remove RlsGrp `SLOT` from CF `LQ`

### DIFF
--- a/docs/json/radarr/cf/lq.json
+++ b/docs/json/radarr/cf/lq.json
@@ -620,15 +620,6 @@
       }
     },
     {
-      "name": "SLOT",
-      "implementation": "ReleaseGroupSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "^(SLOT)$"
-      }
-    },
-    {
       "name": "STUTTERSHIT",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->

Fix: #1582 
- #1582 

SLOT was initially put into the LQ group for preing/releasing a mistagged version of Across the Spiderverse.
SLOT is also one of the few in scene that consistently does 4k web and has nearly 1000 releases, 99% of which are fine, so we decided to remove them from LQ because they only did till now 1 mistagged version

LQ are for RlsGRps that release fake, wrong or cause loops or other issues for automation.

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

- [x] Remove RlsGrp `SLOT` from CF `LQ`

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer.

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
