### PR TITLE
feat(radarr): Added `.VAV` to the  `Retags` Custom Format

### DIFF
--- a/docs/json/radarr/cf/retags.json
+++ b/docs/json/radarr/cf/retags.json
@@ -48,7 +48,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "[.]VAV\b"
+        "value": "[.]VAV\\b"
       }
     }
   ]

--- a/docs/json/radarr/cf/retags.json
+++ b/docs/json/radarr/cf/retags.json
@@ -41,6 +41,15 @@
       "fields": {
         "value": "\\[TGx\\]"
       }
+    },
+    {
+      "name": ".VAV",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "[.]VAV\b"
+      }
     }
   ]
 }


### PR DESCRIPTION
Retagging group VAV adding Vietnamese audio tracks to existing releases, causing unwanted release group parsing. Propose adding to Retag CF to filter out.

# Pull Request

## Purpose

Recommend adding .VAV to retag CF to filter out unwanted VIE audio. Related to recent Radarr update adding VIE to Vietnamese Language parsing.

## Approach

Modify the retags.json in guide with Trash-provided regex to filter out these releases.

## Open Questions and Pre-Merge TODOs

Added code to retags.json as recommended. Task Complete?

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
