### PR TITLE
Add sabnzbd hostname to docker-compose.yml

### DIFF
--- a/includes/docker/docker-compose.yml
+++ b/includes/docker/docker-compose.yml
@@ -50,6 +50,7 @@ services:
       - /data/media:/data/media
   sabnzbd:
     container_name: sabnzbd
+    hostname: sabnzbd
     image: cr.hotio.dev/hotio/sabnzbd:latest
     restart: unless-stopped
     logging:


### PR DESCRIPTION
Sabnzbd won't allow connections from hostnames it doesn't recognise (https://sabnzbd.org/wiki/extra/hostname-check.html). If hostname isn't specified (and "sabnzbd" isn't added to the hostname whitelist), the container sees its own hostname as its docker id and blocks requests from the other containers using container name.

# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer.

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [ ] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
