### PR TITLE
feat(guides): Add 1XBET to LQ (Release Title)

### DIFF
--- a/docs/json/radarr/cf/lq-release-title.json
+++ b/docs/json/radarr/cf/lq-release-title.json
@@ -32,6 +32,15 @@
       "fields": {
         "value": "(?<!-)\\b(jennaortega(UHD)?)\\b"
       }
+    },
+    {
+      "name": "1XBET",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(1XBET)\\b"
+      }
     }
   ]
 }


### PR DESCRIPTION
# Pull Request

## Purpose

fix: #1678 

## Approach

- Add 1XBET release group to LQ (Release Title) custom format

## Open Questions and Pre-Merge TODOs

None

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
