### PR TITLE
fix(Starr): renamed CF `DV (FEL)` to `DV (Disk)`

### DIFF
--- a/docs/Radarr/Radarr-collection-of-custom-formats.md
+++ b/docs/Radarr/Radarr-collection-of-custom-formats.md
@@ -87,7 +87,7 @@ I also made 3 guides related to this one.
 |                                | [AV1](#av1)                         | [VQ](#vq)                     | [FR LQ](#fr-lq)                                 |
 |                                | [SDR](#sdr)                         | [VFB](#vfb)                   |                                                 |
 |                                | [SDR (no WEBDL)](#sdr-no-webdl)     | [VOSTFR](#vostfr)             |                                                 |
-|                                | [DV (FEL)](#dv-fel)                 | [FanSUB](#fansub)             |                                                 |
+|                                | [DV (Disk)](#dv-disk)               | [FanSUB](#fansub)             |                                                 |
 |                                | [Line/Mic Dubbed](#linemic-dubbed)  | [FastSUB](#fastsub)           |                                                 |
 |                                | [HFR](#hfr)                         |                               |                                                 |
 |                                | [VP9](#vp9)                         |                               |                                                 |
@@ -1323,14 +1323,14 @@ I also made 3 guides related to this one.
 
 ### DV FEL
 
-??? question "DV (FEL) - [Click to show/hide]"
+??? question "DV (Disk) - [Click to show/hide]"
 
     - This will boost the score for Dolby Vision Releases using the original full quality Dolby Vision layer from the disc release to replace the old WEBDL HYBRID release.
 
 ??? example "JSON - [Click to show/hide]"
 
     ```json
-    [[% filter indent(width=4) %]][[% include 'json/radarr/cf/dv-fel.json' %]][[% endfilter %]]
+    [[% filter indent(width=4) %]][[% include 'json/radarr/cf/dv-disk.json' %]][[% endfilter %]]
     ```
 
 <sub><sup>[TOP](#index)</sup>

--- a/docs/Radarr/Radarr-collection-of-custom-formats.md
+++ b/docs/Radarr/Radarr-collection-of-custom-formats.md
@@ -1321,7 +1321,7 @@ I also made 3 guides related to this one.
 
 ------
 
-### DV FEL
+### DV (Disk)
 
 ??? question "DV (Disk) - [Click to show/hide]"
 

--- a/docs/Sonarr/sonarr-collection-of-custom-formats.md
+++ b/docs/Sonarr/sonarr-collection-of-custom-formats.md
@@ -1250,7 +1250,7 @@ I also made 3 guides related to this one.
 
 ------
 
-### DV FEL
+### DV (Disk)
 
 ??? question "DV (Disk) - [Click to show/hide]"
 

--- a/docs/Sonarr/sonarr-collection-of-custom-formats.md
+++ b/docs/Sonarr/sonarr-collection-of-custom-formats.md
@@ -96,7 +96,7 @@ I also made 3 guides related to this one.
 |                                | [AV1](#av1)                         | [VQ](#vq)                     | [FR Scene Groups](#fr-scene-groups)           |
 |                                | [SDR](#sdr)                         | [VFB](#vfb)                   | [FR LQ](#fr-lq)                               |
 |                                | [SDR (no WEBDL)](#sdr-no-webdl)     | [VOSTFR](#vostfr)             |                                               |
-|                                | [DV (FEL)](#dv-fel)                 | [FanSUB](#fansub)             |                                               |
+|                                | [DV (Disk)](#dv-disk)               | [FanSUB](#fansub)             |                                               |
 |                                | [HFR](#hfr)                         | [FastSUB](#fastsub)           |                                               |
 |                                | [VP9](#vp9)                         |                               |                                               |
 
@@ -1252,14 +1252,14 @@ I also made 3 guides related to this one.
 
 ### DV FEL
 
-??? question "DV (FEL) - [Click to show/hide]"
+??? question "DV (Disk) - [Click to show/hide]"
 
     - This will boost the score for Dolby Vision Releases using the original full quality Dolby Vision layer from the disc release to replace the old WEBDL HYBRID release.
 
 ??? example "JSON - [Click to show/hide]"
 
     ```json
-    [[% filter indent(width=4) %]][[% include 'json/sonarr/cf/dv-fel.json' %]][[% endfilter %]]
+    [[% filter indent(width=4) %]][[% include 'json/sonarr/cf/dv-disk.json' %]][[% endfilter %]]
     ```
 
 <sub><sup>[TOP](#index)</sup>

--- a/docs/json/radarr/cf/dv-disk.json
+++ b/docs/json/radarr/cf/dv-disk.json
@@ -3,7 +3,7 @@
   "trash_scores": {
     "default": 101
   },
-  "name": "DV (FEL)",
+  "name": "DV (Disk)",
   "includeCustomFormatWhenRenaming": false,
   "specifications": [
     {

--- a/docs/json/sonarr/cf/dv-disk.json
+++ b/docs/json/sonarr/cf/dv-disk.json
@@ -3,7 +3,7 @@
   "trash_scores": {
     "default": 101
   },
-  "name": "DV (FEL)",
+  "name": "DV (Disk)",
   "includeCustomFormatWhenRenaming": false,
   "specifications": [
     {

--- a/includes/sqp/uhd-radarr-optional.md
+++ b/includes/sqp/uhd-radarr-optional.md
@@ -15,7 +15,7 @@
     | [{{ radarr['cf']['scene']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#scene)                           | {{ radarr['cf']['scene']['trash_scores']['default'] }}           | {{ radarr['cf']['scene']['trash_id'] }}           |
     | [{{ radarr['cf']['x265-no-hdrdv']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#x265-no-hdrdv) :warning: | {{ radarr['cf']['x265-no-hdrdv']['trash_scores']['default'] }}   | {{ radarr['cf']['x265-no-hdrdv']['trash_id'] }}   |
     | [{{ radarr['cf']['sdr']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#sdr)                               | {{ radarr['cf']['sdr']['trash_scores']['default'] }}             | {{ radarr['cf']['sdr']['trash_id'] }}             |
-    | [{{ radarr['cf']['dv-fel']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#dv-fel)                         | {{ radarr['cf']['dv-fel']['trash_scores']['default'] }}          | {{ radarr['cf']['dv-fel']['trash_id'] }}          |
+    | [{{ radarr['cf']['dv-disk']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#dv-disk)                       | {{ radarr['cf']['dv-disk']['trash_scores']['default'] }}         | {{ radarr['cf']['dv-disk']['trash_id'] }}         |
 
     ------
 
@@ -54,4 +54,4 @@
         !!! Danger "Don't use this together with [{{ radarr['cf']['x265-hd']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#x265-hd), Only ever include one of them :warning:"
 
     - **{{ radarr['cf']['sdr']['name'] }}:** This will help to prevent to grab UHD/4k releases without HDR Formats.
-    - **{{ radarr['cf']['dv-fel']['name'] }}:** This will boost the score for Dolby Vision Releases using the original full quality Dolby Vision layer from the disc release to replace the old WEBDL HYBRID release.
+    - **{{ radarr['cf']['dv-disk']['name'] }}:** This will boost the score for Dolby Vision Releases using the original full quality Dolby Vision layer from the disc release to replace the old WEBDL HYBRID release.


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->

We once created this CF mainly for framestor releases where they released after their hybrid (DV HDR10) from the steaming services a new release using the DV layer from a new released disk.
We did some research and most disk version had FEL but it could also be MEL. Because we can't be 100% sure what's used we decided to rename it to `DV (Disk)`

**NOTE:** If other RlsGrps have a consistent naming and a way we can figure out the difference between DV hybrid vs the original DV layer from the disk, we are willing to add them.

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

- [x] Renamed CF `DV (FEL)` to `DV (Disk)` for Radarr
- [x] Renamed CF `DV (FEL)` to `DV (Disk)` for Sonarr

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
