### PR TITLE
fix(radarr): SQP-1 (2160p) several updates (v2)

### DIFF
--- a/docs/json/radarr/cf/bcore.json
+++ b/docs/json/radarr/cf/bcore.json
@@ -1,7 +1,9 @@
 {
   "trash_id": "cc5e51a9e85a6296ceefe097a77f12f4",
   "trash_scores": {
-    "default": 15
+    "default": 15,
+    "sqp-1-1080p": -10000,
+    "sqp-1-2160p": -10000
   },
   "name": "BCORE",
   "includeCustomFormatWhenRenaming": true,

--- a/docs/json/radarr/quality-size/sqp-streaming.json
+++ b/docs/json/radarr/quality-size/sqp-streaming.json
@@ -41,20 +41,20 @@
         {
             "quality": "WEBDL-2160p",
             "min": 34.5,
-            "preferred": 399,
-            "max": 400
+            "preferred": 221.2,
+            "max": 222.2
         },
         {
             "quality": "WEBRip-2160p",
             "min": 34.5,
-            "preferred": 399,
-            "max": 400
+            "preferred": 221.2,
+            "max": 222.2
         },
         {
             "quality": "Bluray-2160p",
             "min": 102,
-            "preferred": 170,
-            "max": 171
+            "preferred": 203.4,
+            "max": 204.4
         }
     ]
 }

--- a/includes/sqp/1-4k-cf-scoring-sqp1.md
+++ b/includes/sqp/1-4k-cf-scoring-sqp1.md
@@ -128,4 +128,4 @@
 
 {! include-markdown "../../includes/sqp/hd-radarr-resolution.md" !}
 
-{! include-markdown "../../includes/cf/radarr-streaming-services.md" !}
+{! include-markdown "../../includes/sqp/1-4k-streaming-services.md" !}

--- a/includes/sqp/1-4k-streaming-services.md
+++ b/includes/sqp/1-4k-streaming-services.md
@@ -1,0 +1,28 @@
+??? abstract "Streaming Services - [Click to show/hide]"
+    | Custom Format                                                                             |                                     Score                                      | Trash ID                                |
+    | ----------------------------------------------------------------------------------------- | :----------------------------------------------------------------------------: | --------------------------------------- |
+    | [{{ radarr['cf']['amzn']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#amzn)   |                                       0                                        | {{ radarr['cf']['amzn']['trash_id'] }}  |
+    | [{{ radarr['cf']['atvp']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#atvp)   |                                       0                                        | {{ radarr['cf']['atvp']['trash_id'] }}  |
+    | [{{ radarr['cf']['bcore']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#bcore) | :warning: {{ radarr['cf']['bcore']['trash_scores']['sqp-1-2160p'] }} :warning: | {{ radarr['cf']['bcore']['trash_id'] }} |
+    | [{{ radarr['cf']['crav']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#crav)   |                                       0                                        | {{ radarr['cf']['crav']['trash_id'] }}  |
+    | [{{ radarr['cf']['crit']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#crit)   |             {{ radarr['cf']['crit']['trash_scores']['default'] }}              | {{ radarr['cf']['crit']['trash_id'] }}  |
+    | [{{ radarr['cf']['dsnp']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#dsnp)   |                                       0                                        | {{ radarr['cf']['dsnp']['trash_id'] }}  |
+    | [{{ radarr['cf']['hbo']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#hbo)     |                                       0                                        | {{ radarr['cf']['hbo']['trash_id'] }}   |
+    | [{{ radarr['cf']['hmax']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#hmax)   |                                       0                                        | {{ radarr['cf']['hmax']['trash_id'] }}  |
+    | [{{ radarr['cf']['max']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#max)     |                                       0                                        | {{ radarr['cf']['max']['trash_id'] }}   |
+    | [{{ radarr['cf']['hulu']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#hulu)   |                                       0                                        | {{ radarr['cf']['hulu']['trash_id'] }}  |
+    | [{{ radarr['cf']['ma']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#ma)       |              {{ radarr['cf']['ma']['trash_scores']['default'] }}               | {{ radarr['cf']['ma']['trash_id'] }}    |
+    | [{{ radarr['cf']['nf']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#nf)       |                                       0                                        | {{ radarr['cf']['nf']['trash_id'] }}    |
+    | [{{ radarr['cf']['pathe']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#pathe) |                                       0                                        | {{ radarr['cf']['pathe']['trash_id'] }} |
+    | [{{ radarr['cf']['pcok']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#pcok)   |                                       0                                        | {{ radarr['cf']['pcok']['trash_id'] }}  |
+    | [{{ radarr['cf']['pmtp']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#pmtp)   |                                       0                                        | {{ radarr['cf']['pmtp']['trash_id'] }}  |
+    | [{{ radarr['cf']['stan']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#stan)   |                                       0                                        | {{ radarr['cf']['stan']['trash_id'] }}  |
+    | [{{ radarr['cf']['ovid']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#ovid)   |                                       0                                        | {{ radarr['cf']['ovid']['trash_id'] }}  |
+
+    !!! warning "Scores marked with a :warning: warning :warning: are different to those used in the main public guide"
+    
+    ------
+    Breakdown and Why
+
+    - The reason why these Custom Formats have a score of `0` is because they are mainly used for the naming scheme and other variables should decide for movies if a certain release if preferred.
+    - `CRiT` and `MA` are the only ones with a positive score because of their better source material, or higher bitrate and quality compared to other streaming services. `BCore` has a negative score as these releases have a very high bitrate so can cause transcoding.

--- a/includes/sqp/1-4k-streaming-services.md
+++ b/includes/sqp/1-4k-streaming-services.md
@@ -20,7 +20,7 @@
     | [{{ radarr['cf']['ovid']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#ovid)   |                                       0                                        | {{ radarr['cf']['ovid']['trash_id'] }}  |
 
     !!! warning "Scores marked with a :warning: warning :warning: are different to those used in the main public guide"
-    
+
     ------
     Breakdown and Why
 

--- a/includes/sqp/1-cf-scoring.md
+++ b/includes/sqp/1-cf-scoring.md
@@ -59,4 +59,4 @@
 
 {! include-markdown "../../includes/sqp/hd-radarr-resolution.md" !}
 
-{! include-markdown "../../includes/cf/radarr-streaming-services.md" !}
+{! include-markdown "../../includes/sqp/1-streaming-services.md" !}

--- a/includes/sqp/1-streaming-services.md
+++ b/includes/sqp/1-streaming-services.md
@@ -1,0 +1,28 @@
+??? abstract "Streaming Services - [Click to show/hide]"
+    | Custom Format                                                                             |                                     Score                                      | Trash ID                                |
+    | ----------------------------------------------------------------------------------------- | :----------------------------------------------------------------------------: | --------------------------------------- |
+    | [{{ radarr['cf']['amzn']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#amzn)   |                                       0                                        | {{ radarr['cf']['amzn']['trash_id'] }}  |
+    | [{{ radarr['cf']['atvp']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#atvp)   |                                       0                                        | {{ radarr['cf']['atvp']['trash_id'] }}  |
+    | [{{ radarr['cf']['bcore']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#bcore) | :warning: {{ radarr['cf']['bcore']['trash_scores']['sqp-1-1080p'] }} :warning: | {{ radarr['cf']['bcore']['trash_id'] }} |
+    | [{{ radarr['cf']['crav']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#crav)   |                                       0                                        | {{ radarr['cf']['crav']['trash_id'] }}  |
+    | [{{ radarr['cf']['crit']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#crit)   |             {{ radarr['cf']['crit']['trash_scores']['default'] }}              | {{ radarr['cf']['crit']['trash_id'] }}  |
+    | [{{ radarr['cf']['dsnp']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#dsnp)   |                                       0                                        | {{ radarr['cf']['dsnp']['trash_id'] }}  |
+    | [{{ radarr['cf']['hbo']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#hbo)     |                                       0                                        | {{ radarr['cf']['hbo']['trash_id'] }}   |
+    | [{{ radarr['cf']['hmax']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#hmax)   |                                       0                                        | {{ radarr['cf']['hmax']['trash_id'] }}  |
+    | [{{ radarr['cf']['max']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#max)     |                                       0                                        | {{ radarr['cf']['max']['trash_id'] }}   |
+    | [{{ radarr['cf']['hulu']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#hulu)   |                                       0                                        | {{ radarr['cf']['hulu']['trash_id'] }}  |
+    | [{{ radarr['cf']['ma']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#ma)       |              {{ radarr['cf']['ma']['trash_scores']['default'] }}               | {{ radarr['cf']['ma']['trash_id'] }}    |
+    | [{{ radarr['cf']['nf']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#nf)       |                                       0                                        | {{ radarr['cf']['nf']['trash_id'] }}    |
+    | [{{ radarr['cf']['pathe']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#pathe) |                                       0                                        | {{ radarr['cf']['pathe']['trash_id'] }} |
+    | [{{ radarr['cf']['pcok']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#pcok)   |                                       0                                        | {{ radarr['cf']['pcok']['trash_id'] }}  |
+    | [{{ radarr['cf']['pmtp']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#pmtp)   |                                       0                                        | {{ radarr['cf']['pmtp']['trash_id'] }}  |
+    | [{{ radarr['cf']['stan']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#stan)   |                                       0                                        | {{ radarr['cf']['stan']['trash_id'] }}  |
+    | [{{ radarr['cf']['ovid']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#ovid)   |                                       0                                        | {{ radarr['cf']['ovid']['trash_id'] }}  |
+
+    !!! warning "Scores marked with a :warning: warning :warning: are different to those used in the main public guide"
+
+    ------
+    Breakdown and Why
+
+    - The reason why these Custom Formats have a score of `0` is because they are mainly used for the naming scheme and other variables should decide for movies if a certain release if preferred.
+    - `CRiT` and `MA` are the only ones with a positive score because of their better source material, or higher bitrate and quality compared to other streaming services. `BCore` has a negative score as these releases have a very high bitrate so can cause transcoding.


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->

Fix: #1614
Fix: #1626
Fix: #1627
- #1614
- #1626
- #1627

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

- [x] increase bluray-2160p quality size to compensate for uhd tiers.
- [x] change maximum quality size for WEB-2160p
- [x] remove boost from bcore streaming services and lowered it for SQP-1 to `-10000`

## Open Questions and Pre-Merge TODOs

<!-- - [x] Use GitHub checklists. When solved, check the box and explain the answer. -->

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).

