### PR TITLE
fix(radarr): 3D CF should match BD3D

### DIFF
--- a/docs/json/radarr/cf/3d.json
+++ b/docs/json/radarr/cf/3d.json
@@ -3,6 +3,7 @@
   "trash_scores": {
     "default": -10000
   },
+  "trash_regex": "https://regex101.com/r/hpjKw9/1",
   "name": "3D",
   "includeCustomFormatWhenRenaming": false,
   "specifications": [

--- a/docs/json/radarr/cf/3d.json
+++ b/docs/json/radarr/cf/3d.json
@@ -23,6 +23,15 @@
       "fields": {
         "value": "\\b(BluRay3D)\\b"
       }
+    },
+    {
+      "name": "BD3D",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(BD3D)\\b"
+      }
     }
   ]
 }


### PR DESCRIPTION
# Pull Request

## Purpose

Some releases include `BD3D` to indicate they're 3D instead of the existing specifications.

## Approach

Adds a BD3D spec to the existing 3d cf.

## Open Questions and Pre-Merge TODOs

- [ ] Add the regex to the existing `BluRay3D` spec instead of creating a new spec?
  - [ ]  `\\b((BluRay|BD)3D)\\b` or `\\b(BluRay3D|BD3D)\\b`

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
