### PR TITLE
fix(radarr): IMAX CF false positives

### DIFF
--- a/docs/json/radarr/cf/imax-enhanced.json
+++ b/docs/json/radarr/cf/imax-enhanced.json
@@ -12,7 +12,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "^(?=.*(DSNP|Disney\\+|CORE(?=[ ._-]web[ ._-]?(dl|rip)\\b)|\\bBC(?=[ ._-]web[ ._-]?(dl|rip)\\b)|IMAX[- .]Enhanced)\\b)(?=.*\\b(IMAX|IMAX[- .]Enhanced)\\b).*"
+        "value": "^(?=.*\\b((DSNP|Disney\\+|BC|B?CORE)(?=[ ._-]web[ ._-]?(dl|rip)\\b)))(?=.*\\b((?<!NON[ ._-])IMAX)\\b)|^(?=.*\\b(IMAX[ ._-]Enhanced)\\b)"
       }
     }
   ]

--- a/docs/json/radarr/cf/imax-enhanced.json
+++ b/docs/json/radarr/cf/imax-enhanced.json
@@ -3,6 +3,7 @@
   "trash_scores": {
     "default": 800
   },
+  "trash_regex": "https://regex101.com/r/e7ugxU/1",
   "name": "IMAX Enhanced",
   "includeCustomFormatWhenRenaming": true,
   "specifications": [

--- a/docs/json/radarr/cf/imax.json
+++ b/docs/json/radarr/cf/imax.json
@@ -12,7 +12,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\bIMAX\\b"
+        "value": "\\b((?<!NON[ ._-])IMAX)\\b"
       }
     },
     {

--- a/docs/json/radarr/cf/imax.json
+++ b/docs/json/radarr/cf/imax.json
@@ -21,7 +21,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "^(?=.*(DSNP|CORE(?=[ ._-]web[ ._-]?(dl|rip)\\b)|\\bBC(?=[ ._-]web[ ._-]?(dl|rip)\\b)|IMAX[- .]Enhanced)\\b)(?=.*\\b(IMAX|IMAX[- .]Enhanced)\\b).*"
+        "value": "^(?=.*\\b((DSNP|Disney\\+|BC|B?CORE)(?=[ ._-]web[ ._-]?(dl|rip)\\b)))(?=.*\\b((?<!NON[ ._-])IMAX)\\b)|^(?=.*\\b(IMAX[ ._-]Enhanced)\\b)"
       }
     }
   ]

--- a/docs/json/radarr/cf/imax.json
+++ b/docs/json/radarr/cf/imax.json
@@ -3,6 +3,7 @@
   "trash_scores": {
     "default": 800
   },
+  "trash_regex": "https://regex101.com/r/e7ugxU/1",
   "name": "IMAX",
   "includeCustomFormatWhenRenaming": false,
   "specifications": [


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->

Fix #1654 

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

- Adjust regex of `IMAX` to no longer match on `NON-IMAX`
- Clean up `IMAX Enhanced` CF regex

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
