### PR TITLE
fix(guides): Add DV HDR10Plus to Guides

### DIFF
--- a/includes/cf/radarr-all-hdr-formats.md
+++ b/includes/cf/radarr-all-hdr-formats.md
@@ -17,6 +17,7 @@
 
     | Custom Format                                                                                             |                             Score                              | Trash ID                                        |
     | --------------------------------------------------------------------------------------------------------- | :------------------------------------------------------------: | ----------------------------------------------- |
+    | [{{ radarr['cf']['dv-hdr10plus']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#dv-hdr10plus)   | {{ radarr['cf']['dv-hdr10plus']['trash_scores']['default'] }}  | {{ radarr['cf']['dv-hdr10plus']['trash_id'] }}  |
     | [{{ radarr['cf']['dv-hdr10']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#dv-hdr10)           |   {{ radarr['cf']['dv-hdr10']['trash_scores']['default'] }}    | {{ radarr['cf']['dv-hdr10']['trash_id'] }}      |
     | [{{ radarr['cf']['dv']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#dv)                       |      {{ radarr['cf']['dv']['trash_scores']['default'] }}       | {{ radarr['cf']['dv']['trash_id'] }}            |
     | [{{ radarr['cf']['dv-hlg']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#dv-hlg)               |    {{ radarr['cf']['dv-hlg']['trash_scores']['default'] }}     | {{ radarr['cf']['dv-hlg']['trash_id'] }}        |

--- a/includes/cf/sonarr-all-hdr-formats.md
+++ b/includes/cf/sonarr-all-hdr-formats.md
@@ -17,6 +17,7 @@
 
     | Custom Format                                                                                             |                             Score                              | Trash ID                                        |
     | --------------------------------------------------------------------------------------------------------- | :------------------------------------------------------------: | ----------------------------------------------- |
+    | [{{ sonarr['cf']['dv-hdr10plus']['name'] }}](/Sonarr/Sonarr-collection-of-custom-formats/#dv-hdr10plus)   | {{ sonarr['cf']['dv-hdr10plus']['trash_scores']['default'] }}  | {{ sonarr['cf']['dv-hdr10plus']['trash_id'] }}  |
     | [{{ sonarr['cf']['dv-hdr10']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#dv-hdr10)           |   {{ sonarr['cf']['dv-hdr10']['trash_scores']['default'] }}    | {{ sonarr['cf']['dv-hdr10']['trash_id'] }}      |
     | [{{ sonarr['cf']['dv']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#dv)                       |      {{ sonarr['cf']['dv']['trash_scores']['default'] }}       | {{ sonarr['cf']['dv']['trash_id'] }}            |
     | [{{ sonarr['cf']['dv-hlg']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#dv-hlg)               |    {{ sonarr['cf']['dv-hlg']['trash_scores']['default'] }}     | {{ sonarr['cf']['dv-hlg']['trash_id'] }}        |

--- a/includes/sqp/1-4k-cf-scoring-sqp1.md
+++ b/includes/sqp/1-4k-cf-scoring-sqp1.md
@@ -38,6 +38,7 @@
 
     | Custom Format                                                                                             |                             Score                              | Trash ID                                        |
     | --------------------------------------------------------------------------------------------------------- | :------------------------------------------------------------: | ----------------------------------------------- |
+    | [{{ radarr['cf']['dv-hdr10plus']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#dv-hdr10plus)   | {{ radarr['cf']['dv-hdr10plus']['trash_scores']['default'] }}  | {{ radarr['cf']['dv-hdr10plus']['trash_id'] }}  |
     | [{{ radarr['cf']['dv-hdr10']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#dv-hdr10)           |   {{ radarr['cf']['dv-hdr10']['trash_scores']['default'] }}    | {{ radarr['cf']['dv-hdr10']['trash_id'] }}      |
     | [{{ radarr['cf']['dv']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#dv)                       |      {{ radarr['cf']['dv']['trash_scores']['default'] }}       | {{ radarr['cf']['dv']['trash_id'] }}            |
     | [{{ radarr['cf']['dv-hlg']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#dv-hlg)               |    {{ radarr['cf']['dv-hlg']['trash_scores']['default'] }}     | {{ radarr['cf']['dv-hlg']['trash_id'] }}        |


### PR DESCRIPTION
# Pull Request

## Purpose

Fix missing DV HDR10Plus custom format on guide pages

## Approach

- Add new DV HDR10Plus custom format to relevant guide page HDR sections

## Open Questions and Pre-Merge TODOs

None

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).