### PR TITLE
fix(starr): Custom Format Conditional Changes

### DIFF
--- a/docs/json/radarr/cf/2160p.json
+++ b/docs/json/radarr/cf/2160p.json
@@ -18,24 +18,6 @@
       "fields": {
         "value": 2160
       }
-    },
-    {
-      "name": "HDR Formats",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": false,
-      "required": true,
-      "fields": {
-        "value": "\\bHDR(\\b|\\d)|\\b(dv|dovi|dolby[ .]?v(ision)?)\\b|\\b(FraMeSToR|HQMUX)\\b|\\b(PQ)\\b|\\b(HLG)\\b"
-      }
-    },
-    {
-      "name": "NOT SDR",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": true,
-      "required": true,
-      "fields": {
-        "value": "\\bSDR\\b"
-      }
     }
   ]
 }

--- a/docs/json/radarr/cf/atmos-undefined.json
+++ b/docs/json/radarr/cf/atmos-undefined.json
@@ -72,6 +72,15 @@
       }
     },
     {
+      "name": "Not RlsGrp (Atmos Only)",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": true,
+      "required": true,
+      "fields": {
+        "value": "W4NK3R|HQMUX"
+      }
+    },
+    {
       "name": "Not TrueHD",
       "implementation": "ReleaseTitleSpecification",
       "negate": true,

--- a/docs/json/radarr/cf/atmos-undefined.json
+++ b/docs/json/radarr/cf/atmos-undefined.json
@@ -77,7 +77,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "W4NK3R|HQMUX"
+        "value": "\\b(W4NK3R|HQMUX)\\b"
       }
     },
     {

--- a/docs/json/radarr/cf/truehd-atmos.json
+++ b/docs/json/radarr/cf/truehd-atmos.json
@@ -23,7 +23,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\b(ATMOS|W4NK3R|-DON)(\\b|\\d)"
+        "value": "\\b(ATMOS|W4NK3R|DON)(\\b|\\d)"
       }
     },
     {

--- a/docs/json/radarr/cf/truehd-atmos.json
+++ b/docs/json/radarr/cf/truehd-atmos.json
@@ -14,7 +14,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "True[ .-]?HD"
+        "value": "True[ .-]?HD|W4NK3R|HQMUX"
       }
     },
     {
@@ -23,7 +23,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\bATMOS(\\b|\\d)"
+        "value": "\\b(ATMOS|W4NK3R|-DON)(\\b|\\d)"
       }
     },
     {

--- a/docs/json/radarr/cf/truehd.json
+++ b/docs/json/radarr/cf/truehd.json
@@ -61,6 +61,15 @@
       "fields": {
         "value": "\\bDD[^a-z+]|(?<!e)ac3"
       }
+    },
+    {
+      "name": "Not RlsGrp (TrueHD only)",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": true,
+      "required": true,
+      "fields": {
+        "value": "CtrlHD|W4NK3R|-DON"
+      }
     }
   ]
 }

--- a/docs/json/radarr/cf/truehd.json
+++ b/docs/json/radarr/cf/truehd.json
@@ -68,7 +68,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "CtrlHD|W4NK3R|-DON"
+        "value": "\\b(CtrlHD|W4NK3R|DON)\\b"
       }
     }
   ]

--- a/docs/json/sonarr/cf/2160p.json
+++ b/docs/json/sonarr/cf/2160p.json
@@ -14,24 +14,6 @@
       "fields": {
         "value": 2160
       }
-    },
-    {
-      "name": "HDR Formats",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": false,
-      "required": true,
-      "fields": {
-        "value": "\\bHDR(\\b|\\d)|\\b(dv|dovi|dolby[ .]?v(ision)?)\\b|\\b(FraMeSToR|HQMUX)\\b|\\b(PQ)\\b|\\b(HLG)\\b"
-      }
-    },
-    {
-      "name": "NOT SDR",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": true,
-      "required": true,
-      "fields": {
-        "value": "\\bSDR\\b"
-      }
     }
   ]
 }


### PR DESCRIPTION
# Pull Request

## Purpose

- Fix: #1636 
- Partial reversion of #1553 for Radarr - allows TrueHD Atmos matches for groups who don't use full TrueHD Atmos text in releases

## Approach

- [x] Removed `HDR` and `Not SDR` conditionals from 2160p custom formats
- [x] Added release group conditionals back to TrueHD Atmos custom format for Radarr only

## Open Questions and Pre-Merge TODOs

- [ ] Regex review to confirm this is the best approach, specifically that -RlsGrp is better in this context

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
