### PR TITLE
fix(radarr): Add CtrlHD to Atmos condition in TrueHD Atmos Radarr Custom Format

### DIFF
--- a/docs/json/radarr/cf/truehd-atmos.json
+++ b/docs/json/radarr/cf/truehd-atmos.json
@@ -23,7 +23,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\b(ATMOS|W4NK3R|DON)(\\b|\\d)"
+        "value": "\\b(ATMOS|CtrlHD|W4NK3R|DON)(\\b|\\d)"
       }
     },
     {

--- a/docs/updates.txt
+++ b/docs/updates.txt
@@ -1,3 +1,6 @@
+# 2023-11-19 20:30
+- [fix(radarr): Add CtrlHD to Atmos condition in TrueHD Atmos Radarr Custom Format](https://github.com/TRaSH-Guides/Guides/pull/1651)
+
 # 2023-11-19 16:00
 - [feat(guide): include the different hdr formats in the quality profiles](https://github.com/TRaSH-Guides/Guides/pull/1623)
 - [fix(guide): Update Radarr/Sonarr guide How to rename your folders](https://github.com/TRaSH-Guides/Guides/pull/1647)


### PR DESCRIPTION
# Pull Request

## Purpose

- fix: #1650 

## Approach

- [x] Add CtrlHD to Atmos condition in TrueHD Atmos Radarr Custom Format - this rlsgrp doesn't use 'Atmos' in release names.

## Open Questions and Pre-Merge TODOs

None

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
