### PR TITLE
fix(sonarr): Add Missing Optionals

### DIFF
--- a/docs/Radarr/radarr-setup-quality-profiles.md
+++ b/docs/Radarr/radarr-setup-quality-profiles.md
@@ -99,6 +99,8 @@ If you prefer High-Quality HD Encodes (Bluray-720p/1080p)
 
 {! include-markdown "../../includes/cf/radarr-unwanted.md" !}
 
+{! include-markdown "../../includes/cf/radarr-optional.md" !}
+
 {! include-markdown "../../includes/cf/radarr-streaming-services.md" !}
 
 I decided not to add `Audio Advanced` Custom Formats to the encodes profile, You will hardly find HD audio with HD Bluray Encodes. With HD Bluray Encodes I suggest going for quality. If you also want HD audio formats I would suggest going with Remuxes or UHD Encodes.
@@ -145,6 +147,8 @@ If you prefer High-Quality UHD Encodes (Bluray-2160p)
 
 {! include-markdown "../../includes/cf/radarr-unwanted-uhd.md" !}
 
+{! include-markdown "../../includes/cf/radarr-optional.md" !}
+
 {! include-markdown "../../includes/cf/radarr-optional-uhd.md" !}
 
 {! include-markdown "../../includes/cf/radarr-streaming-services.md" !}
@@ -189,6 +193,8 @@ If you prefer 1080p Remuxes (Remux-1080p)
 
 {! include-markdown "../../includes/cf/radarr-unwanted.md" !}
 
+{! include-markdown "../../includes/cf/radarr-optional.md" !}
+
 {! include-markdown "../../includes/cf/radarr-streaming-services.md" !}
 
 Use the following main settings in your profile.
@@ -232,6 +238,8 @@ If you prefer 2160p Remuxes (Remux-2160p)
 {! include-markdown "../../includes/cf/radarr-misc.md" !}
 
 {! include-markdown "../../includes/cf/radarr-unwanted-uhd.md" !}
+
+{! include-markdown "../../includes/cf/radarr-optional.md" !}
 
 {! include-markdown "../../includes/cf/radarr-optional-uhd.md" !}
 

--- a/docs/Radarr/radarr-setup-quality-profiles.md
+++ b/docs/Radarr/radarr-setup-quality-profiles.md
@@ -103,7 +103,7 @@ If you prefer High-Quality HD Encodes (Bluray-720p/1080p)
 
 {! include-markdown "../../includes/cf/radarr-streaming-services.md" !}
 
-I decided not to add `Audio Advanced` Custom Formats to the encodes profile, You will hardly find HD audio with HD Bluray Encodes. With HD Bluray Encodes I suggest going for quality. If you also want HD audio formats I would suggest going with Remuxes or UHD Encodes.
+I decided not to add `Audio Advanced` Custom Formats to the encodes profile. You will hardly find HD audio with HD Bluray Encodes. When downloading HD Bluray Encodes, I suggest going for quality. If you want HD audio formats, I would suggest going with a Remux or UHD Encode.
 
 Use the following main settings in your profile.
 

--- a/docs/Sonarr/sonarr-setup-quality-profiles.md
+++ b/docs/Sonarr/sonarr-setup-quality-profiles.md
@@ -86,6 +86,8 @@ If you prefer 720p/1080p WEBDL (WEB-1080p)
 
 {! include-markdown "../../includes/cf/sonarr-unwanted.md" !}
 
+{! include-markdown "../../includes/cf/sonarr-optional.md" !}
+
 {! include-markdown "../../includes/cf/sonarr-misc.md" !}
 
 {! include-markdown "../../includes/cf/sonarr-streaming-services.md" !}

--- a/docs/Sonarr/sonarr-setup-quality-profiles.md
+++ b/docs/Sonarr/sonarr-setup-quality-profiles.md
@@ -129,6 +129,8 @@ The only deal breaker with 2160p is when the release includes DV/HDR. 2160p with
 
 {! include-markdown "../../includes/cf/sonarr-unwanted.md" !}
 
+{! include-markdown "../../includes/cf/sonarr-optional.md" !}
+
 {! include-markdown "../../includes/cf/sonarr-optional-uhd.md" !}
 
 {! include-markdown "../../includes/cf/sonarr-misc.md" !}

--- a/docs/json/radarr/cf/lq-release-title.json
+++ b/docs/json/radarr/cf/lq-release-title.json
@@ -23,6 +23,15 @@
       "fields": {
         "value": "(?=.*?(\\b2160p\\b))(?=.*?(\\bBiTOR\\b))"
       }
+    },
+    {
+      "name": "jennaortega",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "(?<!-)\\b(jennaortega(UHD)?)\\b"
+      }
     }
   ]
 }

--- a/docs/json/radarr/cf/lq-release-title.json
+++ b/docs/json/radarr/cf/lq-release-title.json
@@ -23,15 +23,6 @@
       "fields": {
         "value": "(?=.*?(\\b2160p\\b))(?=.*?(\\bBiTOR\\b))"
       }
-    },
-    {
-      "name": "jennaortega",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "(?<!-)\\b(jennaortega(UHD)?)\\b"
-      }
     }
   ]
 }

--- a/includes/cf/radarr-optional-uhd.md
+++ b/includes/cf/radarr-optional-uhd.md
@@ -7,4 +7,4 @@
 
     Breakdown and Why
 
-    - **{{ radarr['cf']['sdr']['name'] }}:** This will prevent grabbing UHD/4k releases without HDR Formats.
+    - **{{ radarr['cf']['sdr']['name'] }}:** This will prevent the grabbing of UHD/4K releases that do not contain HDR.

--- a/includes/cf/radarr-optional-uhd.md
+++ b/includes/cf/radarr-optional-uhd.md
@@ -7,4 +7,4 @@
 
     Breakdown and Why
 
-    - **{{ radarr['cf']['sdr']['name'] }}:** This will help to prevent to grab UHD/4k releases without HDR Formats.
+    - **{{ radarr['cf']['sdr']['name'] }}:** This will prevent grabbing UHD/4k releases without HDR Formats.

--- a/includes/cf/radarr-optional.md
+++ b/includes/cf/radarr-optional.md
@@ -13,8 +13,8 @@
 
     Breakdown and Why
 
-    - **{{ radarr['cf']['bad-dual-groups']['name'] }}:** [*Optional*] These groups take the original release, then they add their own preferred language (ex. Portuguese) as the main audio track (AAC 2.0), What results after renaming and FFprobe that the media file will be recognized as Portuguese AAC audio. It's a common rule that you add the best audio as first.
-    Also they often even rename the release name in to Portuguese.
+    - **{{ radarr['cf']['bad-dual-groups']['name'] }}:** [*Optional*] These groups take the original release and add their own language track (e.g. AAC 2.0 Portuguese) as the first track. Afterward, FFprobe would determine that the media file is Portuguese. It's a common rule that you only add the best audio as the main track.
+    Also they often even rename the release name into Portuguese.
     - **{{ radarr['cf']['evo-no-webdl']['name'] }}:** This group is often banned for low-quality Blu-ray releases, but their WEB-DLs are okay.
     - **{{ radarr['cf']['no-rlsgroup']['name'] }}:** [*Optional*] Some indexers strip out the release group which could result in LQ groups being scored incorrectly. For example, a lot of EVO releases end up with a stripped group name. These releases would appear as "upgrades" and could end up getting a decent score after other CFs are scored.
     - **{{ radarr['cf']['obfuscated']['name'] }}:** [*Optional*] Use these only if you wish to avoid renamed releases.

--- a/includes/cf/radarr-optional.md
+++ b/includes/cf/radarr-optional.md
@@ -15,9 +15,9 @@
 
     - **{{ radarr['cf']['bad-dual-groups']['name'] }}:** [*Optional*] These groups take the original release, then they add their own preferred language (ex. Portuguese) as the main audio track (AAC 2.0), What results after renaming and FFprobe that the media file will be recognized as Portuguese AAC audio. It's a common rule that you add the best audio as first.
     Also they often even rename the release name in to Portuguese.
-    - **{{ radarr['cf']['evo-no-webdl']['name'] }}:** This group is often banned for the low quality Blu-ray releases, but their WEB-DL are okay.
-    - **{{ radarr['cf']['no-rlsgroup']['name'] }}:** [*Optional*] Some indexers strip out the release group what could result in LQ groups getting a higher score. For example a lot of EVO releases end up stripping the group name, so they appear as "upgrades", and they end up getting a decent score if other things match.
-    - **{{ radarr['cf']['obfuscated']['name'] }}:** [*Optional*] (use these only if you dislike renamed releases)
+    - **{{ radarr['cf']['evo-no-webdl']['name'] }}:** This group is often banned for low-quality Blu-ray releases, but their WEB-DLs are okay.
+    - **{{ radarr['cf']['no-rlsgroup']['name'] }}:** [*Optional*] Some indexers strip out the release group which could result in LQ groups being scored incorrectly. For example, a lot of EVO releases end up with a stripped group name. These releases would appear as "upgrades" and could end up getting a decent score after other CFs are scored.
+    - **{{ radarr['cf']['obfuscated']['name'] }}:** [*Optional*] Use these only if you wish to avoid renamed releases.
     - **{{ radarr['cf']['retags']['name'] }}:** [*Optional*] Use this only if you dislike retagged releases. This will help avoid retagged releases that may no longer meet the quality of the original group
     - **{{ radarr['cf']['scene']['name'] }}:** [*Optional*] (use these only if you dislike scene releases)
     - **{{ radarr['cf']['x265-no-hdrdv']['name'] }}:** This blocks 720/1080p (HD) releases that are encoded in x265. - More info [HERE](/Misc/x265-4k/){:target="_blank" rel="noopener noreferrer"}.

--- a/includes/cf/radarr-optional.md
+++ b/includes/cf/radarr-optional.md
@@ -18,8 +18,8 @@
     - **{{ radarr['cf']['evo-no-webdl']['name'] }}:** This group is often banned for low-quality Blu-ray releases, but their WEB-DLs are okay.
     - **{{ radarr['cf']['no-rlsgroup']['name'] }}:** [*Optional*] Some indexers strip out the release group which could result in LQ groups being scored incorrectly. For example, a lot of EVO releases end up with a stripped group name. These releases would appear as "upgrades" and could end up getting a decent score after other CFs are scored.
     - **{{ radarr['cf']['obfuscated']['name'] }}:** [*Optional*] Use these only if you wish to avoid renamed releases.
-    - **{{ radarr['cf']['retags']['name'] }}:** [*Optional*] Use this only if you dislike retagged releases. This will help avoid retagged releases that may no longer meet the quality of the original group
-    - **{{ radarr['cf']['scene']['name'] }}:** [*Optional*] (use these only if you dislike scene releases)
+    - **{{ radarr['cf']['retags']['name'] }}:** [*Optional*] Use this if you want to avoid retagged releases. Retagged releases often are not consistent with the quality of the original group's release.
+    - **{{ radarr['cf']['scene']['name'] }}:** [*Optional*] Use this only if you want to avoid SCENE releases.
     - **{{ radarr['cf']['x265-no-hdrdv']['name'] }}:** This blocks 720/1080p (HD) releases that are encoded in x265. - More info [HERE](/Misc/x265-4k/){:target="_blank" rel="noopener noreferrer"}.
 
         **But it will allow x265 releases if they have HDR and/or DV**

--- a/includes/cf/radarr-optional.md
+++ b/includes/cf/radarr-optional.md
@@ -2,7 +2,6 @@
     | Custom Format                                                                                                       |                              Score                               | Trash ID                                          |
     | ------------------------------------------------------------------------------------------------------------------- | :--------------------------------------------------------------: | ------------------------------------------------- |
     | [{{ radarr['cf']['bad-dual-groups']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#bad-dual-groups)       | {{ radarr['cf']['bad-dual-groups']['trash_scores']['default'] }} | {{ radarr['cf']['bad-dual-groups']['trash_id'] }} |
-    | [{{ radarr['cf']['dv-webdl']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#dv-webdl)                     |                          :interrobang:                           | {{ radarr['cf']['dv-webdl']['trash_id'] }}        |
     | [{{ radarr['cf']['evo-no-webdl']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#evo-no-webdl)             |  {{ radarr['cf']['evo-no-webdl']['trash_scores']['default'] }}   | {{ radarr['cf']['evo-no-webdl']['trash_id'] }}    |
     | [{{ radarr['cf']['no-rlsgroup']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#no-rlsgroup)               |   {{ radarr['cf']['no-rlsgroup']['trash_scores']['default'] }}   | {{ radarr['cf']['no-rlsgroup']['trash_id'] }}     |
     | [{{ radarr['cf']['obfuscated']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#obfuscated)                 |   {{ radarr['cf']['obfuscated']['trash_scores']['default'] }}    | {{ radarr['cf']['obfuscated']['trash_id'] }}      |
@@ -16,24 +15,10 @@
 
     - **{{ radarr['cf']['bad-dual-groups']['name'] }}:** [*Optional*] These groups take the original release, then they add their own preferred language (ex. Portuguese) as the main audio track (AAC 2.0), What results after renaming and FFprobe that the media file will be recognized as Portuguese AAC audio. It's a common rule that you add the best audio as first.
     Also they often even rename the release name in to Portuguese.
-    - **{{ radarr['cf']['dv-webdl']['name'] }}:** This is a special Custom Format that Block WEBDL with Dolby Vision but without HDR10 fallback.
-
-        This Custom Format works together with the normal DV Custom Format that you can use to prefer Dolby Vision.
-
-        Most WEBDL from Streaming Services don't have the fallback to HDR10, What can results in playback issues like weird colors if you want to play it on a not Dolby Vision compatible setup.
-
-        Remuxes and Bluray have a fallback to HDR10.
-
-        !!! tip
-            `[DV WEBDL]` = This custom format you need to score depending of your personal use and setup.
-
-            - If you only watch your movies on a setup that completely supports Dolby Vision from start to end then give it a score of `0` or just don't add it.
-            - If you (or family members you share your collection with) have a setup that doesn't support Dolby Vision then you should add this with a score of `{{ radarr['cf']['dv-webdl']['trash_scores']['default'] }}`.
-
     - **{{ radarr['cf']['evo-no-webdl']['name'] }}:** This group is often banned for the low quality Blu-ray releases, but their WEB-DL are okay.
     - **{{ radarr['cf']['no-rlsgroup']['name'] }}:** [*Optional*] Some indexers strip out the release group what could result in LQ groups getting a higher score. For example a lot of EVO releases end up stripping the group name, so they appear as "upgrades", and they end up getting a decent score if other things match.
     - **{{ radarr['cf']['obfuscated']['name'] }}:** [*Optional*] (use these only if you dislike renamed releases)
-    - **{{ radarr['cf']['retags']['name'] }}:** [*Optional*] (use these only if you dislike retagged releases)
+    - **{{ radarr['cf']['retags']['name'] }}:** [*Optional*] Use this only if you dislike retagged releases. This will help avoid retagged releases that may no longer meet the quality of the original group
     - **{{ radarr['cf']['scene']['name'] }}:** [*Optional*] (use these only if you dislike scene releases)
     - **{{ radarr['cf']['x265-no-hdrdv']['name'] }}:** This blocks 720/1080p (HD) releases that are encoded in x265. - More info [HERE](/Misc/x265-4k/){:target="_blank" rel="noopener noreferrer"}.
 

--- a/includes/cf/sonarr-optional-uhd.md
+++ b/includes/cf/sonarr-optional-uhd.md
@@ -7,4 +7,4 @@
 
     Breakdown and Why
 
-    - **{{ sonarr['cf']['sdr']['name'] }}:** This will prevent grabbing UHD/4k releases without HDR Formats.
+    - **{{ sonarr['cf']['sdr']['name'] }}:** This will prevent the grabbing of UHD/4K releases that do not contain HDR.

--- a/includes/cf/sonarr-optional-uhd.md
+++ b/includes/cf/sonarr-optional-uhd.md
@@ -2,11 +2,9 @@
     | Custom Format                                                                               |                          Score                          | Trash ID                                 |
     | ------------------------------------------------------------------------------------------- | :-----------------------------------------------------: | ---------------------------------------- |
     | [{{ sonarr['cf']['sdr']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#sdr)       |  {{ sonarr['cf']['sdr']['trash_scores']['default'] }}   | {{ sonarr['cf']['sdr']['trash_id'] }}    |
-    | [{{ sonarr['cf']['retags']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#retags) | {{ sonarr['cf']['retags']['trash_scores']['default'] }} | {{ sonarr['cf']['retags']['trash_id'] }} |
 
     ------
 
     Breakdown and Why
 
-    - **{{ sonarr['cf']['sdr']['name'] }}:** This will help to prevent to grab UHD/4k releases without HDR Formats.
-    - **{{ sonarr['cf']['retags']['name'] }}:** This will help avoid retagged releases that may no longer meet the quality of the original group (e.g. TGx downsampling a NTb release from 5.1 audio to 2.0 audio yet maintain the NTb naming)
+    - **{{ sonarr['cf']['sdr']['name'] }}:** This will prevent grabbing UHD/4k releases without HDR Formats.

--- a/includes/cf/sonarr-optional.md
+++ b/includes/cf/sonarr-optional.md
@@ -1,10 +1,29 @@
-??? abstract "Optional (UHD) - [Click to show/hide]"
-    | Custom Format                                                                               |                          Score                          | Trash ID                                 |
-    | ------------------------------------------------------------------------------------------- | :-----------------------------------------------------: | ---------------------------------------- |
-    | [{{ sonarr['cf']['retags']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#retags) | {{ sonarr['cf']['retags']['trash_scores']['default'] }} | {{ sonarr['cf']['retags']['trash_id'] }} |
+??? abstract "Optional - [Click to show/hide]"
+    | Custom Format                                                                                                       |                              Score                               | Trash ID                                          |
+    | ------------------------------------------------------------------------------------------------------------------- | :--------------------------------------------------------------: | ------------------------------------------------- |
+    | [{{ sonarr['cf']['bad-dual-groups']['name'] }}](/Sonarr/Sonarr-collection-of-custom-formats/#bad-dual-groups)       | {{ sonarr['cf']['bad-dual-groups']['trash_scores']['default'] }} | {{ sonarr['cf']['bad-dual-groups']['trash_id'] }} |
+    | [{{ sonarr['cf']['no-rlsgroup']['name'] }}](/Sonarr/Sonarr-collection-of-custom-formats/#no-rlsgroup)               |   {{ sonarr['cf']['no-rlsgroup']['trash_scores']['default'] }}   | {{ sonarr['cf']['no-rlsgroup']['trash_id'] }}     |
+    | [{{ sonarr['cf']['obfuscated']['name'] }}](/Sonarr/Sonarr-collection-of-custom-formats/#obfuscated)                 |   {{ sonarr['cf']['obfuscated']['trash_scores']['default'] }}    | {{ sonarr['cf']['obfuscated']['trash_id'] }}      |
+    | [{{ sonarr['cf']['retags']['name'] }}](/Sonarr/Sonarr-collection-of-custom-formats/#retags)                         |     {{ sonarr['cf']['retags']['trash_scores']['default'] }}      | {{ sonarr['cf']['retags']['trash_id'] }}          |
+    | [{{ sonarr['cf']['scene']['name'] }}](/Sonarr/Sonarr-collection-of-custom-formats/#scene)                           |      {{ sonarr['cf']['scene']['trash_scores']['default'] }}      | {{ sonarr['cf']['scene']['trash_id'] }}           |
+    | [{{ sonarr['cf']['x265-no-hdrdv']['name'] }}](/Sonarr/Sonarr-collection-of-custom-formats/#x265-no-hdrdv) :warning: |  {{ sonarr['cf']['x265-no-hdrdv']['trash_scores']['default'] }}  | {{ sonarr['cf']['x265-no-hdrdv']['trash_id'] }}   |
 
     ------
 
     Breakdown and Why
 
-    - **{{ sonarr['cf']['retags']['name'] }}:** This will help avoid retagged releases that may no longer meet the quality of the original group (e.g. TGx downsampling a NTb release from 5.1 audio to 2.0 audio yet maintain the NTb naming)
+    - **{{ sonarr['cf']['bad-dual-groups']['name'] }}:** [*Optional*] These groups take the original release, then they add their own preferred language (ex. Portuguese) as the main audio track (AAC 2.0), What results after renaming and FFprobe that the media file will be recognized as Portuguese AAC audio. It's a common rule that you add the best audio as first.
+    Also they often even rename the release name in to Portuguese.
+    - **{{ sonarr['cf']['no-rlsgroup']['name'] }}:** [*Optional*] Some indexers strip out the release group what could result in LQ groups getting a higher score. For example a lot of EVO releases end up stripping the group name, so they appear as "upgrades", and they end up getting a decent score if other things match.
+    - **{{ sonarr['cf']['obfuscated']['name'] }}:** [*Optional*] (use these only if you dislike renamed releases)
+    - **{{ sonarr['cf']['retags']['name'] }}:** [*Optional*] Use this only if you dislike retagged releases. This will help avoid retagged releases that may no longer meet the quality of the original group (e.g. TGx downsampling a NTb release from 5.1 audio to 2.0 audio yet maintain the NTb naming)
+    - **{{ sonarr['cf']['scene']['name'] }}:** [*Optional*] (use these only if you dislike scene releases)
+    - **{{ sonarr['cf']['x265-no-hdrdv']['name'] }}:** This blocks 720/1080p (HD) releases that are encoded in x265. - More info [HERE](/Misc/x265-4k/){:target="_blank" rel="noopener noreferrer"}.
+
+        **But it will allow x265 releases if they have HDR and/or DV**
+
+        *Being that some NF releases won't be released as 4k, but you want to have DV/HDR releases.*
+
+        In your quality profile use the following score for this Custom Format: `{{ sonarr['cf']['x265-no-hdrdv']['trash_scores']['default'] }}`
+
+        !!! Danger "Don't use this together with [{{ sonarr['cf']['x265-hd']['name'] }}](/Sonarr/Sonarr-collection-of-custom-formats/#x265-hd), Only ever include one of them :warning:"

--- a/includes/cf/sonarr-optional.md
+++ b/includes/cf/sonarr-optional.md
@@ -1,12 +1,10 @@
 ??? abstract "Optional (UHD) - [Click to show/hide]"
     | Custom Format                                                                               |                          Score                          | Trash ID                                 |
     | ------------------------------------------------------------------------------------------- | :-----------------------------------------------------: | ---------------------------------------- |
-    | [{{ sonarr['cf']['sdr']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#sdr)       |  {{ sonarr['cf']['sdr']['trash_scores']['default'] }}   | {{ sonarr['cf']['sdr']['trash_id'] }}    |
     | [{{ sonarr['cf']['retags']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#retags) | {{ sonarr['cf']['retags']['trash_scores']['default'] }} | {{ sonarr['cf']['retags']['trash_id'] }} |
 
     ------
 
     Breakdown and Why
 
-    - **{{ sonarr['cf']['sdr']['name'] }}:** This will help to prevent to grab UHD/4k releases without HDR Formats.
     - **{{ sonarr['cf']['retags']['name'] }}:** This will help avoid retagged releases that may no longer meet the quality of the original group (e.g. TGx downsampling a NTb release from 5.1 audio to 2.0 audio yet maintain the NTb naming)

--- a/includes/cf/sonarr-optional.md
+++ b/includes/cf/sonarr-optional.md
@@ -12,18 +12,18 @@
 
     Breakdown and Why
 
-    - **{{ sonarr['cf']['bad-dual-groups']['name'] }}:** [*Optional*] These groups take the original release, then they add their own preferred language (ex. Portuguese) as the main audio track (AAC 2.0), What results after renaming and FFprobe that the media file will be recognized as Portuguese AAC audio. It's a common rule that you add the best audio as first.
-    Also they often even rename the release name in to Portuguese.
-    - **{{ sonarr['cf']['no-rlsgroup']['name'] }}:** [*Optional*] Some indexers strip out the release group what could result in LQ groups getting a higher score. For example a lot of EVO releases end up stripping the group name, so they appear as "upgrades", and they end up getting a decent score if other things match.
-    - **{{ sonarr['cf']['obfuscated']['name'] }}:** [*Optional*] (use these only if you dislike renamed releases)
-    - **{{ sonarr['cf']['retags']['name'] }}:** [*Optional*] Use this only if you dislike retagged releases. This will help avoid retagged releases that may no longer meet the quality of the original group (e.g. TGx downsampling a NTb release from 5.1 audio to 2.0 audio yet maintain the NTb naming)
-    - **{{ sonarr['cf']['scene']['name'] }}:** [*Optional*] (use these only if you dislike scene releases)
+    - **{{ sonarr['cf']['bad-dual-groups']['name'] }}:** [*Optional*] These groups take the original release and add their own language track (e.g. AAC 2.0 Portuguese) as the first track. Afterward, FFprobe would determine that the media file is Portuguese. It's a common rule that you only add the best audio as the main track.
+    Also they often even rename the release name into Portuguese.
+    - **{{ sonarr['cf']['no-rlsgroup']['name'] }}:** [*Optional*] Some indexers strip out the release group which could result in LQ groups being scored incorrectly. For example, a lot of EVO releases end up with a stripped group name. These releases would appear as "upgrades" and could end up getting a decent score after other CFs are scored.
+    - **{{ sonarr['cf']['obfuscated']['name'] }}:** [*Optional*] Use these only if you wish to avoid renamed releases.
+    - **{{ sonarr['cf']['retags']['name'] }}:** [*Optional*] Use this if you wish to avoid retagged releases. Retagged releases often are not consistent with the quality of the original group's release (e.g. TGx downsampling an NTb release from 5.1 audio to 2.0 audio, yet maintaining the NTb naming).
+    - **{{ sonarr['cf']['scene']['name'] }}:** [*Optional*] Use this only if you want to avoid SCENE releases.
     - **{{ sonarr['cf']['x265-no-hdrdv']['name'] }}:** This blocks 720/1080p (HD) releases that are encoded in x265. - More info [HERE](/Misc/x265-4k/){:target="_blank" rel="noopener noreferrer"}.
 
-        **But it will allow x265 releases if they have HDR and/or DV**
+        **This will allow x265 releases if they have HDR and/or DV**
 
         *Being that some NF releases won't be released as 4k, but you want to have DV/HDR releases.*
 
         In your quality profile use the following score for this Custom Format: `{{ sonarr['cf']['x265-no-hdrdv']['trash_scores']['default'] }}`
 
-        !!! Danger "Don't use this together with [{{ sonarr['cf']['x265-hd']['name'] }}](/Sonarr/Sonarr-collection-of-custom-formats/#x265-hd), Only ever include one of them :warning:"
+        !!! Danger "Don't use this combined with [{{ sonarr['cf']['x265-hd']['name'] }}](/Sonarr/Sonarr-collection-of-custom-formats/#x265-hd), Only ever apply one of them. :warning:"


### PR DESCRIPTION
# Pull Request

## Purpose

Add missing optional panels from public Radarr/Sonarr guide pages.
Fix: #1656 

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

- [x] review for other missing optionals in guide

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
