### PR TITLE
feat (Guides): Added new qBittorrent Tips page for known working themes

### DIFF
--- a/docs/Downloaders/qBittorrent/Tips/Themes.md
+++ b/docs/Downloaders/qBittorrent/Tips/Themes.md
@@ -2,8 +2,9 @@
 
 A list of known working qBittorrent themes.
 
-| Theme                                                                              | Style | Compatibility |
-| ---------------------------------------------------------------------------------- | ----- | ------------- |
-| [Nightwalker Theme (CallMeBruce fork)](https://github.com/CallMeBruce/nightwalker) | Dark  | v4.5          |
+| Theme                                                                              | Style | Compatibility  |
+| ---------------------------------------------------------------------------------- | ----- | -------------- |
+| [Nightwalker Theme (CallMeBruce fork)](https://github.com/CallMeBruce/nightwalker) | Dark  | v4.5           |
+| [World of Quinoa](https://github.com/gl0ryus/woq)                                  | Dark  | v4.3.9, v4.4.5 |
 
 --8<-- "includes/support.md"

--- a/docs/Downloaders/qBittorrent/Tips/Themes.md
+++ b/docs/Downloaders/qBittorrent/Tips/Themes.md
@@ -1,0 +1,9 @@
+# Themes
+
+A list of known working qBittorrent themes.
+
+| Theme                                                                              | Style | Compatibility |
+| ---------------------------------------------------------------------------------- | ----- | ------------- |
+| [Nightwalker Theme (CallMeBruce fork)](https://github.com/CallMeBruce/nightwalker) | Dark  | v4.5          |
+
+--8<-- "includes/support.md"

--- a/docs/Downloaders/qBittorrent/Tips/Themes.md
+++ b/docs/Downloaders/qBittorrent/Tips/Themes.md
@@ -2,9 +2,9 @@
 
 A list of known working qBittorrent themes.
 
-| Theme                                                                              | Style | Compatibility  |
-| ---------------------------------------------------------------------------------- | ----- | -------------- |
-| [Nightwalker Theme (CallMeBruce fork)](https://github.com/CallMeBruce/nightwalker) | Dark  | v4.5           |
-| [World of Quinoa](https://github.com/gl0ryus/woq)                                  | Dark  | v4.3.9, v4.4.5 |
+| Theme                                                                                                                          | Style | Compatibility  |
+| ------------------------------------------------------------------------------------------------------------------------------ | ----- | -------------- |
+| [Nightwalker Theme (CallMeBruce fork)](https://github.com/CallMeBruce/nightwalker){:target="_blank" rel="noopener noreferrer"} | Dark  | v4.5           |
+| [World of Quinoa](https://github.com/gl0ryus/woq){:target="_blank" rel="noopener noreferrer"}                                  | Dark  | v4.3.9, v4.4.5 |
 
 --8<-- "includes/support.md"


### PR DESCRIPTION
# Pull Request

## Purpose

Feature: #1545 
- https://github.com/TRaSH-Guides/Guides/issues/1545

## Approach

Create a new guide page at Downloaders > qBittorrent > Tips > Themes, containing a table of known working qBittorrent themes

## Open Questions and Pre-Merge TODOs

None

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
