### PR TITLE
feat(starr): add custom formats for Japanese streaming services `FOD`, `TVer` and `U-NEXT`

### DIFF
--- a/docs/Radarr/Radarr-collection-of-custom-formats.md
+++ b/docs/Radarr/Radarr-collection-of-custom-formats.md
@@ -66,6 +66,7 @@ I also made 3 guides related to this one.
 |                                               |                       |                                           | [Stan](#stan)              |
 |                                               |                       |                                           | [Crave](#crav)             |
 |                                               |                       |                                           | [OViD](#ovid)              |
+|                                               |                       |                                           | [FOD](#fod)                |
 
 ------
 
@@ -1948,6 +1949,26 @@ I also made 3 guides related to this one.
 
     ```json
     [[% filter indent(width=4) %]][[% include 'json/radarr/cf/ovid.json' %]][[% endfilter %]]
+    ```
+
+<sub><sup>[TOP](#index)</sup>
+
+------
+
+### FOD
+
+<sub>FOD</sub>
+
+??? question "FOD - [Click to show/hide]"
+
+    - Fuji Television On Demand
+    - [From Wikipedia, the free encyclopedia](https://ja.wikipedia.org/wiki/%E3%83%95%E3%82%B8%E3%83%86%E3%83%AC%E3%83%93%E3%82%AA%E3%83%B3%E3%83%87%E3%83%9E%E3%83%B3%E3%83%89){:target="_blank" rel="noopener noreferrer"}
+    - [FOD Website](https://fod-sp.fujitv.co.jp){:target="_blank" rel="noopener noreferrer"}
+
+??? example "JSON - [Click to show/hide]"
+
+    ```json
+    [[% filter indent(width=4) %]][[% include 'json/radarr/cf/fod.json' %]][[% endfilter %]]
     ```
 
 <sub><sup>[TOP](#index)</sup>

--- a/docs/Radarr/Radarr-collection-of-custom-formats.md
+++ b/docs/Radarr/Radarr-collection-of-custom-formats.md
@@ -68,6 +68,7 @@ I also made 3 guides related to this one.
 |                                               |                       |                                           | [OViD](#ovid)              |
 |                                               |                       |                                           | [FOD](#fod)                |
 |                                               |                       |                                           | [TVer](#tver)              |
+|                                               |                       |                                           | [U-NEXT](#u-next)          |
 
 ------
 
@@ -1989,6 +1990,25 @@ I also made 3 guides related to this one.
 
     ```json
     [[% filter indent(width=4) %]][[% include 'json/radarr/cf/tver.json' %]][[% endfilter %]]
+    ```
+
+<sub><sup>[TOP](#index)</sup>
+
+------
+
+### U-NEXT
+
+<sub>U-NEXT</sub>
+
+??? question "U-NEXT - [Click to show/hide]"
+
+    - [From Wikipedia, the free encyclopedia](https://en.wikipedia.org/wiki/U-Next){:target="_blank" rel="noopener noreferrer"}
+    - [U-NEXT Website](https://video.unext.jp){:target="_blank" rel="noopener noreferrer"}
+
+??? example "JSON - [Click to show/hide]"
+
+    ```json
+    [[% filter indent(width=4) %]][[% include 'json/radarr/cf/u-next.json' %]][[% endfilter %]]
     ```
 
 <sub><sup>[TOP](#index)</sup>

--- a/docs/Radarr/Radarr-collection-of-custom-formats.md
+++ b/docs/Radarr/Radarr-collection-of-custom-formats.md
@@ -67,6 +67,7 @@ I also made 3 guides related to this one.
 |                                               |                       |                                           | [Crave](#crav)             |
 |                                               |                       |                                           | [OViD](#ovid)              |
 |                                               |                       |                                           | [FOD](#fod)                |
+|                                               |                       |                                           | [TVer](#tver)              |
 
 ------
 
@@ -1969,6 +1970,25 @@ I also made 3 guides related to this one.
 
     ```json
     [[% filter indent(width=4) %]][[% include 'json/radarr/cf/fod.json' %]][[% endfilter %]]
+    ```
+
+<sub><sup>[TOP](#index)</sup>
+
+------
+
+### TVer
+
+<sub>TVer</sub>
+
+??? question "TVer - [Click to show/hide]"
+
+    - [From Wikipedia, the free encyclopedia](https://en.wikipedia.org/wiki/TVer_(streaming_service)){:target="_blank" rel="noopener noreferrer"}
+    - [TVer Website](https://tver.jp){:target="_blank" rel="noopener noreferrer"}
+
+??? example "JSON - [Click to show/hide]"
+
+    ```json
+    [[% filter indent(width=4) %]][[% include 'json/radarr/cf/tver.json' %]][[% endfilter %]]
     ```
 
 <sub><sup>[TOP](#index)</sup>

--- a/docs/Sonarr/Sonarr-Release-Profile-RegEx.md
+++ b/docs/Sonarr/Sonarr-Release-Profile-RegEx.md
@@ -227,6 +227,18 @@ Add this to your `Preferred (3)` with a score of [50]
 /\b(ovid)\b(?=[ ._-]web[ ._-]?(dl|rip)\b)/i
 ```
 
+```bash
+/\b(fod)\b(?=[ ._-]web[ ._-]?(dl|rip)\b)/i
+```
+
+```bash
+/\b(tver)\b(?=[ ._-]web[ ._-]?(dl|rip)\b)/i
+```
+
+```bash
+/\b(u-next)\b(?=[ ._-]web[ ._-]?(dl|rip)\b)/i
+```
+
 !!! danger "Caution"
     Don't forget to click on `SAVE` after you've added everything you want to the release profile :bangbang:
 

--- a/docs/Sonarr/sonarr-collection-of-custom-formats.md
+++ b/docs/Sonarr/sonarr-collection-of-custom-formats.md
@@ -73,6 +73,7 @@ I also made 3 guides related to this one.
 |                       |                       |                                         | [OViD](#ovid)                               |
 |                       |                       |                                         | [UHD Streaming Boost](#uhd-streaming-boost) |
 |                       |                       |                                         | [UHD Streaming Cut](#uhd-streaming-cut)     |
+|                       |                       |                                         | [FOD](#fod)                                 |
 
 ------
 
@@ -1819,6 +1820,26 @@ I also made 3 guides related to this one.
 
     ```json
     [[% filter indent(width=4) %]][[% include 'json/sonarr/cf/uhd-streaming-cut.json' %]][[% endfilter %]]
+    ```
+
+<sub><sup>[TOP](#index)</sup>
+
+------
+
+### FOD
+
+<sub>FOD</sub>
+
+??? question "FOD - [Click to show/hide]"
+
+    - Fuji Television On Demand
+    - [From Wikipedia, the free encyclopedia](https://ja.wikipedia.org/wiki/%E3%83%95%E3%82%B8%E3%83%86%E3%83%AC%E3%83%93%E3%82%AA%E3%83%B3%E3%83%87%E3%83%9E%E3%83%B3%E3%83%89){:target="_blank" rel="noopener noreferrer"}
+    - [FOD Website](https://fod-sp.fujitv.co.jp){:target="_blank" rel="noopener noreferrer"}
+
+??? example "JSON - [Click to show/hide]"
+
+    ```json
+    [[% filter indent(width=4) %]][[% include 'json/sonarr/cf/fod.json' %]][[% endfilter %]]
     ```
 
 <sub><sup>[TOP](#index)</sup>

--- a/docs/Sonarr/sonarr-collection-of-custom-formats.md
+++ b/docs/Sonarr/sonarr-collection-of-custom-formats.md
@@ -74,6 +74,7 @@ I also made 3 guides related to this one.
 |                       |                       |                                         | [UHD Streaming Boost](#uhd-streaming-boost) |
 |                       |                       |                                         | [UHD Streaming Cut](#uhd-streaming-cut)     |
 |                       |                       |                                         | [FOD](#fod)                                 |
+|                       |                       |                                         | [TVer](#tver)                               |
 
 ------
 
@@ -1840,6 +1841,25 @@ I also made 3 guides related to this one.
 
     ```json
     [[% filter indent(width=4) %]][[% include 'json/sonarr/cf/fod.json' %]][[% endfilter %]]
+    ```
+
+<sub><sup>[TOP](#index)</sup>
+
+------
+
+### TVer
+
+<sub>TVer</sub>
+
+??? question "TVer - [Click to show/hide]"
+
+    - [From Wikipedia, the free encyclopedia](https://en.wikipedia.org/wiki/TVer_(streaming_service)){:target="_blank" rel="noopener noreferrer"}
+    - [TVer Website](https://tver.jp){:target="_blank" rel="noopener noreferrer"}
+
+??? example "JSON - [Click to show/hide]"
+
+    ```json
+    [[% filter indent(width=4) %]][[% include 'json/sonarr/cf/tver.json' %]][[% endfilter %]]
     ```
 
 <sub><sup>[TOP](#index)</sup>

--- a/docs/Sonarr/sonarr-collection-of-custom-formats.md
+++ b/docs/Sonarr/sonarr-collection-of-custom-formats.md
@@ -75,6 +75,7 @@ I also made 3 guides related to this one.
 |                       |                       |                                         | [UHD Streaming Cut](#uhd-streaming-cut)     |
 |                       |                       |                                         | [FOD](#fod)                                 |
 |                       |                       |                                         | [TVer](#tver)                               |
+|                       |                       |                                         | [U-NEXT](#u-next)                           |
 
 ------
 
@@ -1860,6 +1861,25 @@ I also made 3 guides related to this one.
 
     ```json
     [[% filter indent(width=4) %]][[% include 'json/sonarr/cf/tver.json' %]][[% endfilter %]]
+    ```
+
+<sub><sup>[TOP](#index)</sup>
+
+------
+
+### U-NEXT
+
+<sub>U-NEXT</sub>
+
+??? question "U-NEXT - [Click to show/hide]"
+
+    - [From Wikipedia, the free encyclopedia](https://en.wikipedia.org/wiki/U-Next){:target="_blank" rel="noopener noreferrer"}
+    - [U-NEXT Website](https://video.unext.jp){:target="_blank" rel="noopener noreferrer"}
+
+??? example "JSON - [Click to show/hide]"
+
+    ```json
+    [[% filter indent(width=4) %]][[% include 'json/sonarr/cf/u-next.json' %]][[% endfilter %]]
     ```
 
 <sub><sup>[TOP](#index)</sup>

--- a/docs/json/radarr/cf/fod.json
+++ b/docs/json/radarr/cf/fod.json
@@ -1,0 +1,35 @@
+{
+  "trash_id": "917d1f2c845b2b466036b0cc2d7c72a3",
+  "trash_regex": "https://regex101.com/r/kgngPG/1",
+  "name": "FOD",
+  "includeCustomFormatWhenRenaming": true,
+  "specifications": [
+    {
+      "name": "FOD",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": true,
+      "fields": {
+        "value": "\\b(fod)\\b"
+      }
+    },
+    {
+      "name": "WEBDL",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 7
+      }
+    },
+    {
+      "name": "WEBRIP",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 8
+      }
+    }
+  ]
+}

--- a/docs/json/radarr/cf/tver.json
+++ b/docs/json/radarr/cf/tver.json
@@ -1,0 +1,35 @@
+{
+  "trash_id": "f1b0bae9bc222dab32c1b38b5a7a1088",
+  "trash_regex": "https://regex101.com/r/ZdWC9D/1",
+  "name": "TVer",
+  "includeCustomFormatWhenRenaming": true,
+  "specifications": [
+    {
+      "name": "TVer",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": true,
+      "fields": {
+        "value": "\\b(tver)\\b"
+      }
+    },
+    {
+      "name": "WEBDL",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 7
+      }
+    },
+    {
+      "name": "WEBRIP",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 8
+      }
+    }
+  ]
+}

--- a/docs/json/radarr/cf/u-next.json
+++ b/docs/json/radarr/cf/u-next.json
@@ -1,0 +1,35 @@
+{
+  "trash_id": "279bda7434fd9075786de274e6c3c202",
+  "trash_regex": "https://regex101.com/r/04ZSLm/1",
+  "name": "U-NEXT",
+  "includeCustomFormatWhenRenaming": true,
+  "specifications": [
+    {
+      "name": "U-NEXT",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": true,
+      "fields": {
+        "value": "\\b(u-next)\\b"
+      }
+    },
+    {
+      "name": "WEBDL",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 7
+      }
+    },
+    {
+      "name": "WEBRIP",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 8
+      }
+    }
+  ]
+}

--- a/docs/json/sonarr/cf/fod.json
+++ b/docs/json/sonarr/cf/fod.json
@@ -1,5 +1,9 @@
 {
   "trash_id": "7be9c0572d8cd4f81785dacf7e85985e",
+  "trash_score": 50,
+  "trash_scores": {
+    "default": 50
+  },
   "trash_regex": "https://regex101.com/r/CbFoaJ/1",
   "name": "FOD",
   "includeCustomFormatWhenRenaming": true,

--- a/docs/json/sonarr/cf/fod.json
+++ b/docs/json/sonarr/cf/fod.json
@@ -1,0 +1,35 @@
+{
+  "trash_id": "7be9c0572d8cd4f81785dacf7e85985e",
+  "trash_regex": "https://regex101.com/r/CbFoaJ/1",
+  "name": "FOD",
+  "includeCustomFormatWhenRenaming": true,
+  "specifications": [
+    {
+      "name": "FOD",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": true,
+      "fields": {
+        "value": "\\b(fod)\\b"
+      }
+    },
+    {
+      "name": "WEBDL",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 3
+      }
+    },
+    {
+      "name": "WEBRIP",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 4
+      }
+    }
+  ]
+}

--- a/docs/json/sonarr/cf/fod.json
+++ b/docs/json/sonarr/cf/fod.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "7be9c0572d8cd4f81785dacf7e85985e",
-  "trash_score": 50,
   "trash_scores": {
     "default": 50
   },

--- a/docs/json/sonarr/cf/tver.json
+++ b/docs/json/sonarr/cf/tver.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "d100ea972d1af2150b65b1cffb80f6b5",
-  "trash_score": 50,
   "trash_scores": {
     "default": 50
   },

--- a/docs/json/sonarr/cf/tver.json
+++ b/docs/json/sonarr/cf/tver.json
@@ -1,0 +1,35 @@
+{
+  "trash_id": "d100ea972d1af2150b65b1cffb80f6b5",
+  "trash_regex": "https://regex101.com/r/o9YVOG/1",
+  "name": "TVer",
+  "includeCustomFormatWhenRenaming": true,
+  "specifications": [
+    {
+      "name": "TVer",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": true,
+      "fields": {
+        "value": "\\b(tver)\\b"
+      }
+    },
+    {
+      "name": "WEBDL",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 3
+      }
+    },
+    {
+      "name": "WEBRIP",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 4
+      }
+    }
+  ]
+}

--- a/docs/json/sonarr/cf/tver.json
+++ b/docs/json/sonarr/cf/tver.json
@@ -1,5 +1,9 @@
 {
   "trash_id": "d100ea972d1af2150b65b1cffb80f6b5",
+  "trash_score": 50,
+  "trash_scores": {
+    "default": 50
+  },
   "trash_regex": "https://regex101.com/r/o9YVOG/1",
   "name": "TVer",
   "includeCustomFormatWhenRenaming": true,

--- a/docs/json/sonarr/cf/u-next.json
+++ b/docs/json/sonarr/cf/u-next.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "0e99e7cc719a8a73b2668c3a0c3fe10c",
-  "trash_score": 50,
   "trash_scores": {
     "default": 50
   },

--- a/docs/json/sonarr/cf/u-next.json
+++ b/docs/json/sonarr/cf/u-next.json
@@ -1,0 +1,35 @@
+{
+  "trash_id": "0e99e7cc719a8a73b2668c3a0c3fe10c",
+  "trash_regex": "https://regex101.com/r/eQuNMO/1",
+  "name": "U-NEXT",
+  "includeCustomFormatWhenRenaming": true,
+  "specifications": [
+    {
+      "name": "U-NEXT",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": true,
+      "fields": {
+        "value": "\\b(u-next)\\b"
+      }
+    },
+    {
+      "name": "WEBDL",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 3
+      }
+    },
+    {
+      "name": "WEBRIP",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 4
+      }
+    }
+  ]
+}

--- a/docs/json/sonarr/cf/u-next.json
+++ b/docs/json/sonarr/cf/u-next.json
@@ -1,5 +1,9 @@
 {
   "trash_id": "0e99e7cc719a8a73b2668c3a0c3fe10c",
+  "trash_score": 50,
+  "trash_scores": {
+    "default": 50
+  },
   "trash_regex": "https://regex101.com/r/eQuNMO/1",
   "name": "U-NEXT",
   "includeCustomFormatWhenRenaming": true,

--- a/docs/json/sonarr/rp/streaming.json
+++ b/docs/json/sonarr/rp/streaming.json
@@ -52,7 +52,10 @@
         "/\\b(red)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)/i",
         "/\\b(sho|showtime)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)/i",
         "/\\b(vdl)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)/i",
-        "/\\b(ovid)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)/i"
+        "/\\b(ovid)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)/i",
+        "/\\b(fod)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)/i",
+        "/\\b(tver)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)/i",
+        "/\\b(u-next)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)/i"
       ]
     }
   ],

--- a/includes/cf/radarr-streaming-services.md
+++ b/includes/cf/radarr-streaming-services.md
@@ -19,6 +19,7 @@
     | [{{ radarr['cf']['stan']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#stan)     |                           0                            | {{ radarr['cf']['stan']['trash_id'] }}   |
     | [{{ radarr['cf']['ovid']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#ovid)     |                           0                            | {{ radarr['cf']['ovid']['trash_id'] }}   |
     | [{{ radarr['cf']['fod']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#fod)       |                           0                            | {{ radarr['cf']['fod']['trash_id'] }}    |
+    | [{{ radarr['cf']['tver']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#tver)     |                           0                            | {{ radarr['cf']['tver']['trash_id'] }}   |
 
     ------
     Breakdown and Why

--- a/includes/cf/radarr-streaming-services.md
+++ b/includes/cf/radarr-streaming-services.md
@@ -1,23 +1,24 @@
 ??? abstract "Streaming Services - [Click to show/hide]"
-    | Custom Format                                                                             |                         Score                          | Trash ID                                |
-    | ----------------------------------------------------------------------------------------- | :----------------------------------------------------: | --------------------------------------- |
-    | [{{ radarr['cf']['amzn']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#amzn)   |                           0                            | {{ radarr['cf']['amzn']['trash_id'] }}  |
-    | [{{ radarr['cf']['atvp']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#atvp)   |                           0                            | {{ radarr['cf']['atvp']['trash_id'] }}  |
-    | [{{ radarr['cf']['bcore']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#bcore) | {{ radarr['cf']['bcore']['trash_scores']['default'] }} | {{ radarr['cf']['bcore']['trash_id'] }} |
-    | [{{ radarr['cf']['crav']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#crav)   |                           0                            | {{ radarr['cf']['crav']['trash_id'] }}  |
-    | [{{ radarr['cf']['crit']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#crit)   | {{ radarr['cf']['crit']['trash_scores']['default'] }}  | {{ radarr['cf']['crit']['trash_id'] }}  |
-    | [{{ radarr['cf']['dsnp']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#dsnp)   |                           0                            | {{ radarr['cf']['dsnp']['trash_id'] }}  |
-    | [{{ radarr['cf']['hbo']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#hbo)     |                           0                            | {{ radarr['cf']['hbo']['trash_id'] }}   |
-    | [{{ radarr['cf']['hmax']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#hmax)   |                           0                            | {{ radarr['cf']['hmax']['trash_id'] }}  |
-    | [{{ radarr['cf']['max']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#max)     |                           0                            | {{ radarr['cf']['max']['trash_id'] }}   |
-    | [{{ radarr['cf']['hulu']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#hulu)   |                           0                            | {{ radarr['cf']['hulu']['trash_id'] }}  |
-    | [{{ radarr['cf']['ma']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#ma)       |  {{ radarr['cf']['ma']['trash_scores']['default'] }}   | {{ radarr['cf']['ma']['trash_id'] }}    |
-    | [{{ radarr['cf']['nf']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#nf)       |                           0                            | {{ radarr['cf']['nf']['trash_id'] }}    |
-    | [{{ radarr['cf']['pathe']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#pathe) |                           0                            | {{ radarr['cf']['pathe']['trash_id'] }} |
-    | [{{ radarr['cf']['pcok']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#pcok)   |                           0                            | {{ radarr['cf']['pcok']['trash_id'] }}  |
-    | [{{ radarr['cf']['pmtp']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#pmtp)   |                           0                            | {{ radarr['cf']['pmtp']['trash_id'] }}  |
-    | [{{ radarr['cf']['stan']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#stan)   |                           0                            | {{ radarr['cf']['stan']['trash_id'] }}  |
-    | [{{ radarr['cf']['ovid']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#ovid)   |                           0                            | {{ radarr['cf']['ovid']['trash_id'] }}  |
+    | Custom Format                                                                               |                         Score                          | Trash ID                                 |
+    | ------------------------------------------------------------------------------------------- | :----------------------------------------------------: | ---------------------------------------- |
+    | [{{ radarr['cf']['amzn']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#amzn)     |                           0                            | {{ radarr['cf']['amzn']['trash_id'] }}   |
+    | [{{ radarr['cf']['atvp']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#atvp)     |                           0                            | {{ radarr['cf']['atvp']['trash_id'] }}   |
+    | [{{ radarr['cf']['bcore']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#bcore)   | {{ radarr['cf']['bcore']['trash_scores']['default'] }} | {{ radarr['cf']['bcore']['trash_id'] }}  |
+    | [{{ radarr['cf']['crav']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#crav)     |                           0                            | {{ radarr['cf']['crav']['trash_id'] }}   |
+    | [{{ radarr['cf']['crit']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#crit)     | {{ radarr['cf']['crit']['trash_scores']['default'] }}  | {{ radarr['cf']['crit']['trash_id'] }}   |
+    | [{{ radarr['cf']['dsnp']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#dsnp)     |                           0                            | {{ radarr['cf']['dsnp']['trash_id'] }}   |
+    | [{{ radarr['cf']['hbo']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#hbo)       |                           0                            | {{ radarr['cf']['hbo']['trash_id'] }}    |
+    | [{{ radarr['cf']['hmax']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#hmax)     |                           0                            | {{ radarr['cf']['hmax']['trash_id'] }}   |
+    | [{{ radarr['cf']['max']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#max)       |                           0                            | {{ radarr['cf']['max']['trash_id'] }}    |
+    | [{{ radarr['cf']['hulu']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#hulu)     |                           0                            | {{ radarr['cf']['hulu']['trash_id'] }}   |
+    | [{{ radarr['cf']['ma']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#ma)         |  {{ radarr['cf']['ma']['trash_scores']['default'] }}   | {{ radarr['cf']['ma']['trash_id'] }}     |
+    | [{{ radarr['cf']['nf']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#nf)         |                           0                            | {{ radarr['cf']['nf']['trash_id'] }}     |
+    | [{{ radarr['cf']['pathe']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#pathe)   |                           0                            | {{ radarr['cf']['pathe']['trash_id'] }}  |
+    | [{{ radarr['cf']['pcok']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#pcok)     |                           0                            | {{ radarr['cf']['pcok']['trash_id'] }}   |
+    | [{{ radarr['cf']['pmtp']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#pmtp)     |                           0                            | {{ radarr['cf']['pmtp']['trash_id'] }}   |
+    | [{{ radarr['cf']['stan']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#stan)     |                           0                            | {{ radarr['cf']['stan']['trash_id'] }}   |
+    | [{{ radarr['cf']['ovid']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#ovid)     |                           0                            | {{ radarr['cf']['ovid']['trash_id'] }}   |
+    | [{{ radarr['cf']['fod']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#fod)       |                           0                            | {{ radarr['cf']['fod']['trash_id'] }}    |
 
     ------
     Breakdown and Why

--- a/includes/cf/radarr-streaming-services.md
+++ b/includes/cf/radarr-streaming-services.md
@@ -20,6 +20,7 @@
     | [{{ radarr['cf']['ovid']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#ovid)     |                           0                            | {{ radarr['cf']['ovid']['trash_id'] }}   |
     | [{{ radarr['cf']['fod']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#fod)       |                           0                            | {{ radarr['cf']['fod']['trash_id'] }}    |
     | [{{ radarr['cf']['tver']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#tver)     |                           0                            | {{ radarr['cf']['tver']['trash_id'] }}   |
+    | [{{ radarr['cf']['u-next']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#u-next) |                           0                            | {{ radarr['cf']['u-next']['trash_id'] }} |
 
     ------
     Breakdown and Why

--- a/includes/cf/sonarr-streaming-services.md
+++ b/includes/cf/sonarr-streaming-services.md
@@ -23,3 +23,4 @@
     | [{{ sonarr['cf']['vdl']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#vdl)       | {{ sonarr['cf']['vdl']['trash_scores']['default'] }}  | {{ sonarr['cf']['vdl']['trash_id'] }}    |
     | [{{ sonarr['cf']['ovid']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#ovid)     | {{ sonarr['cf']['ovid']['trash_scores']['default'] }} | {{ sonarr['cf']['ovid']['trash_id'] }}   |
     | [{{ sonarr['cf']['fod']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#fod)       |                           0                           | {{ sonarr['cf']['fod']['trash_id'] }}    |
+    | [{{ sonarr['cf']['tver']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#tver)     |                           0                           | {{ sonarr['cf']['tver']['trash_id'] }}   |

--- a/includes/cf/sonarr-streaming-services.md
+++ b/includes/cf/sonarr-streaming-services.md
@@ -1,24 +1,25 @@
 ??? abstract "Streaming Services - [Click to show/hide]"
-    | Custom Format                                                                           |                         Score                         | Trash ID                               |
-    | --------------------------------------------------------------------------------------- | :---------------------------------------------------: | -------------------------------------- |
-    | [{{ sonarr['cf']['atvp']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#atvp) | {{ sonarr['cf']['atvp']['trash_scores']['default'] }} | {{ sonarr['cf']['atvp']['trash_id'] }} |
-    | [{{ sonarr['cf']['dsnp']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#dsnp) | {{ sonarr['cf']['dsnp']['trash_scores']['default'] }} | {{ sonarr['cf']['dsnp']['trash_id'] }} |
-    | [{{ sonarr['cf']['max']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#max)   | {{ sonarr['cf']['max']['trash_scores']['default'] }}  | {{ sonarr['cf']['max']['trash_id'] }}  |
-    | [{{ sonarr['cf']['hmax']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#hmax) | {{ sonarr['cf']['hmax']['trash_scores']['default'] }} | {{ sonarr['cf']['hmax']['trash_id'] }} |
-    | [{{ sonarr['cf']['qibi']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#qibi) | {{ sonarr['cf']['qibi']['trash_scores']['default'] }} | {{ sonarr['cf']['qibi']['trash_id'] }} |
-    | [{{ sonarr['cf']['amzn']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#amzn) | {{ sonarr['cf']['amzn']['trash_scores']['default'] }} | {{ sonarr['cf']['amzn']['trash_id'] }} |
-    | [{{ sonarr['cf']['nf']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#nf)     |  {{ sonarr['cf']['nf']['trash_scores']['default'] }}  | {{ sonarr['cf']['nf']['trash_id'] }}   |
-    | [{{ sonarr['cf']['pcok']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#pcok) | {{ sonarr['cf']['pcok']['trash_scores']['default'] }} | {{ sonarr['cf']['pcok']['trash_id'] }} |
-    | [{{ sonarr['cf']['pmtp']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#pmtp) | {{ sonarr['cf']['pmtp']['trash_scores']['default'] }} | {{ sonarr['cf']['pmtp']['trash_id'] }} |
-    | [{{ sonarr['cf']['stan']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#stan) | {{ sonarr['cf']['stan']['trash_scores']['default'] }} | {{ sonarr['cf']['stan']['trash_id'] }} |
-    | [{{ sonarr['cf']['cc']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#cc)     |  {{ sonarr['cf']['cc']['trash_scores']['default'] }}  | {{ sonarr['cf']['cc']['trash_id'] }}   |
-    | [{{ sonarr['cf']['crav']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#crav) | {{ sonarr['cf']['crav']['trash_scores']['default'] }} | {{ sonarr['cf']['crav']['trash_id'] }} |
-    | [{{ sonarr['cf']['dcu']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#dcu)   | {{ sonarr['cf']['dcu']['trash_scores']['default'] }}  | {{ sonarr['cf']['dcu']['trash_id'] }}  |
-    | [{{ sonarr['cf']['hbo']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#hbo)   | {{ sonarr['cf']['hbo']['trash_scores']['default'] }}  | {{ sonarr['cf']['hbo']['trash_id'] }}  |
-    | [{{ sonarr['cf']['hulu']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#hulu) | {{ sonarr['cf']['hulu']['trash_scores']['default'] }} | {{ sonarr['cf']['hulu']['trash_id'] }} |
-    | [{{ sonarr['cf']['it']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#it)     |  {{ sonarr['cf']['it']['trash_scores']['default'] }}  | {{ sonarr['cf']['it']['trash_id'] }}   |
-    | [{{ sonarr['cf']['nlz']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#nlz)   | {{ sonarr['cf']['nlz']['trash_scores']['default'] }}  | {{ sonarr['cf']['nlz']['trash_id'] }}  |
-    | [{{ sonarr['cf']['red']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#red)   | {{ sonarr['cf']['red']['trash_scores']['default'] }}  | {{ sonarr['cf']['red']['trash_id'] }}  |
-    | [{{ sonarr['cf']['sho']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#sho)   | {{ sonarr['cf']['sho']['trash_scores']['default'] }}  | {{ sonarr['cf']['sho']['trash_id'] }}  |
-    | [{{ sonarr['cf']['vdl']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#vdl)   | {{ sonarr['cf']['vdl']['trash_scores']['default'] }}  | {{ sonarr['cf']['vdl']['trash_id'] }}  |
-    | [{{ sonarr['cf']['ovid']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#ovid) | {{ sonarr['cf']['ovid']['trash_scores']['default'] }} | {{ sonarr['cf']['ovid']['trash_id'] }} |
+    | Custom Format                                                                               |                         Score                         | Trash ID                                 |
+    | ------------------------------------------------------------------------------------------- | :---------------------------------------------------: | ---------------------------------------- |
+    | [{{ sonarr['cf']['atvp']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#atvp)     | {{ sonarr['cf']['atvp']['trash_scores']['default'] }} | {{ sonarr['cf']['atvp']['trash_id'] }}   |
+    | [{{ sonarr['cf']['dsnp']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#dsnp)     | {{ sonarr['cf']['dsnp']['trash_scores']['default'] }} | {{ sonarr['cf']['dsnp']['trash_id'] }}   |
+    | [{{ sonarr['cf']['max']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#max)       | {{ sonarr['cf']['max']['trash_scores']['default'] }}  | {{ sonarr['cf']['max']['trash_id'] }}    |
+    | [{{ sonarr['cf']['hmax']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#hmax)     | {{ sonarr['cf']['hmax']['trash_scores']['default'] }} | {{ sonarr['cf']['hmax']['trash_id'] }}   |
+    | [{{ sonarr['cf']['qibi']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#qibi)     | {{ sonarr['cf']['qibi']['trash_scores']['default'] }} | {{ sonarr['cf']['qibi']['trash_id'] }}   |
+    | [{{ sonarr['cf']['amzn']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#amzn)     | {{ sonarr['cf']['amzn']['trash_scores']['default'] }} | {{ sonarr['cf']['amzn']['trash_id'] }}   |
+    | [{{ sonarr['cf']['nf']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#nf)         |  {{ sonarr['cf']['nf']['trash_scores']['default'] }}  | {{ sonarr['cf']['nf']['trash_id'] }}     |
+    | [{{ sonarr['cf']['pcok']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#pcok)     | {{ sonarr['cf']['pcok']['trash_scores']['default'] }} | {{ sonarr['cf']['pcok']['trash_id'] }}   |
+    | [{{ sonarr['cf']['pmtp']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#pmtp)     | {{ sonarr['cf']['pmtp']['trash_scores']['default'] }} | {{ sonarr['cf']['pmtp']['trash_id'] }}   |
+    | [{{ sonarr['cf']['stan']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#stan)     | {{ sonarr['cf']['stan']['trash_scores']['default'] }} | {{ sonarr['cf']['stan']['trash_id'] }}   |
+    | [{{ sonarr['cf']['cc']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#cc)         |  {{ sonarr['cf']['cc']['trash_scores']['default'] }}  | {{ sonarr['cf']['cc']['trash_id'] }}     |
+    | [{{ sonarr['cf']['crav']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#crav)     | {{ sonarr['cf']['crav']['trash_scores']['default'] }} | {{ sonarr['cf']['crav']['trash_id'] }}   |
+    | [{{ sonarr['cf']['dcu']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#dcu)       | {{ sonarr['cf']['dcu']['trash_scores']['default'] }}  | {{ sonarr['cf']['dcu']['trash_id'] }}    |
+    | [{{ sonarr['cf']['hbo']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#hbo)       | {{ sonarr['cf']['hbo']['trash_scores']['default'] }}  | {{ sonarr['cf']['hbo']['trash_id'] }}    |
+    | [{{ sonarr['cf']['hulu']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#hulu)     | {{ sonarr['cf']['hulu']['trash_scores']['default'] }} | {{ sonarr['cf']['hulu']['trash_id'] }}   |
+    | [{{ sonarr['cf']['it']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#it)         |  {{ sonarr['cf']['it']['trash_scores']['default'] }}  | {{ sonarr['cf']['it']['trash_id'] }}     |
+    | [{{ sonarr['cf']['nlz']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#nlz)       | {{ sonarr['cf']['nlz']['trash_scores']['default'] }}  | {{ sonarr['cf']['nlz']['trash_id'] }}    |
+    | [{{ sonarr['cf']['red']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#red)       | {{ sonarr['cf']['red']['trash_scores']['default'] }}  | {{ sonarr['cf']['red']['trash_id'] }}    |
+    | [{{ sonarr['cf']['sho']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#sho)       | {{ sonarr['cf']['sho']['trash_scores']['default'] }}  | {{ sonarr['cf']['sho']['trash_id'] }}    |
+    | [{{ sonarr['cf']['vdl']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#vdl)       | {{ sonarr['cf']['vdl']['trash_scores']['default'] }}  | {{ sonarr['cf']['vdl']['trash_id'] }}    |
+    | [{{ sonarr['cf']['ovid']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#ovid)     | {{ sonarr['cf']['ovid']['trash_scores']['default'] }} | {{ sonarr['cf']['ovid']['trash_id'] }}   |
+    | [{{ sonarr['cf']['fod']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#fod)       |                           0                           | {{ sonarr['cf']['fod']['trash_id'] }}    |

--- a/includes/cf/sonarr-streaming-services.md
+++ b/includes/cf/sonarr-streaming-services.md
@@ -1,27 +1,27 @@
 ??? abstract "Streaming Services - [Click to show/hide]"
-    | Custom Format                                                                               |                         Score                         | Trash ID                                 |
-    | ------------------------------------------------------------------------------------------- | :---------------------------------------------------: | ---------------------------------------- |
-    | [{{ sonarr['cf']['atvp']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#atvp)     | {{ sonarr['cf']['atvp']['trash_scores']['default'] }} | {{ sonarr['cf']['atvp']['trash_id'] }}   |
-    | [{{ sonarr['cf']['dsnp']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#dsnp)     | {{ sonarr['cf']['dsnp']['trash_scores']['default'] }} | {{ sonarr['cf']['dsnp']['trash_id'] }}   |
-    | [{{ sonarr['cf']['max']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#max)       | {{ sonarr['cf']['max']['trash_scores']['default'] }}  | {{ sonarr['cf']['max']['trash_id'] }}    |
-    | [{{ sonarr['cf']['hmax']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#hmax)     | {{ sonarr['cf']['hmax']['trash_scores']['default'] }} | {{ sonarr['cf']['hmax']['trash_id'] }}   |
-    | [{{ sonarr['cf']['qibi']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#qibi)     | {{ sonarr['cf']['qibi']['trash_scores']['default'] }} | {{ sonarr['cf']['qibi']['trash_id'] }}   |
-    | [{{ sonarr['cf']['amzn']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#amzn)     | {{ sonarr['cf']['amzn']['trash_scores']['default'] }} | {{ sonarr['cf']['amzn']['trash_id'] }}   |
-    | [{{ sonarr['cf']['nf']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#nf)         |  {{ sonarr['cf']['nf']['trash_scores']['default'] }}  | {{ sonarr['cf']['nf']['trash_id'] }}     |
-    | [{{ sonarr['cf']['pcok']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#pcok)     | {{ sonarr['cf']['pcok']['trash_scores']['default'] }} | {{ sonarr['cf']['pcok']['trash_id'] }}   |
-    | [{{ sonarr['cf']['pmtp']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#pmtp)     | {{ sonarr['cf']['pmtp']['trash_scores']['default'] }} | {{ sonarr['cf']['pmtp']['trash_id'] }}   |
-    | [{{ sonarr['cf']['stan']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#stan)     | {{ sonarr['cf']['stan']['trash_scores']['default'] }} | {{ sonarr['cf']['stan']['trash_id'] }}   |
-    | [{{ sonarr['cf']['cc']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#cc)         |  {{ sonarr['cf']['cc']['trash_scores']['default'] }}  | {{ sonarr['cf']['cc']['trash_id'] }}     |
-    | [{{ sonarr['cf']['crav']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#crav)     | {{ sonarr['cf']['crav']['trash_scores']['default'] }} | {{ sonarr['cf']['crav']['trash_id'] }}   |
-    | [{{ sonarr['cf']['dcu']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#dcu)       | {{ sonarr['cf']['dcu']['trash_scores']['default'] }}  | {{ sonarr['cf']['dcu']['trash_id'] }}    |
-    | [{{ sonarr['cf']['hbo']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#hbo)       | {{ sonarr['cf']['hbo']['trash_scores']['default'] }}  | {{ sonarr['cf']['hbo']['trash_id'] }}    |
-    | [{{ sonarr['cf']['hulu']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#hulu)     | {{ sonarr['cf']['hulu']['trash_scores']['default'] }} | {{ sonarr['cf']['hulu']['trash_id'] }}   |
-    | [{{ sonarr['cf']['it']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#it)         |  {{ sonarr['cf']['it']['trash_scores']['default'] }}  | {{ sonarr['cf']['it']['trash_id'] }}     |
-    | [{{ sonarr['cf']['nlz']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#nlz)       | {{ sonarr['cf']['nlz']['trash_scores']['default'] }}  | {{ sonarr['cf']['nlz']['trash_id'] }}    |
-    | [{{ sonarr['cf']['red']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#red)       | {{ sonarr['cf']['red']['trash_scores']['default'] }}  | {{ sonarr['cf']['red']['trash_id'] }}    |
-    | [{{ sonarr['cf']['sho']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#sho)       | {{ sonarr['cf']['sho']['trash_scores']['default'] }}  | {{ sonarr['cf']['sho']['trash_id'] }}    |
-    | [{{ sonarr['cf']['vdl']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#vdl)       | {{ sonarr['cf']['vdl']['trash_scores']['default'] }}  | {{ sonarr['cf']['vdl']['trash_id'] }}    |
-    | [{{ sonarr['cf']['ovid']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#ovid)     | {{ sonarr['cf']['ovid']['trash_scores']['default'] }} | {{ sonarr['cf']['ovid']['trash_id'] }}   |
-    | [{{ sonarr['cf']['fod']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#fod)       |                           0                           | {{ sonarr['cf']['fod']['trash_id'] }}    |
-    | [{{ sonarr['cf']['tver']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#tver)     |                           0                           | {{ sonarr['cf']['tver']['trash_id'] }}   |
-    | [{{ sonarr['cf']['u-next']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#u-next) |                           0                           | {{ sonarr['cf']['u-next']['trash_id'] }} |
+    | Custom Format                                                                               |                         Score                           | Trash ID                                 |
+    | ------------------------------------------------------------------------------------------- | :-----------------------------------------------------: | ---------------------------------------- |
+    | [{{ sonarr['cf']['atvp']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#atvp)     | {{ sonarr['cf']['atvp']['trash_scores']['default'] }}   | {{ sonarr['cf']['atvp']['trash_id'] }}   |
+    | [{{ sonarr['cf']['dsnp']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#dsnp)     | {{ sonarr['cf']['dsnp']['trash_scores']['default'] }}   | {{ sonarr['cf']['dsnp']['trash_id'] }}   |
+    | [{{ sonarr['cf']['max']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#max)       | {{ sonarr['cf']['max']['trash_scores']['default'] }}    | {{ sonarr['cf']['max']['trash_id'] }}    |
+    | [{{ sonarr['cf']['hmax']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#hmax)     | {{ sonarr['cf']['hmax']['trash_scores']['default'] }}   | {{ sonarr['cf']['hmax']['trash_id'] }}   |
+    | [{{ sonarr['cf']['qibi']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#qibi)     | {{ sonarr['cf']['qibi']['trash_scores']['default'] }}   | {{ sonarr['cf']['qibi']['trash_id'] }}   |
+    | [{{ sonarr['cf']['amzn']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#amzn)     | {{ sonarr['cf']['amzn']['trash_scores']['default'] }}   | {{ sonarr['cf']['amzn']['trash_id'] }}   |
+    | [{{ sonarr['cf']['nf']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#nf)         | {{ sonarr['cf']['nf']['trash_scores']['default'] }}     | {{ sonarr['cf']['nf']['trash_id'] }}     |
+    | [{{ sonarr['cf']['pcok']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#pcok)     | {{ sonarr['cf']['pcok']['trash_scores']['default'] }}   | {{ sonarr['cf']['pcok']['trash_id'] }}   |
+    | [{{ sonarr['cf']['pmtp']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#pmtp)     | {{ sonarr['cf']['pmtp']['trash_scores']['default'] }}   | {{ sonarr['cf']['pmtp']['trash_id'] }}   |
+    | [{{ sonarr['cf']['stan']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#stan)     | {{ sonarr['cf']['stan']['trash_scores']['default'] }}   | {{ sonarr['cf']['stan']['trash_id'] }}   |
+    | [{{ sonarr['cf']['cc']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#cc)         | {{ sonarr['cf']['cc']['trash_scores']['default'] }}     | {{ sonarr['cf']['cc']['trash_id'] }}     |
+    | [{{ sonarr['cf']['crav']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#crav)     | {{ sonarr['cf']['crav']['trash_scores']['default'] }}   | {{ sonarr['cf']['crav']['trash_id'] }}   |
+    | [{{ sonarr['cf']['dcu']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#dcu)       | {{ sonarr['cf']['dcu']['trash_scores']['default'] }}    | {{ sonarr['cf']['dcu']['trash_id'] }}    |
+    | [{{ sonarr['cf']['hbo']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#hbo)       | {{ sonarr['cf']['hbo']['trash_scores']['default'] }}    | {{ sonarr['cf']['hbo']['trash_id'] }}    |
+    | [{{ sonarr['cf']['hulu']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#hulu)     | {{ sonarr['cf']['hulu']['trash_scores']['default'] }}   | {{ sonarr['cf']['hulu']['trash_id'] }}   |
+    | [{{ sonarr['cf']['it']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#it)         | {{ sonarr['cf']['it']['trash_scores']['default'] }}     | {{ sonarr['cf']['it']['trash_id'] }}     |
+    | [{{ sonarr['cf']['nlz']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#nlz)       | {{ sonarr['cf']['nlz']['trash_scores']['default'] }}    | {{ sonarr['cf']['nlz']['trash_id'] }}    |
+    | [{{ sonarr['cf']['red']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#red)       | {{ sonarr['cf']['red']['trash_scores']['default'] }}    | {{ sonarr['cf']['red']['trash_id'] }}    |
+    | [{{ sonarr['cf']['sho']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#sho)       | {{ sonarr['cf']['sho']['trash_scores']['default'] }}    | {{ sonarr['cf']['sho']['trash_id'] }}    |
+    | [{{ sonarr['cf']['vdl']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#vdl)       | {{ sonarr['cf']['vdl']['trash_scores']['default'] }}    | {{ sonarr['cf']['vdl']['trash_id'] }}    |
+    | [{{ sonarr['cf']['ovid']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#ovid)     | {{ sonarr['cf']['ovid']['trash_scores']['default'] }}   | {{ sonarr['cf']['ovid']['trash_id'] }}   |
+    | [{{ sonarr['cf']['fod']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#fod)       | {{ sonarr['cf']['fod']['trash_scores']['default'] }}    | {{ sonarr['cf']['fod']['trash_id'] }}    |
+    | [{{ sonarr['cf']['tver']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#tver)     | {{ sonarr['cf']['tver']['trash_scores']['default'] }}   | {{ sonarr['cf']['tver']['trash_id'] }}   |
+    | [{{ sonarr['cf']['u-next']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#u-next) | {{ sonarr['cf']['u-next']['trash_scores']['default'] }} | {{ sonarr['cf']['u-next']['trash_id'] }} |

--- a/includes/cf/sonarr-streaming-services.md
+++ b/includes/cf/sonarr-streaming-services.md
@@ -24,3 +24,4 @@
     | [{{ sonarr['cf']['ovid']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#ovid)     | {{ sonarr['cf']['ovid']['trash_scores']['default'] }} | {{ sonarr['cf']['ovid']['trash_id'] }}   |
     | [{{ sonarr['cf']['fod']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#fod)       |                           0                           | {{ sonarr['cf']['fod']['trash_id'] }}    |
     | [{{ sonarr['cf']['tver']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#tver)     |                           0                           | {{ sonarr['cf']['tver']['trash_id'] }}   |
+    | [{{ sonarr['cf']['u-next']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#u-next) |                           0                           | {{ sonarr['cf']['u-next']['trash_id'] }} |


### PR DESCRIPTION
# Pull Request

## Purpose

- Add the following streaming service to the guides
  - `FOD`
  - `TVer`
  - `U-NEXT`

## Approach

Added: Streaming Service `FOD`, `TVer` and `U-NEXT` with a score of `0`, mainly for the naming scheme

- [x]  Add `FOD`, `TVer` and `U-NEXT` Streaming Service CF to Radarr
- [x]  Added Radarr hashcode for `FOD`, `TVer` and `U-NEXT` Streaming Service CF
- [x]  Provided a link to your regex example of your Radarr Custom Formats
- [x]  Add `FOD`, `TVer` and `U-NEXT` Streaming Service CF to Radarr Collection Table
- [x]  Add `FOD`, `TVer` and `U-NEXT` Streaming Service CF to Radarr Guide Quality Profiles
- [x]  Add new `FOD`, `TVer` and `U-NEXT` Streaming Service CF to Sonarr v4
- [x]  Added Sonarr hashcode for `FOD`, `TVer` and `U-NEXT` Streaming Service CF
- [x]  Provided a link to your regex example of your Sonarr  Custom Formats
- [x]  Add `FOD`, `TVer` and `U-NEXT` Streaming Service CF to Sonarr Collection Table
- [x]  Add `FOD`, `TVer` and `U-NEXT` Streaming Service CF to Sonarr Guide Quality Profiles
- [x]  Test changes in local test setup
- [ ]  **Added Changelog after review and approve**

## Open Questions and Pre-Merge TODOs

- Should the Sonarr v3 release profiles also be updated? In that case, what score would be appropriate?

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).