### PR TITLE
fix:(radarr): remove SDR condition from UHD Bluray Tier 1-3

### DIFF
--- a/docs/json/radarr/cf/uhd-bluray-tier-01.json
+++ b/docs/json/radarr/cf/uhd-bluray-tier-01.json
@@ -55,15 +55,6 @@
       }
     },
     {
-      "name": "Not SDR",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": true,
-      "required": true,
-      "fields": {
-        "value": "\\bSDR\\b"
-      }
-    },
-    {
       "name": "Not WEBDL",
       "implementation": "SourceSpecification",
       "negate": true,

--- a/docs/json/radarr/cf/uhd-bluray-tier-02.json
+++ b/docs/json/radarr/cf/uhd-bluray-tier-02.json
@@ -46,15 +46,6 @@
       }
     },
     {
-      "name": "Not SDR",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": true,
-      "required": true,
-      "fields": {
-        "value": "\\bSDR\\b"
-      }
-    },
-    {
       "name": "Not WEBDL",
       "implementation": "SourceSpecification",
       "negate": true,

--- a/docs/json/radarr/cf/uhd-bluray-tier-03.json
+++ b/docs/json/radarr/cf/uhd-bluray-tier-03.json
@@ -55,15 +55,6 @@
       }
     },
     {
-      "name": "Not SDR",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": true,
-      "required": true,
-      "fields": {
-        "value": "\\bSDR\\b"
-      }
-    },
-    {
       "name": "Not WEBDL",
       "implementation": "SourceSpecification",
       "negate": true,


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->

Fix: #1588 
- #1588 

SDR can be handles with the SDR CF on user choice

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

- [x] Removed SDR condition from UHD Bluray Tier 1
- [x] Removed SDR condition from UHD Bluray Tier 2
- [x] Removed SDR condition from UHD Bluray Tier 3

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer.

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
