### PR TITLE
chore(github): add automatic changelog

### DIFF
--- a/.github/configs/release-changelog-builder-action.json
+++ b/.github/configs/release-changelog-builder-action.json
@@ -1,0 +1,63 @@
+{
+  "categories": [
+      {
+          "title": "### Guide - Features",
+          "labels": ["type: enhancement", "type: guide request"],
+          "exhaustive": true
+      },
+      {
+          "title": "### Guide - Fixes",
+          "labels": ["type: bug"],
+          "exclude_labels": ["status: non issue"]
+      },
+      {
+          "title": "### Guide - Updates",
+          "labels": ["status: confirmed"]
+      },
+      {
+          "title": "### Radarr - Features",
+          "labels": ["area: radarr", "type: enhancement"],
+          "exhaustive": true
+      },
+      {
+          "title": "### Radarr - Fixes",
+          "labels": ["area: radarr", "type: bug"],
+          "exclude_labels": ["status: non issue"],
+          "exhaustive": true
+      },
+      {
+          "title": "### Radarr - Updates",
+          "labels": ["area: radarr"]
+      },
+      {
+          "title": "### Sonarr - Features",
+          "labels": ["area: sonarr", "type: enhancement"],
+          "exhaustive": true
+      },
+      {
+          "title": "### Sonarr - Fixes",
+          "labels": ["area: sonarr", "type: bug"],
+          "exclude_labels": ["status: non issue"],
+          "exhaustive": true
+      },
+      {
+          "title": "### Sonarr - Updates",
+          "labels": ["area: sonarr"]
+      },
+      {
+          "title": "### Others",
+          "labels": []
+      }
+  ],
+  "ignore_labels": ["status: declined"],
+  "sort": {
+      "order": "ASC",
+      "on_property": "title"
+  },
+  "template": "${{CHANGELOG}}\n${{UNCATEGORIZED}}",
+  "pr_template": "- [${{TITLE}}](${{URL}})",
+  "empty_template": "- no changes",
+  "base_branches": [
+    "master"
+  ]
+}

--- a/.github/workflows/changelog-builder.yml
+++ b/.github/workflows/changelog-builder.yml
@@ -1,0 +1,31 @@
+name: Release Creation
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # Build the changelog
+      - name: Build Changelog
+        id: build_changelog
+        uses: mikepenz/release-changelog-builder-action@v4
+        with:
+          configuration: ".github/configs/release-changelog-builder-action.json"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Change the update file
+      - name: Modify updates.txt
+        uses: jaywcjlove/github-action-modify-file-content@main
+        with:
+          path: docs/updates.txt
+          body: "#{{date:YYYY-MM-DD HH:mm}}\n${{ steps.build_changelog.outputs.changelog }}"
+          openDelimiter: ""
+          closeDelimiter: ""


### PR DESCRIPTION
# Pull Request

## Purpose

A potential way to Automate Changelog / ReleaseNotes / Github Version Tags

## Approach

Using the "Release Changelog Builder" and the "Modify File" Github Actions

## Open Questions and Pre-Merge TODOs

- [x] First draft
- [ ] Check if those work as attended
- [ ] Check format of changelog
- [ ] Get validation
- [ ] Polishing?

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
