### PR TITLE
fix: :arrow_up: use twemoji from mkdocs material

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .cache
 venv/
 mkdocs-dev-server.bat
+site/
 /docs/Notifiarr/preview.bat
 /docs/Notifiarr/Integrations/_TEMPLATE.md
 /includes/flowcharts/.$radarr-flowchart.drawio.bkp

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -29,7 +29,7 @@ markdown_extensions:
   - pymdownx.critic
   - pymdownx.details
   - pymdownx.emoji:
-      emoji_index: !!python/name:material.extensions.emoji.twemoji 
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
       emoji_generator: !!python/name:material.extensions.emoji.to_svg
   - pymdownx.extra
   - pymdownx.highlight:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -29,8 +29,8 @@ markdown_extensions:
   - pymdownx.critic
   - pymdownx.details
   - pymdownx.emoji:
-      emoji_index: !!python/name:materialx.emoji.twemoji
-      emoji_generator: !!python/name:materialx.emoji.to_svg
+      emoji_index: !!python/name:material.extensions.emoji.twemoji 
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
   - pymdownx.extra
   - pymdownx.highlight:
       guess_lang: true


### PR DESCRIPTION
https://squidfunk.github.io/mkdocs-material/setup/extensions/python-markdown-extensions/?h=twemoji#emoji

Removes deprecation warnings

Also add `site/` to gitignore, which helps when building locally.