### PR TITLE
Remove all `trash_score` properties from CF json files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,7 +73,6 @@ When doing a PR that is in-progress and not yet complete / ready for review or n
 ```json
 {
   "trash_id": "HASHCODE",
-  "trash_score": 50,
   "trash_scores": {
     "default": 50,
     "some_other_profile": 100
@@ -87,10 +86,11 @@ General Structure
 
 - json file name - name of the [json file](#file-naming)
 - `trash_id` - Generated [HashCode](#hashcode) for the Custom Format
-- `trash_score` - (Legacy) [Default Score for the Custom Format](#scoring). Note that Custom Formats with Default Scores of 0 should NOT have a `trash_score`
-- `trash_scores` - (New) Json object of [score(s) for the Custom Format](#scoring). Note that Custom Formats with Default Scores of 0 should NOT have a `trash_scores.default`
+- `trash_scores` - Json object of [score(s) for the Custom Format](#scoring). Note that Custom
+  Formats with Default Scores of 0 should NOT have a `trash_scores.default`
 - `trash_regex` - Link to [regex test cases](#regex-test-cases) for regex
-- STARRJSONEXPORT - The exported custom format created within Starr. Note that this will have a leading `{` that will need to have the `trash` specific regex added after
+- STARRJSONEXPORT - The exported custom format created within Starr. Note that this will have a
+  leading `{` that will need to have the `trash` specific regex added after
 
 ### File Naming
 
@@ -123,11 +123,10 @@ When updating or adding a new CF the test case url (`trash_regex`) needs to be p
 
 ### Scoring
 
-- Scores must be added both as a single value under (legacy) `trash_score` and as JSON objects under `trash_scores`, for example:
+- Scores must be added as JSON objects under `trash_scores`, for example:
 
 ```json
 {
-  "trash_score": 50,
   "trash_scores": {
     "default": 50,
     "some_other_profile": 100
@@ -136,9 +135,7 @@ When updating or adding a new CF the test case url (`trash_regex`) needs to be p
 ```
 
 - This allows for Custom Formats to be assigned different scores for different profiles
-- The `trash_score` value MUST be the same as the `trash_scores.default` value
-- The legacy `trash_score` value is currently retained for compatibility reasons, but will eventually be removed
-- Default Scores of 0 (`trash_score` or `trash_scores.default` are FORBIDDEN
+- Default Scores of 0 (e.g. as in `trash_scores.default`) are FORBIDDEN
 
 ## YAML file naming
 

--- a/docs/json/guide-only/language-not-dutch.json
+++ b/docs/json/guide-only/language-not-dutch.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "guide-only",
-  "trash_score": -10000,
   "trash_scores": {
     "default": -10000
   },

--- a/docs/json/guide-only/language-not-english.json
+++ b/docs/json/guide-only/language-not-english.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "guide-only",
-  "trash_score": -10000,
   "trash_scores": {
     "default": -10000
   },

--- a/docs/json/guide-only/language-not-original-or-german.json
+++ b/docs/json/guide-only/language-not-original-or-german.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "guide-only",
-  "trash_score": -10000,
   "trash_scores": {
     "default": -10000
   },

--- a/docs/json/guide-only/language-not-original.json
+++ b/docs/json/guide-only/language-not-original.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "guide-only",
-  "trash_score": -10000,
   "trash_scores": {
     "default": -10000
   },

--- a/docs/json/guide-only/language-prefer-dutch.json
+++ b/docs/json/guide-only/language-prefer-dutch.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "guide-only",
-  "trash_score": 10,
   "trash_scores": {
     "default": 10
   },

--- a/docs/json/guide-only/language-prefer-german.json
+++ b/docs/json/guide-only/language-prefer-german.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "guide-only",
-  "trash_score": 10,
   "trash_scores": {
     "default": 10
   },

--- a/docs/json/radarr/cf/1080p.json
+++ b/docs/json/radarr/cf/1080p.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "820b09bb9acbfde9c35c71e0e565dad8",
-  "trash_score": 50,
   "trash_scores": {
     "default": 50
   },

--- a/docs/json/radarr/cf/2160p.json
+++ b/docs/json/radarr/cf/2160p.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "fb392fb0d61a010ae38e49ceaa24a1ef",
-  "trash_score": 100,
   "trash_scores": {
     "default": 100,
     "sqp-2": 151,

--- a/docs/json/radarr/cf/3d.json
+++ b/docs/json/radarr/cf/3d.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "b8cd450cbfa689c0259a01d9e29ba3d6",
-  "trash_score": -10000,
   "trash_scores": {
     "default": -10000
   },

--- a/docs/json/radarr/cf/4k-remaster.json
+++ b/docs/json/radarr/cf/4k-remaster.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "eca37840c13c6ef2dd0262b141a5482f",
-  "trash_score": 25,
   "trash_scores": {
     "default": 25
   },

--- a/docs/json/radarr/cf/720p.json
+++ b/docs/json/radarr/cf/720p.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "b2be17d608fc88818940cd1833b0b24c",
-  "trash_score": 5,
   "trash_scores": {
     "default": 5
   },

--- a/docs/json/radarr/cf/aac.json
+++ b/docs/json/radarr/cf/aac.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "240770601cc226190c367ef59aba7463",
-  "trash_score": 1000,
   "trash_scores": {
     "default": 1000,
     "sqp-1-1080p": 0,

--- a/docs/json/radarr/cf/anime-bd-tier-01-top-seadex-muxers.json
+++ b/docs/json/radarr/cf/anime-bd-tier-01-top-seadex-muxers.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "fb3ccc5d5cc8f77c9055d4cb4561dded",
-  "trash_score": 1400,
   "trash_scores": {
     "default": 1400
   },

--- a/docs/json/radarr/cf/anime-bd-tier-02-seadex-muxers.json
+++ b/docs/json/radarr/cf/anime-bd-tier-02-seadex-muxers.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "66926c8fa9312bc74ab71bf69aae4f4a",
-  "trash_score": 1300,
   "trash_scores": {
     "default": 1300
   },

--- a/docs/json/radarr/cf/anime-bd-tier-03-seadex-muxers.json
+++ b/docs/json/radarr/cf/anime-bd-tier-03-seadex-muxers.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "fa857662bad28d5ff21a6e611869a0ff",
-  "trash_score": 1200,
   "trash_scores": {
     "default": 1200
   },

--- a/docs/json/radarr/cf/anime-bd-tier-04-seadex-muxers.json
+++ b/docs/json/radarr/cf/anime-bd-tier-04-seadex-muxers.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "f262f1299d99b1a2263375e8fa2ddbb3",
-  "trash_score": 1100,
   "trash_scores": {
     "default": 1100
   },

--- a/docs/json/radarr/cf/anime-bd-tier-05-remuxes.json
+++ b/docs/json/radarr/cf/anime-bd-tier-05-remuxes.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "ca864ed93c7b431150cc6748dc34875d",
-  "trash_score": 1000,
   "trash_scores": {
     "default": 1000
   },

--- a/docs/json/radarr/cf/anime-bd-tier-06-fansubs.json
+++ b/docs/json/radarr/cf/anime-bd-tier-06-fansubs.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "9dce189b960fddf47891b7484ee886ca",
-  "trash_score": 900,
   "trash_scores": {
     "default": 900
   },

--- a/docs/json/radarr/cf/anime-bd-tier-07-p2pscene.json
+++ b/docs/json/radarr/cf/anime-bd-tier-07-p2pscene.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "1ef101b3a82646b40e0cab7fc92cd896",
-  "trash_score": 800,
   "trash_scores": {
     "default": 800
   },

--- a/docs/json/radarr/cf/anime-bd-tier-08-mini-encodes.json
+++ b/docs/json/radarr/cf/anime-bd-tier-08-mini-encodes.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "6115ccd6640b978234cc47f2c1f2cadc",
-  "trash_score": 700,
   "trash_scores": {
     "default": 700
   },

--- a/docs/json/radarr/cf/anime-lq-groups.json
+++ b/docs/json/radarr/cf/anime-lq-groups.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "b0fdc5897f68c9a68c70c25169f77447",
-  "trash_score": -10000,
   "trash_scores": {
     "default": -10000
   },

--- a/docs/json/radarr/cf/anime-raws.json
+++ b/docs/json/radarr/cf/anime-raws.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "06b6542a47037d1e33b15aa3677c2365",
-  "trash_score": -10000,
   "trash_scores": {
     "default": -10000
   },

--- a/docs/json/radarr/cf/anime-web-tier-01-muxers.json
+++ b/docs/json/radarr/cf/anime-web-tier-01-muxers.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "8167cffba4febfb9a6988ef24f274e7e",
-  "trash_score": 600,
   "trash_scores": {
     "default": 600
   },

--- a/docs/json/radarr/cf/anime-web-tier-02-top-fansubs.json
+++ b/docs/json/radarr/cf/anime-web-tier-02-top-fansubs.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "8526c54e36b4962d340fce52ef030e76",
-  "trash_score": 500,
   "trash_scores": {
     "default": 500
   },

--- a/docs/json/radarr/cf/anime-web-tier-03-official-subs.json
+++ b/docs/json/radarr/cf/anime-web-tier-03-official-subs.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "de41e72708d2c856fa261094c85e965d",
-  "trash_score": 400,
   "trash_scores": {
     "default": 400
   },

--- a/docs/json/radarr/cf/anime-web-tier-04-official-subs.json
+++ b/docs/json/radarr/cf/anime-web-tier-04-official-subs.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "9edaeee9ea3bcd585da9b7c0ac3fc54f",
-  "trash_score": 300,
   "trash_scores": {
     "default": 300
   },

--- a/docs/json/radarr/cf/anime-web-tier-05-fansubs.json
+++ b/docs/json/radarr/cf/anime-web-tier-05-fansubs.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "22d953bbe897857b517928f3652b8dd3",
-  "trash_score": 200,
   "trash_scores": {
     "default": 200
   },

--- a/docs/json/radarr/cf/anime-web-tier-06-fansubs.json
+++ b/docs/json/radarr/cf/anime-web-tier-06-fansubs.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "a786fbc0eae05afe3bb51aee3c83a9d4",
-  "trash_score": 100,
   "trash_scores": {
     "default": 100
   },

--- a/docs/json/radarr/cf/atmos-undefined.json
+++ b/docs/json/radarr/cf/atmos-undefined.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "417804f7f2c4308c1f4c5d380d4c4475",
-  "trash_score": 3000,
   "trash_scores": {
     "default": 3000,
     "sqp-1-1080p": 0,

--- a/docs/json/radarr/cf/bad-dual-groups.json
+++ b/docs/json/radarr/cf/bad-dual-groups.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "b6832f586342ef70d9c128d40c07b872",
-  "trash_score": -10000,
   "trash_scores": {
     "default": -10000,
     "french-multi": 0

--- a/docs/json/radarr/cf/bcore.json
+++ b/docs/json/radarr/cf/bcore.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "cc5e51a9e85a6296ceefe097a77f12f4",
-  "trash_score": 15,
   "trash_scores": {
     "default": 15
   },

--- a/docs/json/radarr/cf/bhdstudio.json
+++ b/docs/json/radarr/cf/bhdstudio.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "5153ec7413d9dae44e24275589b5e944",
-  "trash_score": 1000,
   "trash_scores": {
     "default": 1000
   },

--- a/docs/json/radarr/cf/br-disk.json
+++ b/docs/json/radarr/cf/br-disk.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "ed38b889b31be83fda192888e2286d83",
-  "trash_score": -10000,
   "trash_scores": {
     "default": -10000
   },

--- a/docs/json/radarr/cf/crit.json
+++ b/docs/json/radarr/cf/crit.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "16622a6911d1ab5d5b8b713d5b0036d4",
-  "trash_score": 20,
   "trash_scores": {
     "default": 20
   },

--- a/docs/json/radarr/cf/criterion-collection.json
+++ b/docs/json/radarr/cf/criterion-collection.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "e0c07d59beb37348e975a930d5e50319",
-  "trash_score": 25,
   "trash_scores": {
     "default": 25
   },

--- a/docs/json/radarr/cf/dd.json
+++ b/docs/json/radarr/cf/dd.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "c2998bd0d90ed5621d8df281e839436e",
-  "trash_score": 750,
   "trash_scores": {
     "default": 750,
     "sqp-1-1080p": 115,

--- a/docs/json/radarr/cf/ddplus-atmos.json
+++ b/docs/json/radarr/cf/ddplus-atmos.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "1af239278386be2919e1bcee0bde047e",
-  "trash_score": 3000,
   "trash_scores": {
     "default": 3000,
     "sqp-1-1080p": 135,

--- a/docs/json/radarr/cf/ddplus.json
+++ b/docs/json/radarr/cf/ddplus.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "185f1dd7264c4562b9022d963ac37424",
-  "trash_score": 1750,
   "trash_scores": {
     "default": 1750,
     "sqp-1-1080p": 125,

--- a/docs/json/radarr/cf/dts-es.json
+++ b/docs/json/radarr/cf/dts-es.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "f9f847ac70a0af62ea4a08280b859636",
-  "trash_score": 1500,
   "trash_scores": {
     "default": 1500,
     "sqp-1-1080p": 0,

--- a/docs/json/radarr/cf/dts-hd-hra.json
+++ b/docs/json/radarr/cf/dts-hd-hra.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "8e109e50e0a0b83a5098b056e13bf6db",
-  "trash_score": 2000,
   "trash_scores": {
     "default": 2000,
     "sqp-1-1080p": -10000,

--- a/docs/json/radarr/cf/dts-hd-ma.json
+++ b/docs/json/radarr/cf/dts-hd-ma.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "dcf3ec6938fa32445f590a4da84256cd",
-  "trash_score": 2500,
   "trash_scores": {
     "default": 2500,
     "sqp-1-1080p": -10000,

--- a/docs/json/radarr/cf/dts-x.json
+++ b/docs/json/radarr/cf/dts-x.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "2f22d89048b01681dde8afe203bf2e95",
-  "trash_score": 4500,
   "trash_scores": {
     "default": 4500,
     "sqp-1-1080p": -10000,

--- a/docs/json/radarr/cf/dts.json
+++ b/docs/json/radarr/cf/dts.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "1c1a4c5e823891c75bc50380a6866f73",
-  "trash_score": 1250,
   "trash_scores": {
     "default": 1250,
     "sqp-1-1080p": 0,

--- a/docs/json/radarr/cf/dubs-only.json
+++ b/docs/json/radarr/cf/dubs-only.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "b23eae459cc960816f2d6ba84af45055",
-  "trash_score": -10000,
   "trash_scores": {
     "default": -10000
   },

--- a/docs/json/radarr/cf/dv-fel.json
+++ b/docs/json/radarr/cf/dv-fel.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "f700d29429c023a5734505e77daeaea7",
-  "trash_score": 101,
   "trash_scores": {
     "default": 101
   },

--- a/docs/json/radarr/cf/dv-hdr10.json
+++ b/docs/json/radarr/cf/dv-hdr10.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "e23edd2482476e595fb990b12e7c609c",
-  "trash_score": 1500,
   "trash_scores": {
     "default": 1500
   },

--- a/docs/json/radarr/cf/dv-hlg.json
+++ b/docs/json/radarr/cf/dv-hlg.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "55d53828b9d81cbe20b02efd00aa0efd",
-  "trash_score": 1500,
   "trash_scores": {
     "default": 1500
   },

--- a/docs/json/radarr/cf/dv-sdr.json
+++ b/docs/json/radarr/cf/dv-sdr.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "a3e19f8f627608af0211acd02bf89735",
-  "trash_score": 1500,
   "trash_scores": {
     "default": 1500
   },

--- a/docs/json/radarr/cf/dv-webdl.json
+++ b/docs/json/radarr/cf/dv-webdl.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "923b6abef9b17f937fab56cfcf89e1f1",
-  "trash_score": -10000,
   "trash_scores": {
     "default": -10000
   },

--- a/docs/json/radarr/cf/dv.json
+++ b/docs/json/radarr/cf/dv.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "58d6a88f13e2db7f5059c41047876f00",
-  "trash_score": 1500,
   "trash_scores": {
     "default": 1500
   },

--- a/docs/json/radarr/cf/evo-no-webdl.json
+++ b/docs/json/radarr/cf/evo-no-webdl.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "90cedc1fea7ea5d11298bebd3d1d3223",
-  "trash_score": -10000,
   "trash_scores": {
     "default": -10000
   },

--- a/docs/json/radarr/cf/extras.json
+++ b/docs/json/radarr/cf/extras.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "0a3f082873eb454bde444150b70253cc",
-  "trash_score": -10000,
   "trash_scores": {
     "default": -10000
   },

--- a/docs/json/radarr/cf/fastsub.json
+++ b/docs/json/radarr/cf/fastsub.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "7f9b93f82b7e996391525f2be1d891e0",
-  "trash_score": -10000,
   "trash_scores": {
     "default": -10000
   },

--- a/docs/json/radarr/cf/flac.json
+++ b/docs/json/radarr/cf/flac.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "a570d4a0e56a2874b64e5bfa55202a1b",
-  "trash_score": 2250,
   "trash_scores": {
     "default": 2250,
     "sqp-1-1080p": 0,

--- a/docs/json/radarr/cf/flux.json
+++ b/docs/json/radarr/cf/flux.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "e098247bc6652dd88c76644b275260ed",
-  "trash_score": 51,
   "trash_scores": {
     "default": 51
   },

--- a/docs/json/radarr/cf/framestor.json
+++ b/docs/json/radarr/cf/framestor.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "ff5bc9e8ce91d46c997ca3ac6994d6f8",
-  "trash_score": 101,
   "trash_scores": {
     "default": 101
   },

--- a/docs/json/radarr/cf/freeleech.json
+++ b/docs/json/radarr/cf/freeleech.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "0d91270a7255a1e388fa85e959f359d8",
-  "trash_score": 1,
   "trash_scores": {
     "default": 1
   },

--- a/docs/json/radarr/cf/french-audio.json
+++ b/docs/json/radarr/cf/french-audio.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "6d27683346c78d6a3f772e30877910a7",
-  "trash_score": 1,
   "trash_scores": {
     "default": 1
   },

--- a/docs/json/radarr/cf/french-hd-bluray-tier-01.json
+++ b/docs/json/radarr/cf/french-hd-bluray-tier-01.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "5322da05b19d857acc1e75be3edf47b3",
-  "trash_score": 1800,
   "trash_scores": {
     "default": 1800
   },

--- a/docs/json/radarr/cf/french-hd-bluray-tier-02.json
+++ b/docs/json/radarr/cf/french-hd-bluray-tier-02.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "57f34251344be2e283fc30e00e458be6",
-  "trash_score": 1750,
   "trash_scores": {
     "default": 1750
   },

--- a/docs/json/radarr/cf/french-lq.json
+++ b/docs/json/radarr/cf/french-lq.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "48f031e76111f17ea94898f4cdc34fdc",
-  "trash_score": -10000,
   "trash_scores": {
     "default": -10000
   },

--- a/docs/json/radarr/cf/french-remux-tier-01.json
+++ b/docs/json/radarr/cf/french-remux-tier-01.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "5583260016e0b9f683f53af41fb42e4a",
-  "trash_score": 1950,
   "trash_scores": {
     "default": 1950
   },

--- a/docs/json/radarr/cf/french-remux-tier-02.json
+++ b/docs/json/radarr/cf/french-remux-tier-02.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "9019d81307e68cd4a7eb06a567e833b8",
-  "trash_score": 1900,
   "trash_scores": {
     "default": 1900
   },

--- a/docs/json/radarr/cf/french-scene.json
+++ b/docs/json/radarr/cf/french-scene.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "0d94489c0d5828cd3bf9409d309fb32b",
-  "trash_score": 1500,
   "trash_scores": {
     "default": 1500
   },

--- a/docs/json/radarr/cf/french-uhd-bluray-tier-01.json
+++ b/docs/json/radarr/cf/french-uhd-bluray-tier-01.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "64f8f12bbf7472a6ccf838bfd6b5e3e8",
-  "trash_score": 1800,
   "trash_scores": {
     "default": 1800
   },

--- a/docs/json/radarr/cf/french-uhd-bluray-tier-02.json
+++ b/docs/json/radarr/cf/french-uhd-bluray-tier-02.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "0dcf0c8a386d82e3f2d424189af14065",
-  "trash_score": 1750,
   "trash_scores": {
     "default": 1750
   },

--- a/docs/json/radarr/cf/french-web-tier-01.json
+++ b/docs/json/radarr/cf/french-web-tier-01.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "9790a618cec1aeac8ce75601a17ea40d",
-  "trash_score": 1700,
   "trash_scores": {
     "default": 1700
   },

--- a/docs/json/radarr/cf/french-web-tier-02.json
+++ b/docs/json/radarr/cf/french-web-tier-02.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "3c83a765f84239716bd5fd2d7af188f9",
-  "trash_score": 1650,
   "trash_scores": {
     "default": 1650
   },

--- a/docs/json/radarr/cf/hd-bluray-tier-01.json
+++ b/docs/json/radarr/cf/hd-bluray-tier-01.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "ed27ebfef2f323e964fb1f61391bcb35",
-  "trash_score": 1800,
   "trash_scores": {
     "default": 1800,
     "sqp-1-1080p": 1100,

--- a/docs/json/radarr/cf/hd-bluray-tier-02.json
+++ b/docs/json/radarr/cf/hd-bluray-tier-02.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "c20c8647f2746a1f4c4262b0fbbeeeae",
-  "trash_score": 1750,
   "trash_scores": {
     "default": 1750,
     "sqp-1-1080p": 1050,

--- a/docs/json/radarr/cf/hd-bluray-tier-03.json
+++ b/docs/json/radarr/cf/hd-bluray-tier-03.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "5608c71bcebba0a5e666223bae8c9227",
-  "trash_score": 1700,
   "trash_scores": {
     "default": 1700,
     "sqp-1-1080p": 1000,

--- a/docs/json/radarr/cf/hdr-undefined.json
+++ b/docs/json/radarr/cf/hdr-undefined.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "2a4d9069cc1fe3242ff9bdaebed239bb",
-  "trash_score": 500,
   "trash_scores": {
     "default": 500
   },

--- a/docs/json/radarr/cf/hdr.json
+++ b/docs/json/radarr/cf/hdr.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "e61e28db95d22bedcadf030b8f156d96",
-  "trash_score": 500,
   "trash_scores": {
     "default": 500
   },

--- a/docs/json/radarr/cf/hdr10.json
+++ b/docs/json/radarr/cf/hdr10.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "dfb86d5941bc9075d6af23b09c2aeecd",
-  "trash_score": 500,
   "trash_scores": {
     "default": 500
   },

--- a/docs/json/radarr/cf/hdr10plus-boost.json
+++ b/docs/json/radarr/cf/hdr10plus-boost.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "b17886cb4158d9fea189859409975758",
-  "trash_score": 901,
   "trash_scores": {
     "default": 901
   },

--- a/docs/json/radarr/cf/hdr10plus.json
+++ b/docs/json/radarr/cf/hdr10plus.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "b974a6cd08c1066250f1f177d7aa1225",
-  "trash_score": 600,
   "trash_scores": {
     "default": 600
   },

--- a/docs/json/radarr/cf/hlg.json
+++ b/docs/json/radarr/cf/hlg.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "9364dd386c9b4a1100dde8264690add7",
-  "trash_score": 500,
   "trash_scores": {
     "default": 500
   },

--- a/docs/json/radarr/cf/hybrid.json
+++ b/docs/json/radarr/cf/hybrid.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "0f12c086e289cf966fa5948eac571f44",
-  "trash_score": 100,
   "trash_scores": {
     "default": 100
   },

--- a/docs/json/radarr/cf/imax-enhanced.json
+++ b/docs/json/radarr/cf/imax-enhanced.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "9f6cbff8cfe4ebbc1bde14c7b7bec0de",
-  "trash_score": 800,
   "trash_scores": {
     "default": 800
   },

--- a/docs/json/radarr/cf/imax.json
+++ b/docs/json/radarr/cf/imax.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "eecf3a857724171f968a66cb5719e152",
-  "trash_score": 800,
   "trash_scores": {
     "default": 800
   },

--- a/docs/json/radarr/cf/line-mic-dubbed.json
+++ b/docs/json/radarr/cf/line-mic-dubbed.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "c465ccc73923871b3eb1802042331306",
-  "trash_score": -10000,
   "trash_scores": {
     "default": -10000
   },

--- a/docs/json/radarr/cf/lq.json
+++ b/docs/json/radarr/cf/lq.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "90a6f9a284dff5103f6346090e6280c8",
-  "trash_score": -10000,
   "trash_scores": {
     "default": -10000
   },

--- a/docs/json/radarr/cf/ma.json
+++ b/docs/json/radarr/cf/ma.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "2a6039655313bf5dab1e43523b62c374",
-  "trash_score": 20,
   "trash_scores": {
     "default": 20
   },

--- a/docs/json/radarr/cf/masters-of-cinema.json
+++ b/docs/json/radarr/cf/masters-of-cinema.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "9d27d9d2181838f76dee150882bdc58c",
-  "trash_score": 25,
   "trash_scores": {
     "default": 25
   },

--- a/docs/json/radarr/cf/mp3.json
+++ b/docs/json/radarr/cf/mp3.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "6ba9033150e7896bdc9ec4b44f2b230f",
-  "trash_score": 500,
   "trash_scores": {
     "default": 500
   },

--- a/docs/json/radarr/cf/multi-audio.json
+++ b/docs/json/radarr/cf/multi-audio.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "72b1548df1ac3175ca105a9ce7043c91",
-  "trash_score": 300,
   "trash_scores": {
     "default": 300
   },

--- a/docs/json/radarr/cf/no-rlsgroup.json
+++ b/docs/json/radarr/cf/no-rlsgroup.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "ae9b7c9ebde1f3bd336a8cbd1ec4c5e5",
-  "trash_score": -10000,
   "trash_scores": {
     "default": -10000
   },

--- a/docs/json/radarr/cf/obfuscated.json
+++ b/docs/json/radarr/cf/obfuscated.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "7357cf5161efbf8c4d5d0c30b4815ee2",
-  "trash_score": -10000,
   "trash_scores": {
     "default": -10000
   },

--- a/docs/json/radarr/cf/open-matte.json
+++ b/docs/json/radarr/cf/open-matte.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "09d9dd29a0fc958f9796e65c2a8864b4",
-  "trash_score": 25,
   "trash_scores": {
     "default": 25
   },

--- a/docs/json/radarr/cf/opus.json
+++ b/docs/json/radarr/cf/opus.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "a061e2e700f81932daf888599f8a8273",
-  "trash_score": 250,
   "trash_scores": {
     "default": 250
   },

--- a/docs/json/radarr/cf/pcm.json
+++ b/docs/json/radarr/cf/pcm.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "e7c2fcae07cbada050a0af3357491d7b",
-  "trash_score": 2250,
   "trash_scores": {
     "default": 2250,
     "sqp-1-1080p": 0,

--- a/docs/json/radarr/cf/pq.json
+++ b/docs/json/radarr/cf/pq.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "08d6d8834ad9ec87b1dc7ec8148e7a1f",
-  "trash_score": 500,
   "trash_scores": {
     "default": 500
   },

--- a/docs/json/radarr/cf/remaster.json
+++ b/docs/json/radarr/cf/remaster.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "570bc9ebecd92723d2d21500f4be314c",
-  "trash_score": 25,
   "trash_scores": {
     "default": 25
   },

--- a/docs/json/radarr/cf/remux-tier-01.json
+++ b/docs/json/radarr/cf/remux-tier-01.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "3a3ff47579026e76d6504ebea39390de",
-  "trash_score": 1950,
   "trash_scores": {
     "default": 1950,
     "anime-radarr": 1050

--- a/docs/json/radarr/cf/remux-tier-02.json
+++ b/docs/json/radarr/cf/remux-tier-02.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "9f98181fe5a3fbeb0cc29340da2a468a",
-  "trash_score": 1900,
   "trash_scores": {
     "default": 1900,
     "anime-radarr": 1000

--- a/docs/json/radarr/cf/remux-tier-03.json
+++ b/docs/json/radarr/cf/remux-tier-03.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "8baaf0b3142bf4d94c42a724f034e27a",
-  "trash_score": 1850,
   "trash_scores": {
     "default": 1850,
     "anime-radarr": 950

--- a/docs/json/radarr/cf/repack-proper.json
+++ b/docs/json/radarr/cf/repack-proper.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "e7718d7a3ce595f289bfee26adc178f5",
-  "trash_score": 5,
   "trash_scores": {
     "default": 5
   },

--- a/docs/json/radarr/cf/repack2.json
+++ b/docs/json/radarr/cf/repack2.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "ae43b294509409a6a13919dedd4764c4",
-  "trash_score": 6,
   "trash_scores": {
     "default": 6
   },

--- a/docs/json/radarr/cf/retags.json
+++ b/docs/json/radarr/cf/retags.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "5c44f52a8714fdd79bb4d98e2673be1f",
-  "trash_score": -10000,
   "trash_scores": {
     "default": -10000
   },

--- a/docs/json/radarr/cf/scene.json
+++ b/docs/json/radarr/cf/scene.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "f537cf427b64c38c8e36298f657e4828",
-  "trash_score": -10000,
   "trash_scores": {
     "default": -10000
   },

--- a/docs/json/radarr/cf/sdr-no-webdl.json
+++ b/docs/json/radarr/cf/sdr-no-webdl.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "25c12f78430a3a23413652cbd1d48d77",
-  "trash_score": -10000,
   "trash_scores": {
     "default": -10000
   },

--- a/docs/json/radarr/cf/sdr.json
+++ b/docs/json/radarr/cf/sdr.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "9c38ebb7384dada637be8899efa68e6f",
-  "trash_score": -10000,
   "trash_scores": {
     "default": -10000
   },

--- a/docs/json/radarr/cf/sic.json
+++ b/docs/json/radarr/cf/sic.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "8cd3ac70db7ac318cf9a0e01333940a4",
-  "trash_score": 51,
   "trash_scores": {
     "default": 51
   },

--- a/docs/json/radarr/cf/special-edition.json
+++ b/docs/json/radarr/cf/special-edition.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "957d0f44b592285f26449575e8b1167e",
-  "trash_score": 125,
   "trash_scores": {
     "default": 125
   },

--- a/docs/json/radarr/cf/truehd-atmos.json
+++ b/docs/json/radarr/cf/truehd-atmos.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "496f355514737f7d83bf7aa4d24f8169",
-  "trash_score": 5000,
   "trash_scores": {
     "default": 5000,
     "sqp-1-1080p": -10000,

--- a/docs/json/radarr/cf/truehd.json
+++ b/docs/json/radarr/cf/truehd.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "3cafb66171b47f226146a0770576870f",
-  "trash_score": 2750,
   "trash_scores": {
     "default": 2750,
     "sqp-1-1080p": -10000,

--- a/docs/json/radarr/cf/uhd-bluray-tier-01.json
+++ b/docs/json/radarr/cf/uhd-bluray-tier-01.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "4d74ac4c4db0b64bff6ce0cffef99bf0",
-  "trash_score": 1800,
   "trash_scores": {
     "default": 1800,
     "sqp-1-2160p": 1100,

--- a/docs/json/radarr/cf/uhd-bluray-tier-02.json
+++ b/docs/json/radarr/cf/uhd-bluray-tier-02.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "a58f517a70193f8e578056642178419d",
-  "trash_score": 1750,
   "trash_scores": {
     "default": 1750,
     "sqp-1-2160p": 1050,

--- a/docs/json/radarr/cf/uhd-bluray-tier-03.json
+++ b/docs/json/radarr/cf/uhd-bluray-tier-03.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "e71939fae578037e7aed3ee219bbe7c1",
-  "trash_score": 1700,
   "trash_scores": {
     "default": 1700,
     "sqp-1-2160p": 1000,

--- a/docs/json/radarr/cf/upscaled.json
+++ b/docs/json/radarr/cf/upscaled.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "bfd8eb01832d646a0a89c4deb46f8564",
-  "trash_score": -10000,
   "trash_scores": {
     "default": -10000
   },

--- a/docs/json/radarr/cf/v0.json
+++ b/docs/json/radarr/cf/v0.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "c259005cbaeb5ab44c06eddb4751e70c",
-  "trash_score": -51,
   "trash_scores": {
     "default": -51
   },

--- a/docs/json/radarr/cf/v1.json
+++ b/docs/json/radarr/cf/v1.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "5f400539421b8fcf71d51e6384434573",
-  "trash_score": 1,
   "trash_scores": {
     "default": 1
   },

--- a/docs/json/radarr/cf/v2.json
+++ b/docs/json/radarr/cf/v2.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "3df5e6dfef4b09bb6002f732bed5b774",
-  "trash_score": 2,
   "trash_scores": {
     "default": 2
   },

--- a/docs/json/radarr/cf/v3.json
+++ b/docs/json/radarr/cf/v3.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "db92c27ba606996b146b57fbe6d09186",
-  "trash_score": 3,
   "trash_scores": {
     "default": 3
   },

--- a/docs/json/radarr/cf/v4.json
+++ b/docs/json/radarr/cf/v4.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "d4e5e842fad129a3c097bdb2d20d31a0",
-  "trash_score": 4,
   "trash_scores": {
     "default": 4
   },

--- a/docs/json/radarr/cf/vinegar-syndrome.json
+++ b/docs/json/radarr/cf/vinegar-syndrome.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "db9b4c4b53d312a3ca5f1378f6440fc9",
-  "trash_score": 25,
   "trash_scores": {
     "default": 25
   },

--- a/docs/json/radarr/cf/vrv.json
+++ b/docs/json/radarr/cf/vrv.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "60f6d50cbd3cfc3e9a8c00e3a30c3114",
-  "trash_score": 10,
   "trash_scores": {
     "default": 10
   },
@@ -36,4 +35,3 @@
     }
   ]
 }
-

--- a/docs/json/radarr/cf/web-tier-01.json
+++ b/docs/json/radarr/cf/web-tier-01.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "c20f169ef63c5f40c2def54abaf4438e",
-  "trash_score": 1700,
   "trash_scores": {
     "default": 1700,
     "anime-radarr": 350

--- a/docs/json/radarr/cf/web-tier-02.json
+++ b/docs/json/radarr/cf/web-tier-02.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "403816d65392c79236dcb6dd591aeda4",
-  "trash_score": 1650,
   "trash_scores": {
     "default": 1650,
     "anime-radarr": 250

--- a/docs/json/radarr/cf/web-tier-03.json
+++ b/docs/json/radarr/cf/web-tier-03.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "af94e0fe497124d1f9ce732069ec8c3b",
-  "trash_score": 1600,
   "trash_scores": {
     "default": 1600,
     "anime-radarr": 150

--- a/docs/json/radarr/cf/x265-hd.json
+++ b/docs/json/radarr/cf/x265-hd.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "dc98083864ea246d05a42df0d05f81cc",
-  "trash_score": -10000,
   "trash_scores": {
     "default": -10000
   },

--- a/docs/json/radarr/cf/x265-no-hdrdv.json
+++ b/docs/json/radarr/cf/x265-no-hdrdv.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "839bea857ed2c0a8e084f3cbdbd65ecb",
-  "trash_score": -10000,
   "trash_scores": {
     "default": -10000
   },

--- a/docs/json/sonarr/cf/1080p.json
+++ b/docs/json/sonarr/cf/1080p.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "290078c8b266272a5cc8e251b5e2eb0b",
-  "trash_score": 50,
   "trash_scores": {
     "default": 50
   },

--- a/docs/json/sonarr/cf/2160p.json
+++ b/docs/json/sonarr/cf/2160p.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "1bef6c151fa35093015b0bfef18279e5",
-  "trash_score": 100,
   "trash_scores": {
     "default": 100
   },

--- a/docs/json/sonarr/cf/aac.json
+++ b/docs/json/sonarr/cf/aac.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "a50b8a0c62274a7c38b09a9619ba9d86",
-  "trash_score": 1000,
   "trash_scores": {
     "default": 1000
   },

--- a/docs/json/sonarr/cf/amzn.json
+++ b/docs/json/sonarr/cf/amzn.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "d660701077794679fd59e8bdf4ce3a29",
-  "trash_score": 70,
   "trash_scores": {
     "default": 70,
     "anime-sonarr": 3

--- a/docs/json/sonarr/cf/anime-bd-tier-01-top-seadex-muxers.json
+++ b/docs/json/sonarr/cf/anime-bd-tier-01-top-seadex-muxers.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "949c16fe0a8147f50ba82cc2df9411c9",
-  "trash_score": 1400,
   "trash_scores": {
     "default": 1400
   },

--- a/docs/json/sonarr/cf/anime-bd-tier-02-seadex-muxers.json
+++ b/docs/json/sonarr/cf/anime-bd-tier-02-seadex-muxers.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "ed7f1e315e000aef424a58517fa48727",
-  "trash_score": 1300,
   "trash_scores": {
     "default": 1300
   },

--- a/docs/json/sonarr/cf/anime-bd-tier-03-seadex-muxers.json
+++ b/docs/json/sonarr/cf/anime-bd-tier-03-seadex-muxers.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "096e406c92baa713da4a72d88030b815",
-  "trash_score": 1200,
   "trash_scores": {
     "default": 1200
   },

--- a/docs/json/sonarr/cf/anime-bd-tier-04-seadex-muxers.json
+++ b/docs/json/sonarr/cf/anime-bd-tier-04-seadex-muxers.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "30feba9da3030c5ed1e0f7d610bcadc4",
-  "trash_score": 1100,
   "trash_scores": {
     "default": 1100
   },

--- a/docs/json/sonarr/cf/anime-bd-tier-05-remuxes.json
+++ b/docs/json/sonarr/cf/anime-bd-tier-05-remuxes.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "545a76b14ddc349b8b185a6344e28b04",
-  "trash_score": 1000,
   "trash_scores": {
     "default": 1000
   },

--- a/docs/json/sonarr/cf/anime-bd-tier-06-fansubs.json
+++ b/docs/json/sonarr/cf/anime-bd-tier-06-fansubs.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "25d2afecab632b1582eaf03b63055f72",
-  "trash_score": 900,
   "trash_scores": {
     "default": 900
   },

--- a/docs/json/sonarr/cf/anime-bd-tier-07-p2pscene.json
+++ b/docs/json/sonarr/cf/anime-bd-tier-07-p2pscene.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "0329044e3d9137b08502a9f84a7e58db",
-  "trash_score": 800,
   "trash_scores": {
     "default": 800
   },

--- a/docs/json/sonarr/cf/anime-bd-tier-08-mini-encodes.json
+++ b/docs/json/sonarr/cf/anime-bd-tier-08-mini-encodes.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "c81bbfb47fed3d5a3ad027d077f889de",
-  "trash_score": 700,
   "trash_scores": {
     "default": 700
   },

--- a/docs/json/sonarr/cf/anime-lq-groups.json
+++ b/docs/json/sonarr/cf/anime-lq-groups.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "e3515e519f3b1360cbfc17651944354c",
-  "trash_score": -10000,
   "trash_scores": {
     "default": -10000
   },

--- a/docs/json/sonarr/cf/anime-raws.json
+++ b/docs/json/sonarr/cf/anime-raws.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "b4a1b3d705159cdca36d71e57ca86871",
-  "trash_score": -10000,
   "trash_scores": {
     "default": -10000
   },

--- a/docs/json/sonarr/cf/anime-web-tier-01-muxers.json
+++ b/docs/json/sonarr/cf/anime-web-tier-01-muxers.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "e0014372773c8f0e1bef8824f00c7dc4",
-  "trash_score": 600,
   "trash_scores": {
     "default": 600
   },

--- a/docs/json/sonarr/cf/anime-web-tier-02-top-fansubs.json
+++ b/docs/json/sonarr/cf/anime-web-tier-02-top-fansubs.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "19180499de5ef2b84b6ec59aae444696",
-  "trash_score": 500,
   "trash_scores": {
     "default": 500
   },

--- a/docs/json/sonarr/cf/anime-web-tier-03-official-subs.json
+++ b/docs/json/sonarr/cf/anime-web-tier-03-official-subs.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "c27f2ae6a4e82373b0f1da094e2489ad",
-  "trash_score": 400,
   "trash_scores": {
     "default": 400
   },

--- a/docs/json/sonarr/cf/anime-web-tier-04-official-subs.json
+++ b/docs/json/sonarr/cf/anime-web-tier-04-official-subs.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "4fd5528a3a8024e6b49f9c67053ea5f3",
-  "trash_score": 300,
   "trash_scores": {
     "default": 300
   },

--- a/docs/json/sonarr/cf/anime-web-tier-05-fansubs.json
+++ b/docs/json/sonarr/cf/anime-web-tier-05-fansubs.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "29c2a13d091144f63307e4a8ce963a39",
-  "trash_score": 200,
   "trash_scores": {
     "default": 200
   },

--- a/docs/json/sonarr/cf/anime-web-tier-06-fansubs.json
+++ b/docs/json/sonarr/cf/anime-web-tier-06-fansubs.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "dc262f88d74c651b12e9d90b39f6c753",
-  "trash_score": 100,
   "trash_scores": {
     "default": 100
   },

--- a/docs/json/sonarr/cf/atmos-undefined.json
+++ b/docs/json/sonarr/cf/atmos-undefined.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "b6fbafa7942952a13e17e2b1152b539a",
-  "trash_score": 3000,
   "trash_scores": {
     "default": 3000
   },

--- a/docs/json/sonarr/cf/atvp.json
+++ b/docs/json/sonarr/cf/atvp.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "f67c9ca88f463a48346062e8ad07713f",
-  "trash_score": 100,
   "trash_scores": {
     "default": 100
   },

--- a/docs/json/sonarr/cf/bad-dual-groups.json
+++ b/docs/json/sonarr/cf/bad-dual-groups.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "32b367365729d530ca1c124a0b180c64",
-  "trash_score": -10000,
   "trash_scores": {
     "default": -10000,
     "french-multi": 0

--- a/docs/json/sonarr/cf/br-disk-btn.json
+++ b/docs/json/sonarr/cf/br-disk-btn.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "6f808933a71bd9666531610cb8c059cc",
-  "trash_score": -10000,
   "trash_scores": {
     "default": -10000
   },
@@ -19,4 +18,3 @@
     }
   ]
 }
-

--- a/docs/json/sonarr/cf/br-disk.json
+++ b/docs/json/sonarr/cf/br-disk.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "85c61753df5da1fb2aab6f2a47426b09",
-  "trash_score": -10000,
   "trash_scores": {
     "default": -10000
   },

--- a/docs/json/sonarr/cf/cc.json
+++ b/docs/json/sonarr/cf/cc.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "77a7b25585c18af08f60b1547bb9b4fb",
-  "trash_score": 50,
   "trash_scores": {
     "default": 50
   },

--- a/docs/json/sonarr/cf/cr.json
+++ b/docs/json/sonarr/cf/cr.json
@@ -1,6 +1,5 @@
 {
     "trash_id": "3e0b26604165f463f3e8e192261e7284",
-  "trash_score": 6,
   "trash_scores": {
     "default": 6
   },

--- a/docs/json/sonarr/cf/crav.json
+++ b/docs/json/sonarr/cf/crav.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "4e9a630db98d5391aec1368a0256e2fe",
-  "trash_score": 50,
   "trash_scores": {
     "default": 50
   },

--- a/docs/json/sonarr/cf/dcu.json
+++ b/docs/json/sonarr/cf/dcu.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "36b72f59f4ea20aad9316f475f2d9fbb",
-  "trash_score": 50,
   "trash_scores": {
     "default": 50
   },

--- a/docs/json/sonarr/cf/dd.json
+++ b/docs/json/sonarr/cf/dd.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "dbe00161b08a25ac6154c55f95e6318d",
-  "trash_score": 750,
   "trash_scores": {
     "default": 750
   },

--- a/docs/json/sonarr/cf/ddplus-atmos.json
+++ b/docs/json/sonarr/cf/ddplus-atmos.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "4232a509ce60c4e208d13825b7c06264",
-  "trash_score": 3000,
   "trash_scores": {
     "default": 3000
   },

--- a/docs/json/sonarr/cf/ddplus.json
+++ b/docs/json/sonarr/cf/ddplus.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "63487786a8b01b7f20dd2bc90dd4a477",
-  "trash_score": 1750,
   "trash_scores": {
     "default": 1750
   },

--- a/docs/json/sonarr/cf/dsnp.json
+++ b/docs/json/sonarr/cf/dsnp.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "89358767a60cc28783cdc3d0be9388a4",
-  "trash_score": 100,
   "trash_scores": {
     "default": 100,
     "anime-sonarr": 5

--- a/docs/json/sonarr/cf/dts-es.json
+++ b/docs/json/sonarr/cf/dts-es.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "c1a25cd67b5d2e08287c957b1eb903ec",
-  "trash_score": 1500,
   "trash_scores": {
     "default": 1500
   },

--- a/docs/json/sonarr/cf/dts-hd-hra.json
+++ b/docs/json/sonarr/cf/dts-hd-hra.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "cfa5fbd8f02a86fc55d8d223d06a5e1f",
-  "trash_score": 2000,
   "trash_scores": {
     "default": 2000
   },

--- a/docs/json/sonarr/cf/dts-hd-ma.json
+++ b/docs/json/sonarr/cf/dts-hd-ma.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "c429417a57ea8c41d57e6990a8b0033f",
-  "trash_score": 2500,
   "trash_scores": {
     "default": 2500
   },

--- a/docs/json/sonarr/cf/dts-x.json
+++ b/docs/json/sonarr/cf/dts-x.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "9d00418ba386a083fbf4d58235fc37ef",
-  "trash_score": 4500,
   "trash_scores": {
     "default": 4500
   },

--- a/docs/json/sonarr/cf/dts.json
+++ b/docs/json/sonarr/cf/dts.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "5964f2a8b3be407d083498e4459d05d0",
-  "trash_score": 1250,
   "trash_scores": {
     "default": 1250
   },

--- a/docs/json/sonarr/cf/dubs-only.json
+++ b/docs/json/sonarr/cf/dubs-only.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "9c14d194486c4014d422adc64092d794",
-  "trash_score": -10000,
   "trash_scores": {
     "default": -10000
   },

--- a/docs/json/sonarr/cf/dv-fel.json
+++ b/docs/json/sonarr/cf/dv-fel.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "ef4963043b0987f8485bc9106f16db38",
-  "trash_score": 101,
   "trash_scores": {
     "default": 101
   },

--- a/docs/json/sonarr/cf/dv-hdr10.json
+++ b/docs/json/sonarr/cf/dv-hdr10.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "7878c33f1963fefb3d6c8657d46c2f0a",
-  "trash_score": 1500,
   "trash_scores": {
     "default": 1500
   },

--- a/docs/json/sonarr/cf/dv-hlg.json
+++ b/docs/json/sonarr/cf/dv-hlg.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "1f733af03141f068a540eec352589a89",
-  "trash_score": 1500,
   "trash_scores": {
     "default": 1500
   },

--- a/docs/json/sonarr/cf/dv-sdr.json
+++ b/docs/json/sonarr/cf/dv-sdr.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "27954b0a80aab882522a88a4d9eae1cd",
-  "trash_score": 1500,
   "trash_scores": {
     "default": 1500
   },

--- a/docs/json/sonarr/cf/dv-webdl.json
+++ b/docs/json/sonarr/cf/dv-webdl.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "9b27ab6498ec0f31a3353992e19434ca",
-  "trash_score": -10000,
   "trash_scores": {
     "default": -10000
   },

--- a/docs/json/sonarr/cf/dv.json
+++ b/docs/json/sonarr/cf/dv.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "6d0d8de7b57e35518ac0308b0ddf404e",
-  "trash_score": 1500,
   "trash_scores": {
     "default": 1500
   },

--- a/docs/json/sonarr/cf/extras.json
+++ b/docs/json/sonarr/cf/extras.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "fbcb31d8dabd2a319072b84fc0b7249c",
-  "trash_score": -10000,
   "trash_scores": {
     "default": -10000
   },

--- a/docs/json/sonarr/cf/fastsub.json
+++ b/docs/json/sonarr/cf/fastsub.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "ea0bb4b6ba388992fad1092703b5ff7b",
-  "trash_score": -10000,
   "trash_scores": {
     "default": -10000
   },

--- a/docs/json/sonarr/cf/flac.json
+++ b/docs/json/sonarr/cf/flac.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "851bd64e04c9374c51102be3dd9ae4cc",
-  "trash_score": 2250,
   "trash_scores": {
     "default": 2250
   },

--- a/docs/json/sonarr/cf/flux.json
+++ b/docs/json/sonarr/cf/flux.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "5d9fd1b1e06cd8a475462f40214b7df6",
-  "trash_score": 51,
   "trash_scores": {
     "default": 51
   },

--- a/docs/json/sonarr/cf/french-adn.json
+++ b/docs/json/sonarr/cf/french-adn.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "d54cd2bf1326287275b56bccedb72ee2",
-  "trash_score": 3,
   "trash_scores": {
     "default": 3,
     "anime-sonarr": 1

--- a/docs/json/sonarr/cf/french-anime-fansub.json
+++ b/docs/json/sonarr/cf/french-anime-fansub.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "44b6c964dad997577d793fd004a39224",
-  "trash_score": 1400,
   "trash_scores": {
     "default": 1400
   },

--- a/docs/json/sonarr/cf/french-anime-tier-01.json
+++ b/docs/json/sonarr/cf/french-anime-tier-01.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "db13a377f7afb29975ea39470434d2ef",
-  "trash_score": 1650,
   "trash_scores": {
     "default": 1650
   },

--- a/docs/json/sonarr/cf/french-anime-tier-02.json
+++ b/docs/json/sonarr/cf/french-anime-tier-02.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "4e6134a384dbc0ef166234cc0e45d26d",
-  "trash_score": 1600,
   "trash_scores": {
     "default": 1600
   },

--- a/docs/json/sonarr/cf/french-anime-tier-03.json
+++ b/docs/json/sonarr/cf/french-anime-tier-03.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "db34d4357937fbfe89b63ba095f22155",
-  "trash_score": 1550,
   "trash_scores": {
     "default": 1550
   },

--- a/docs/json/sonarr/cf/french-audio.json
+++ b/docs/json/sonarr/cf/french-audio.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "4721382d9ee05f1b4967a25e75072911",
-  "trash_score": 1,
   "trash_scores": {
     "default": 1
   },

--- a/docs/json/sonarr/cf/french-hd-bluray-tier-01.json
+++ b/docs/json/sonarr/cf/french-hd-bluray-tier-01.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "d844321db5e126d2e7e46152f0706532",
-  "trash_score": 1800,
   "trash_scores": {
     "default": 1800,
     "french-anime": 1150

--- a/docs/json/sonarr/cf/french-lq.json
+++ b/docs/json/sonarr/cf/french-lq.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "3ba797e5dc13af4b8d9bb25e83d90de2",
-  "trash_score": -10000,
   "trash_scores": {
     "default": -10000
   },

--- a/docs/json/sonarr/cf/french-remux-tier-01.json
+++ b/docs/json/sonarr/cf/french-remux-tier-01.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "b8e91cc8fb2bd96468fab74730c30d18",
-  "trash_score": 1900,
   "trash_scores": {
     "default": 1900
   },

--- a/docs/json/sonarr/cf/french-scene.json
+++ b/docs/json/sonarr/cf/french-scene.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "2f3422339d185eb227a324644a2fbfca",
-  "trash_score": 1500,
   "trash_scores": {
     "default": 1500
   },

--- a/docs/json/sonarr/cf/french-web-tier-01.json
+++ b/docs/json/sonarr/cf/french-web-tier-01.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "ddb8eaa9c85a549c50034d280539d54d",
-  "trash_score": 1700,
   "trash_scores": {
     "default": 1700,
     "french-anime": 1100

--- a/docs/json/sonarr/cf/french-web-tier-02.json
+++ b/docs/json/sonarr/cf/french-web-tier-02.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "a4c51febd4d8b2a0db10a3c974f21d92",
-  "trash_score": 1650,
   "trash_scores": {
     "default": 1650,
     "french-anime": 1100

--- a/docs/json/sonarr/cf/french-web-tier-03.json
+++ b/docs/json/sonarr/cf/french-web-tier-03.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "dbfc0a4b5cb4cbd693311c4482ae9683",
-  "trash_score": 1600,
   "trash_scores": {
     "default": 1600,
     "french-anime": 1100

--- a/docs/json/sonarr/cf/funi.json
+++ b/docs/json/sonarr/cf/funi.json
@@ -1,6 +1,5 @@
 {
     "trash_id": "1284d18e693de8efe0fe7d6b3e0b9170",
-  "trash_score": 2,
   "trash_scores": {
     "default": 2
   },

--- a/docs/json/sonarr/cf/hbo.json
+++ b/docs/json/sonarr/cf/hbo.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "7a235133c87f7da4c8cccceca7e3c7a6",
-  "trash_score": 50,
   "trash_scores": {
     "default": 50
   },

--- a/docs/json/sonarr/cf/hd-bluray-tier-01.json
+++ b/docs/json/sonarr/cf/hd-bluray-tier-01.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "d6819cba26b1a6508138d25fb5e32293",
-  "trash_score": 1800,
   "trash_scores": {
     "default": 1800
   },

--- a/docs/json/sonarr/cf/hd-bluray-tier-02.json
+++ b/docs/json/sonarr/cf/hd-bluray-tier-02.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "c2216b7b8aa545dc1ce8388c618f8d57",
-  "trash_score": 1750,
   "trash_scores": {
     "default": 1750
   },

--- a/docs/json/sonarr/cf/hdr-undefined.json
+++ b/docs/json/sonarr/cf/hdr-undefined.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "bb019e1cd00f304f80971c965de064dc",
-  "trash_score": 500,
   "trash_scores": {
     "default": 500
   },

--- a/docs/json/sonarr/cf/hdr.json
+++ b/docs/json/sonarr/cf/hdr.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "3e2c4e748b64a1a1118e0ea3f4cf6875",
-  "trash_score": 500,
   "trash_scores": {
     "default": 500
   },

--- a/docs/json/sonarr/cf/hdr10.json
+++ b/docs/json/sonarr/cf/hdr10.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "3497799d29a085e2ac2df9d468413c94",
-  "trash_score": 500,
   "trash_scores": {
     "default": 500
   },

--- a/docs/json/sonarr/cf/hdr10plus-boost.json
+++ b/docs/json/sonarr/cf/hdr10plus-boost.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "0dad0a507451acddd754fe6dc3a7f5e7",
-  "trash_score": 901,
   "trash_scores": {
     "default": 901
   },

--- a/docs/json/sonarr/cf/hdr10plus.json
+++ b/docs/json/sonarr/cf/hdr10plus.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "a3d82cbef5039f8d295478d28a887159",
-  "trash_score": 600,
   "trash_scores": {
     "default": 600
   },

--- a/docs/json/sonarr/cf/hlg.json
+++ b/docs/json/sonarr/cf/hlg.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "17e889ce13117940092308f48b48b45b",
-  "trash_score": 500,
   "trash_scores": {
     "default": 500
   },

--- a/docs/json/sonarr/cf/hmax.json
+++ b/docs/json/sonarr/cf/hmax.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "a880d6abc21e7c16884f3ae393f84179",
-  "trash_score": 80,
   "trash_scores": {
     "default": 80
   },

--- a/docs/json/sonarr/cf/hulu.json
+++ b/docs/json/sonarr/cf/hulu.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "f6cce30f1733d5c8194222a7507909bb",
-  "trash_score": 50,
   "trash_scores": {
     "default": 50
   },

--- a/docs/json/sonarr/cf/hybrid.json
+++ b/docs/json/sonarr/cf/hybrid.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "3a4127d8aa781b44120d907f2cd62627",
-  "trash_score": 100,
   "trash_scores": {
     "default": 100
   },

--- a/docs/json/sonarr/cf/it.json
+++ b/docs/json/sonarr/cf/it.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "0ac24a2a68a9700bcb7eeca8e5cd644c",
-  "trash_score": 50,
   "trash_scores": {
     "default": 50
   },

--- a/docs/json/sonarr/cf/lq.json
+++ b/docs/json/sonarr/cf/lq.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "9c11cd3f07101cdba90a2d81cf0e56b4",
-  "trash_score": -10000,
   "trash_scores": {
     "default": -10000
   },

--- a/docs/json/sonarr/cf/max.json
+++ b/docs/json/sonarr/cf/max.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "81d1fbf600e2540cee87f3a23f9d3c1c",
-  "trash_score": 90,
   "trash_scores": {
     "default": 90
   },

--- a/docs/json/sonarr/cf/mp3.json
+++ b/docs/json/sonarr/cf/mp3.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "3e8b714263b26f486972ee1e0fe7606c",
-  "trash_score": 500,
   "trash_scores": {
     "default": 500
   },

--- a/docs/json/sonarr/cf/multi-audio.json
+++ b/docs/json/sonarr/cf/multi-audio.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "2f6e84efc47246ec9071e311e71c4953",
-  "trash_score": 300,
   "trash_scores": {
     "default": 300
   },

--- a/docs/json/sonarr/cf/nf.json
+++ b/docs/json/sonarr/cf/nf.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "d34870697c9db575f17700212167be23",
-  "trash_score": 60,
   "trash_scores": {
     "default": 60,
     "anime-sonarr": 4

--- a/docs/json/sonarr/cf/nlz.json
+++ b/docs/json/sonarr/cf/nlz.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "b2b980877494b560443631eb1f473867",
-  "trash_score": 50,
   "trash_scores": {
     "default": 50
   },

--- a/docs/json/sonarr/cf/no-rlsgroup.json
+++ b/docs/json/sonarr/cf/no-rlsgroup.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "82d40da2bc6923f41e14394075dd4b03",
-  "trash_score": -10000,
   "trash_scores": {
     "default": -10000
   },

--- a/docs/json/sonarr/cf/obfuscated.json
+++ b/docs/json/sonarr/cf/obfuscated.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "e1a997ddb54e3ecbfe06341ad323c458",
-  "trash_score": -10000,
   "trash_scores": {
     "default": -10000
   },

--- a/docs/json/sonarr/cf/opus.json
+++ b/docs/json/sonarr/cf/opus.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "28f6ef16d61e2d1adfce3156ed8257e3",
-  "trash_score": 250,
   "trash_scores": {
     "default": 250
   },

--- a/docs/json/sonarr/cf/ovid.json
+++ b/docs/json/sonarr/cf/ovid.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "fb1a91cdc0f26f7ca0696e0e95274645",
-  "trash_score": 50,
   "trash_scores": {
     "default": 50
   },

--- a/docs/json/sonarr/cf/pcm.json
+++ b/docs/json/sonarr/cf/pcm.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "30f70576671ca933adbdcfc736a69718",
-  "trash_score": 2250,
   "trash_scores": {
     "default": 2250
   },

--- a/docs/json/sonarr/cf/pcok.json
+++ b/docs/json/sonarr/cf/pcok.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "1656adc6d7bb2c8cca6acfb6592db421",
-  "trash_score": 60,
   "trash_scores": {
     "default": 60
   },

--- a/docs/json/sonarr/cf/pmtp.json
+++ b/docs/json/sonarr/cf/pmtp.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "c67a75ae4a1715f2bb4d492755ba4195",
-  "trash_score": 60,
   "trash_scores": {
     "default": 60
   },

--- a/docs/json/sonarr/cf/pq.json
+++ b/docs/json/sonarr/cf/pq.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "2a7e3be05d3861d6df7171ec74cad727",
-  "trash_score": 500,
   "trash_scores": {
     "default": 500
   },

--- a/docs/json/sonarr/cf/qibi.json
+++ b/docs/json/sonarr/cf/qibi.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "3ac5d84fce98bab1b531393e9c82f467",
-  "trash_score": 80,
   "trash_scores": {
     "default": 80
   },

--- a/docs/json/sonarr/cf/red.json
+++ b/docs/json/sonarr/cf/red.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "c30d2958827d1867c73318a5a2957eb1",
-  "trash_score": 50,
   "trash_scores": {
     "default": 50
   },

--- a/docs/json/sonarr/cf/remaster.json
+++ b/docs/json/sonarr/cf/remaster.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "b735f09d3c025cbb7d75a5d38325b73b",
-  "trash_score": 25,
   "trash_scores": {
     "default": 25
   },

--- a/docs/json/sonarr/cf/remux-tier-01.json
+++ b/docs/json/sonarr/cf/remux-tier-01.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "9965a052eb87b0d10313b1cea89eb451",
-  "trash_score": 1900,
   "trash_scores": {
     "default": 1900,
     "anime-sonarr": 1050

--- a/docs/json/sonarr/cf/remux-tier-02.json
+++ b/docs/json/sonarr/cf/remux-tier-02.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "8a1d0c3d7497e741736761a1da866a2e",
-  "trash_score": 1850,
   "trash_scores": {
     "default": 1850,
     "anime-sonarr": 1000

--- a/docs/json/sonarr/cf/repack-proper.json
+++ b/docs/json/sonarr/cf/repack-proper.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "ec8fa7296b64e8cd390a1600981f3923",
-  "trash_score": 5,
   "trash_scores": {
     "default": 5
   },

--- a/docs/json/sonarr/cf/repack-v2.json
+++ b/docs/json/sonarr/cf/repack-v2.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "eb3d5cc0a2be0db205fb823640db6a3c",
-  "trash_score": 6,
   "trash_scores": {
     "default": 6
   },

--- a/docs/json/sonarr/cf/repack-v3.json
+++ b/docs/json/sonarr/cf/repack-v3.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "44e7c4de10ae50265753082e5dc76047",
-  "trash_score": 7,
   "trash_scores": {
     "default": 7
   },

--- a/docs/json/sonarr/cf/retags.json
+++ b/docs/json/sonarr/cf/retags.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "06d66ab109d4d2eddb2794d21526d140",
-  "trash_score": -10000,
   "trash_scores": {
     "default": -10000
   },

--- a/docs/json/sonarr/cf/scene.json
+++ b/docs/json/sonarr/cf/scene.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "1b3994c551cbb92a2c781af061f4ab44",
-  "trash_score": -10000,
   "trash_scores": {
     "default": -10000
   },

--- a/docs/json/sonarr/cf/sdr-no-webdl.json
+++ b/docs/json/sonarr/cf/sdr-no-webdl.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "83304f261cf516bb208c18c54c0adf97",
-  "trash_score": -10000,
   "trash_scores": {
     "default": -10000
   },

--- a/docs/json/sonarr/cf/sdr.json
+++ b/docs/json/sonarr/cf/sdr.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "2016d1676f5ee13a5b7257ff86ac9a93",
-  "trash_score": -10000,
   "trash_scores": {
     "default": -10000
   },

--- a/docs/json/sonarr/cf/sho.json
+++ b/docs/json/sonarr/cf/sho.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "ae58039e1319178e6be73caab5c42166",
-  "trash_score": 50,
   "trash_scores": {
     "default": 50
   },

--- a/docs/json/sonarr/cf/stan.json
+++ b/docs/json/sonarr/cf/stan.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "1efe8da11bfd74fbbcd4d8117ddb9213",
-  "trash_score": 60,
   "trash_scores": {
     "default": 60
   },

--- a/docs/json/sonarr/cf/truehd-atmos.json
+++ b/docs/json/sonarr/cf/truehd-atmos.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "0d7824bb924701997f874e7ff7d4844a",
-  "trash_score": 5000,
   "trash_scores": {
     "default": 5000
   },

--- a/docs/json/sonarr/cf/truehd.json
+++ b/docs/json/sonarr/cf/truehd.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "1808e4b9cee74e064dfae3f1db99dbfe",
-  "trash_score": 2750,
   "trash_scores": {
     "default": 2750
   },

--- a/docs/json/sonarr/cf/uhd-streaming-boost.json
+++ b/docs/json/sonarr/cf/uhd-streaming-boost.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "43b3cf48cb385cd3eac608ee6bca7f09",
-  "trash_score": 20,
   "trash_scores": {
     "default": 20
   },

--- a/docs/json/sonarr/cf/uhd-streaming-cut.json
+++ b/docs/json/sonarr/cf/uhd-streaming-cut.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "d2d299244a92b8a52d4921ce3897a256",
-  "trash_score": -20,
   "trash_scores": {
     "default": -20
   },

--- a/docs/json/sonarr/cf/v0.json
+++ b/docs/json/sonarr/cf/v0.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "d2d7b8a9d39413da5f44054080e028a3",
-  "trash_score": -51,
   "trash_scores": {
     "default": -51
   },

--- a/docs/json/sonarr/cf/v1.json
+++ b/docs/json/sonarr/cf/v1.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "273bd326df95955e1b6c26527d1df89b",
-  "trash_score": 1,
   "trash_scores": {
     "default": 1
   },

--- a/docs/json/sonarr/cf/v2.json
+++ b/docs/json/sonarr/cf/v2.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "228b8ee9aa0a609463efca874524a6b8",
-  "trash_score": 2,
   "trash_scores": {
     "default": 2
   },

--- a/docs/json/sonarr/cf/v3.json
+++ b/docs/json/sonarr/cf/v3.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "0e5833d3af2cc5fa96a0c29cd4477feb",
-  "trash_score": 3,
   "trash_scores": {
     "default": 3
   },

--- a/docs/json/sonarr/cf/v4.json
+++ b/docs/json/sonarr/cf/v4.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "4fc15eeb8f2f9a749f918217d4234ad8",
-  "trash_score": 4,
   "trash_scores": {
     "default": 4
   },

--- a/docs/json/sonarr/cf/vdl.json
+++ b/docs/json/sonarr/cf/vdl.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "5d2317d99af813b6529c7ebf01c83533",
-  "trash_score": 50,
   "trash_scores": {
     "default": 50
   },

--- a/docs/json/sonarr/cf/vrv.json
+++ b/docs/json/sonarr/cf/vrv.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "44a8ee6403071dd7b8a3a8dd3fe8cb20",
-  "trash_score": 3,
   "trash_scores": {
     "default": 3
   },

--- a/docs/json/sonarr/cf/web-scene.json
+++ b/docs/json/sonarr/cf/web-scene.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "d0c516558625b04b363fa6c5c2c7cfd4",
-  "trash_score": 1600,
   "trash_scores": {
     "default": 1600
   },

--- a/docs/json/sonarr/cf/web-tier-01.json
+++ b/docs/json/sonarr/cf/web-tier-01.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "e6258996055b9fbab7e9cb2f75819294",
-  "trash_score": 1700,
   "trash_scores": {
     "default": 1700,
     "anime-sonarr": 350

--- a/docs/json/sonarr/cf/web-tier-02.json
+++ b/docs/json/sonarr/cf/web-tier-02.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "58790d4e2fdcd9733aa7ae68ba2bb503",
-  "trash_score": 1650,
   "trash_scores": {
     "default": 1650,
     "anime-sonarr": 150

--- a/docs/json/sonarr/cf/web-tier-03.json
+++ b/docs/json/sonarr/cf/web-tier-03.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "d84935abd3f8556dcd51d4f27e22d0a6",
-  "trash_score": 1600,
   "trash_scores": {
     "default": 1600,
     "anime-sonarr": 150

--- a/docs/json/sonarr/cf/x265-hd.json
+++ b/docs/json/sonarr/cf/x265-hd.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "47435ece6b99a0b477caf360e79ba0bb",
-  "trash_score": -10000,
   "trash_scores": {
     "default": -10000
   },

--- a/docs/json/sonarr/cf/x265-no-hdrdv.json
+++ b/docs/json/sonarr/cf/x265-no-hdrdv.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "9b64dff695c2115facf1b6ea59c9bd07",
-  "trash_score": -10000,
   "trash_scores": {
     "default": -10000
   },


### PR DESCRIPTION
Both Notifiarr and Recyclarr no longer use these values.
