### PR TITLE
chore(Guide): fix the jdupes repo as per Jody Bruchon’s website

### DIFF
--- a/docs/Hardlinks/Replace-copies-with-hardlinks.md
+++ b/docs/Hardlinks/Replace-copies-with-hardlinks.md
@@ -4,14 +4,14 @@ You recently switched to a proper setup that supports Hardlinks and Instant Move
 
 And you would like to replace copies with hardlinks ?
 
-If your Operating System supports it you could make use of [Jdupes](https://github.com/jbruchon/jdupes).
+If your Operating System supports it you could make use of [Jdupes](https://codeberg.org/jbruchon/jdupes).
 
 ## Usage
 
 !!! info ""
     I won't cover every command :bangbang:
 
-    If you want to know what else [Jdupes](https://github.com/jbruchon/jdupes) can do please read the manual.
+    If you want to know what else [Jdupes](https://codeberg.org/jbruchon/jdupes) can do please read the manual.
 
 !!! tip
     This process can take a long time and a pretty big hit on your resources depending on how big your library is, I did notice the first time it takes longer then the second time. Not sure if this is a cache thing or something else.


### PR DESCRIPTION
# Pull Request

## Purpose

I was browsing the jdupes repo and noticed the repo has moved, the github is now deprecated, see:
https://www.jdupes.com/2023/10/05/news-github-is-out-codeberg-is-in/

## Approach

Github out, codeberg in.

## Open Questions and Pre-Merge TODOs

## Requirements

- [X] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [X] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
