### PR TITLE
feat(guides): Add Honeywell qBittorrent Theme to Themes Page

### DIFF
--- a/docs/Downloaders/qBittorrent/Tips/Themes.md
+++ b/docs/Downloaders/qBittorrent/Tips/Themes.md
@@ -2,9 +2,10 @@
 
 A list of known working qBittorrent themes.
 
-| Theme                                                                                                                          | Style | Compatibility  |
-| ------------------------------------------------------------------------------------------------------------------------------ | ----- | -------------- |
-| [Nightwalker Theme (CallMeBruce fork)](https://github.com/CallMeBruce/nightwalker){:target="_blank" rel="noopener noreferrer"} | Dark  | v4.5           |
-| [World of Quinoa](https://github.com/gl0ryus/woq){:target="_blank" rel="noopener noreferrer"}                                  | Dark  | v4.3.9, v4.4.5 |
+| Theme                                                                                                                          | Style | Compatibility   |
+| ------------------------------------------------------------------------------------------------------------------------------ | ----- | --------------- |
+| [Honeywell](https://github.com/stacksmash76/qbt-honeywell)                                                                     | Dark  | v4.3.1 - v4.4.5 |
+| [Nightwalker Theme (CallMeBruce fork)](https://github.com/CallMeBruce/nightwalker){:target="_blank" rel="noopener noreferrer"} | Dark  | v4.5            |
+| [World of Quinoa](https://github.com/gl0ryus/woq){:target="_blank" rel="noopener noreferrer"}                                  | Dark  | v4.3.9, v4.4.5  |
 
 --8<-- "includes/support.md"

--- a/docs/Downloaders/qBittorrent/Tips/Themes.md
+++ b/docs/Downloaders/qBittorrent/Tips/Themes.md
@@ -4,7 +4,7 @@ A list of known working qBittorrent themes.
 
 | Theme                                                                                                                          | Style | Compatibility   |
 | ------------------------------------------------------------------------------------------------------------------------------ | ----- | --------------- |
-| [Honeywell](https://github.com/stacksmash76/qbt-honeywell)                                                                     | Dark  | v4.3.1 - v4.4.5 |
+| [Honeywell](https://github.com/stacksmash76/qbt-honeywell){:target="_blank" rel="noopener noreferrer"}                         | Dark  | v4.3.1 - v4.4.5 |
 | [Nightwalker Theme (CallMeBruce fork)](https://github.com/CallMeBruce/nightwalker){:target="_blank" rel="noopener noreferrer"} | Dark  | v4.5            |
 | [World of Quinoa](https://github.com/gl0ryus/woq){:target="_blank" rel="noopener noreferrer"}                                  | Dark  | v4.3.9, v4.4.5  |
 


### PR DESCRIPTION
# Pull Request

## Purpose

Resolve: #1632
- #1632 

## Approach

- [x] Add Honeywell theme to table on qBittorrent themes page

## Open Questions and Pre-Merge TODOs

None

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
