### PR TITLE
feat(Radarr): add RlsGrp `Will1869` to `LQ (Release Title)`

### DIFF
--- a/docs/json/radarr/cf/lq-release-title.json
+++ b/docs/json/radarr/cf/lq-release-title.json
@@ -7,12 +7,12 @@
   "includeCustomFormatWhenRenaming": false,
   "specifications": [
     {
-      "name": "TeeWee",
+      "name": "1XBET",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,
       "required": false,
       "fields": {
-        "value": "\\b(TeeWee)\\b"
+        "value": "\\b(1XBET)\\b"
       }
     },
     {
@@ -34,12 +34,21 @@
       }
     },
     {
-      "name": "1XBET",
+      "name": "TeeWee",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,
       "required": false,
       "fields": {
-        "value": "\\b(1XBET)\\b"
+        "value": "\\b(TeeWee)\\b"
+      }
+    },
+    {
+      "name": "Will1869",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Will1869)\\b"
       }
     }
   ]


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->

does a lot of cam/prerips where he merges video from one region with audio from cam to produce releases that still just aren't great and have issues half the time

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

Add RlsGrp `Will1869` to `LQ (Release Title)`

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
