### PR TITLE
feat(Sonarr-fr): add `Seimeisen` to FR Anime FanSub

### DIFF
--- a/docs/json/sonarr/cf/french-anime-fansub.json
+++ b/docs/json/sonarr/cf/french-anime-fansub.json
@@ -70,6 +70,15 @@
       }
     },
     {
+      "name": "Seimeisen",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Seimeisen)\\b"
+      }
+    },
+    {
       "name": "Team Arcedo",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,


### PR DESCRIPTION
# Pull Request

## Purpose

Added the FR group `Seimeisen` to the FR Anime FanSub CF.

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
