### PR TITLE
feat(radarr): add RlsGrp `LoRD` to `HD Bluray Tier 03`

### DIFF
--- a/docs/json/radarr/cf/hd-bluray-tier-03.json
+++ b/docs/json/radarr/cf/hd-bluray-tier-03.json
@@ -37,6 +37,15 @@
       }
     },
     {
+      "name": "LoRD",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(LoRD)$"
+      }
+    },
+    {
       "name": "playHD",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->

Fix: #1581 
- #1581 

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

- [x] add RlsGrp `LoRD` to `HD Bluray Tier 03`
- [x] Sorted RlsGrps in JSON

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer.

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
