### PR TITLE
fix(starr): DV HDR10 mismatching

### DIFF
--- a/docs/json/radarr/cf/dv-hdr10.json
+++ b/docs/json/radarr/cf/dv-hdr10.json
@@ -17,6 +17,15 @@
       }
     },
     {
+      "name": "Not DV HDR10Plus",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": true,
+      "required": true,
+      "fields": {
+        "value": "^(?=.*\\b(DV|DoVi|Dolby[ .]?V(ision)?)\\b)(?=.*\\b((HDR10(?=(P(lus)?)\\b|\\+))))"
+      }
+    },
+    {
       "name": "Not DV HLG",
       "implementation": "ReleaseTitleSpecification",
       "negate": true,

--- a/docs/json/sonarr/cf/dv-hdr10.json
+++ b/docs/json/sonarr/cf/dv-hdr10.json
@@ -17,6 +17,15 @@
       }
     },
     {
+      "name": "Not DV HDR10Plus",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": true,
+      "required": true,
+      "fields": {
+        "value": "^(?=.*\\b(DV|DoVi|Dolby[ .]?V(ision)?)\\b)(?=.*\\b((HDR10(?=(P(lus)?)\\b|\\+))))"
+      }
+    },
+    {
       "name": "Not DV HLG",
       "implementation": "ReleaseTitleSpecification",
       "negate": true,


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->
Fix `DV HDR10` CF matching on a file with `DV HDR10Plus` mediainfo after import.

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->
Negate `DV HDR10Plus` in the `DV HDR10` CF.

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
