### PR TITLE
Add Groups to LQ

### DIFF
--- a/docs/json/radarr/cf/hd-bluray-tier-03.json
+++ b/docs/json/radarr/cf/hd-bluray-tier-03.json
@@ -45,15 +45,6 @@
       }
     },
     {
-      "name": "BiTOR",
-      "implementation": "ReleaseGroupSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "^(BiTOR)$"
-      }
-    },
-    {
       "name": "HONE",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,

--- a/docs/json/radarr/cf/lq-release-title.json
+++ b/docs/json/radarr/cf/lq-release-title.json
@@ -14,6 +14,15 @@
       "fields": {
         "value": "\\b(TeeWee)\\b"
       }
+    },
+    {
+      "name": "BiTOR (2160p)",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "(?=.*?(\\b2160p\\b))(?=.*?(\\bBiTOR\\b))"
+      }
     }
   ]
 }

--- a/docs/json/radarr/cf/lq.json
+++ b/docs/json/radarr/cf/lq.json
@@ -178,6 +178,15 @@
       }
     },
     {
+      "name": "DepraveD",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(DepraveD)$"
+      }
+    },
+    {
       "name": "DNL",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,
@@ -625,6 +634,15 @@
       "required": false,
       "fields": {
         "value": "^(SWTYBLZ)$"
+      }
+    },
+    {
+      "name": "tarunk9c",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(tarunk9c)$"
       }
     },
     {

--- a/docs/json/sonarr/cf/lq-release-title.json
+++ b/docs/json/sonarr/cf/lq-release-title.json
@@ -14,6 +14,15 @@
       "fields": {
         "value": "\\b(TeeWee)\\b"
       }
+    },
+    {
+      "name": "BiTOR (2160p)",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "(?=.*?(\\b2160p\\b))(?=.*?(\\bBiTOR\\b))"
+      }
     }
   ]
 }


### PR DESCRIPTION


# Pull Request

## Purpose

- Fix: #1641 
- Partial reversion of #1605 

## Approach

- Add tarunk9c and DepraveD to `LQ`
- Add BiTOR 2160p releases to `LQ (Release Title)` (1080p releases are not currently added to LQ, but will now be un-tiered)
- Remove BiTOR from `HD Bluray Tier 03`

## Open Questions and Pre-Merge TODOs

- [x] Check regex when reviewed

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
