### PR TITLE
feat(radarr): add .VAV to Retags CF

### DIFF
--- a/docs/json/radarr/cf/retags.json
+++ b/docs/json/radarr/cf/retags.json
@@ -41,6 +41,15 @@
       "fields": {
         "value": "\\[TGx\\]"
       }
+    },
+    {
+      "name": ".VAV",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "[.]VAV\b"
+      }
     }
   ]
 }


### PR DESCRIPTION
Retagging group VAV adding Vietnamese audio tracks to existing releases, causing unwanted release group parsing. Propose adding to Retag CF to filter out.

# Pull Request

## Purpose

Recommend adding .VAV to retag CF to filter out unwanted VIE audio. Related to recent Radarr update adding VIE to Vietnamese Language parsing. 

## Approach

Modify the retags.json in guide with Trash-provided regex to filter out these releases. 

## Open Questions and Pre-Merge TODOs

Added code to retags.json as recommended. Task Complete?

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [ X ] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [ X ] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
