### PR TITLE
feat(starr): Create SDR (no WEBDL) custom formats

### DIFF
--- a/docs/Radarr/Radarr-collection-of-custom-formats.md
+++ b/docs/Radarr/Radarr-collection-of-custom-formats.md
@@ -1265,7 +1265,7 @@ I also made 3 guides related to this one.
 
 ??? question "SDR (no WEBDL) - [Click to show/hide]"
 
-    - This will prevent grabbing UHD/4k Remux and Bluray encode releases without HDR Formats - i.e., SDR WEB releases will still be allowed.
+    - This will prevent grabbing UHD/4k Remux and Bluray encode releases without HDR Formats - i.e., SDR WEB releases will still be allowed. 4K SDR WEB releases can look better than the 1080p version, owing to improved bitrates.
 
 ??? example "JSON - [Click to show/hide]"
 

--- a/docs/Radarr/Radarr-collection-of-custom-formats.md
+++ b/docs/Radarr/Radarr-collection-of-custom-formats.md
@@ -82,9 +82,10 @@ I also made 3 guides related to this one.
 |                                | [x265 (no HDR/DV)](#x265-no-hdrdv)  | [VOQ](#voq)                   | [FR Scene Groups](#fr-scene-groups)             |
 |                                | [AV1](#av1)                         | [VQ](#vq)                     | [FR LQ](#fr-lq)                                 |
 |                                | [SDR](#sdr)                         | [VFB](#vfb)                   |                                                 |
-|                                | [DV (FEL)](#dv-fel)                 | [VOSTFR](#vostfr)             |                                                 |
-|                                | [Line/Mic Dubbed](#linemic-dubbed)  | [FanSUB](#fansub)             |                                                 |
-|                                | [HFR](#hfr)                         | [FastSUB](#fastsub)           |                                                 |
+|                                | [SDR (no WEBDL)](#sdr-no-webdl)     | [VOSTFR](#vostfr)             |                                                 |
+|                                | [DV (FEL)](#dv-fel)                 | [FanSUB](#fansub)             |                                                 |
+|                                | [Line/Mic Dubbed](#linemic-dubbed)  | [FastSUB](#fastsub)           |                                                 |
+|                                | [HFR](#hfr)                         |                               |                                                 |
 |                                | [VP9](#vp9)                         |                               |                                                 |
 
 ------
@@ -1248,12 +1249,28 @@ I also made 3 guides related to this one.
 
 ??? question "SDR - [Click to show/hide]"
 
-    - This will help to prevent to grab UHD/4k releases without HDR Formats.
+    - This will prevent grabbing UHD/4k releases without HDR Formats.
 
 ??? example "JSON - [Click to show/hide]"
 
     ```json
     [[% filter indent(width=4) %]][[% include 'json/radarr/cf/sdr.json' %]][[% endfilter %]]
+    ```
+
+<sub><sup>[TOP](#index)</sup>
+
+------
+
+### SDR (no WEBDL)
+
+??? question "SDR (no WEBDL) - [Click to show/hide]"
+
+    - This will prevent grabbing UHD/4k Remux and Bluray encode releases without HDR Formats - i.e., SDR WEB releases will still be allowed.
+
+??? example "JSON - [Click to show/hide]"
+
+    ```json
+    [[% filter indent(width=4) %]][[% include 'json/radarr/cf/sdr-no-webdl.json' %]][[% endfilter %]]
     ```
 
 <sub><sup>[TOP](#index)</sup>

--- a/docs/Sonarr/sonarr-collection-of-custom-formats.md
+++ b/docs/Sonarr/sonarr-collection-of-custom-formats.md
@@ -89,9 +89,10 @@ I also made 3 guides related to this one.
 |                                | [x265 (no HDR/DV)](#x265-no-hdrdv)  | [VOQ](#voq)                   | [FR Anime FanSub](#fr-anime-fansub)           |
 |                                | [AV1](#av1)                         | [VQ](#vq)                     | [FR Scene Groups](#fr-scene-groups)           |
 |                                | [SDR](#sdr)                         | [VFB](#vfb)                   | [FR LQ](#fr-lq)                               |
-|                                | [DV (FEL)](#dv-fel)                 | [VOSTFR](#vostfr)             |                                               |
-|                                | [HFR](#hfr)                         | [FanSUB](#fansub)             |                                               |
-|                                | [VP9](#vp9)                         | [FastSUB](#fastsub)           |                                               |
+|                                | [SDR (no WEBDL)](#sdr-no-webdl)     | [VOSTFR](#vostfr)             |                                               |
+|                                | [DV (FEL)](#dv-fel)                 | [FanSUB](#fansub)             |                                               |
+|                                | [HFR](#hfr)                         | [FastSUB](#fastsub)           |                                               |
+|                                | [VP9](#vp9)                         |                               |                                               |
 
 ------
 
@@ -1180,6 +1181,22 @@ I also made 3 guides related to this one.
 
     ```json
     [[% filter indent(width=4) %]][[% include 'json/sonarr/cf/sdr.json' %]][[% endfilter %]]
+    ```
+
+<sub><sup>[TOP](#index)</sup>
+
+------
+
+### SDR (no WEBDL)
+
+??? question "SDR (no WEBDL) - [Click to show/hide]"
+
+    - This will prevent grabbing UHD/4k Remux and Bluray encode releases without HDR Formats - i.e., SDR WEB releases will still be allowed.
+
+??? example "JSON - [Click to show/hide]"
+
+    ```json
+    [[% filter indent(width=4) %]][[% include 'json/sonarr/cf/sdr-no-webdl.json' %]][[% endfilter %]]
     ```
 
 <sub><sup>[TOP](#index)</sup>

--- a/docs/Sonarr/sonarr-collection-of-custom-formats.md
+++ b/docs/Sonarr/sonarr-collection-of-custom-formats.md
@@ -1191,7 +1191,7 @@ I also made 3 guides related to this one.
 
 ??? question "SDR (no WEBDL) - [Click to show/hide]"
 
-    - This will prevent grabbing UHD/4k Remux and Bluray encode releases without HDR Formats - i.e., SDR WEB releases will still be allowed.
+    - This will prevent grabbing UHD/4k Remux and Bluray encode releases without HDR Formats - i.e., SDR WEB releases will still be allowed. 4K SDR WEB releases can look better than the 1080p version, owing to improved bitrates.
 
 ??? example "JSON - [Click to show/hide]"
 

--- a/docs/json/radarr/cf/sdr-no-webdl.json
+++ b/docs/json/radarr/cf/sdr-no-webdl.json
@@ -1,0 +1,56 @@
+{
+  "trash_id": "25c12f78430a3a23413652cbd1d48d77",
+  "trash_score": -10000,
+  "trash_scores": {
+    "default": -10000
+  },
+  "name": "SDR (no WEBDL)",
+  "includeCustomFormatWhenRenaming": false,
+  "specifications": [
+    {
+      "name": "2160p",
+      "implementation": "ResolutionSpecification",
+      "negate": false,
+      "required": true,
+      "fields": {
+        "value": 2160
+      }
+    },
+    {
+      "name": "HDR Formats",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": true,
+      "required": false,
+      "fields": {
+        "value": "\\bHDR(\\b|\\d)|\\b(dv|dovi|dolby[ .]?v(ision)?)\\b|\\b(FraMeSToR|HQMUX|SICFoI)\\b|\\b(PQ)\\b|\\bHLG(\\b|\\d)"
+      }
+    },
+    {
+      "name": "SDR",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\bSDR\\b"
+      }
+    },
+    {
+      "name": "Not WEBDL",
+      "implementation": "SourceSpecification",
+      "negate": true,
+      "required": true,
+      "fields": {
+        "value": 7
+      }
+    },
+    {
+      "name": "Not WEBRIP",
+      "implementation": "SourceSpecification",
+      "negate": true,
+      "required": true,
+      "fields": {
+        "value": 8
+      }
+    }
+  ]
+}

--- a/docs/json/sonarr/cf/sdr-no-webdl.json
+++ b/docs/json/sonarr/cf/sdr-no-webdl.json
@@ -1,0 +1,56 @@
+{
+  "trash_id": "83304f261cf516bb208c18c54c0adf97",
+  "trash_score": -10000,
+  "trash_scores": {
+    "default": -10000
+  },
+  "name": "SDR (no WEBDL)",
+  "includeCustomFormatWhenRenaming": false,
+  "specifications": [
+    {
+      "name": "2160p",
+      "implementation": "ResolutionSpecification",
+      "negate": false,
+      "required": true,
+      "fields": {
+        "value": 2160
+      }
+    },
+    {
+      "name": "HDR Formats",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": true,
+      "required": false,
+      "fields": {
+        "value": "\\bHDR(\\b|\\d)|\\b(dv|dovi|dolby[ .]?v(ision)?)\\b|\\b(FraMeSToR|HQMUX|SICFoI)\\b|\\b(PQ)\\b|\\bHLG(\\b|\\d)"
+      }
+    },
+    {
+      "name": "SDR",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\bSDR\\b"
+      }
+    },
+    {
+      "name": "Not WEBDL",
+      "implementation": "SourceSpecification",
+      "negate": true,
+      "required": true,
+      "fields": {
+        "value": 3
+      }
+    },
+    {
+      "name": "Not WEBRip",
+      "implementation": "SourceSpecification",
+      "negate": true,
+      "required": true,
+      "fields": {
+        "value": 4
+      }
+    }
+  ]
+}


### PR DESCRIPTION


# Pull Request

## Purpose

To create custom formats which allow users to permit 4K SDR WEB releases whilst still blocking 4K SDR Remux/Bluray releases.

## Approach

- [x] Create new SDR (no WEBDL) custom formats for Radarr and Sonarr
- [x] Add new custom formats to the collection of custom formats tables and lists
- [x] Tweak SDR description in custom formats lists

## Open Questions and Pre-Merge TODOs

- [x] Not added to guide profiles at this time, only to the collections of custom formats

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
