### PR TITLE
feat(starr): add rlsgrp `vnlls` to `Bad Dual Groups`

### DIFF
--- a/docs/json/radarr/cf/bad-dual-groups.json
+++ b/docs/json/radarr/cf/bad-dual-groups.json
@@ -7,230 +7,239 @@
   "name": "Bad Dual Groups",
   "includeCustomFormatWhenRenaming": false,
   "specifications": [
-  {
-    "name": "alfaHD",
-    "implementation": "ReleaseGroupSpecification",
-    "negate": false,
-    "required": false,
-    "fields": {
-      "value": "^(alfaHD.*)$"
+    {
+      "name": "alfaHD",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(alfaHD.*)$"
+      }
+    },
+    {
+      "name": "BAT",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(BAT)$"
+      }
+    },
+    {
+      "name": "BlackBit",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(BlackBit)$"
+      }
+    },
+    {
+      "name": "BNd",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(BNd)$"
+      }
+    },
+    {
+      "name": "C.A.A",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(C\\.A\\.A)$"
+      }
+    },
+    {
+      "name": "Cory",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(Cory)$"
+      }
+    },
+    {
+      "name": "EXTREME",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(EXTREME)$"
+      }
+    },
+    {
+      "name": "FF",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(FF)$"
+      }
+    },
+    {
+      "name": "FOXX",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(FOXX)$"
+      }
+    },
+    {
+      "name": "G4RiS",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(G4RiS)$"
+      }
+    },
+    {
+      "name": "GUEIRA",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(GUEIRA)$"
+      }
+    },
+    {
+      "name": "N3G4N",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(N3G4N)$"
+      }
+    },
+    {
+      "name": "ONLYMOViE",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(ONLYMOViE)$"
+      }
+    },
+    {
+      "name": "PD",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(PD)$"
+      }
+    },
+    {
+      "name": "PTHome",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(PTHome)$"
+      }
+    },
+    {
+      "name": "RiPER",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(RiPER)$"
+      }
+    },
+    {
+      "name": "RK",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(RK)$"
+      }
+    },
+    {
+      "name": "SiGLA",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(SiGLA)$"
+      }
+    },
+    {
+      "name": "Tars",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(Tars)$"
+      }
+    },
+    {
+      "name": "TvR",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(TvR)$"
+      }
+    },
+    {
+      "name": "vnlls",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(vnlls)$"
+      }
+    },
+    {
+      "name": "WTV",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(WTV)$"
+      }
+    },
+    {
+      "name": "Yatogam1",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(Yatogam1)$"
+      }
+    },
+    {
+      "name": "YusukeFLA",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(YusukeFLA)$"
+      }
+    },
+    {
+      "name": "ZigZag",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(ZigZag)$"
+      }
+    },
+    {
+      "name": "ZNM",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(ZNM)$"
+      }
     }
-  },
-  {
-    "name": "BAT",
-    "implementation": "ReleaseGroupSpecification",
-    "negate": false,
-    "required": false,
-    "fields": {
-      "value": "^(BAT)$"
-    }
-  },
-  {
-    "name": "BlackBit",
-    "implementation": "ReleaseGroupSpecification",
-    "negate": false,
-    "required": false,
-    "fields": {
-      "value": "^(BlackBit)$"
-    }
-  },
-  {
-    "name": "BNd",
-    "implementation": "ReleaseGroupSpecification",
-    "negate": false,
-    "required": false,
-    "fields": {
-      "value": "^(BNd)$"
-    }
-  },
-  {
-    "name": "C.A.A",
-    "implementation": "ReleaseGroupSpecification",
-    "negate": false,
-    "required": false,
-    "fields": {
-      "value": "^(C\\.A\\.A)$"
-    }
-  },
-  {
-    "name": "Cory",
-    "implementation": "ReleaseGroupSpecification",
-    "negate": false,
-    "required": false,
-    "fields": {
-      "value": "^(Cory)$"
-    }
-  },
-  {
-    "name": "EXTREME",
-    "implementation": "ReleaseGroupSpecification",
-    "negate": false,
-    "required": false,
-    "fields": {
-      "value": "^(EXTREME)$"
-    }
-  },
-  {
-    "name": "FF",
-    "implementation": "ReleaseGroupSpecification",
-    "negate": false,
-    "required": false,
-    "fields": {
-      "value": "^(FF)$"
-    }
-  },
-  {
-    "name": "FOXX",
-    "implementation": "ReleaseGroupSpecification",
-    "negate": false,
-    "required": false,
-    "fields": {
-      "value": "^(FOXX)$"
-    }
-  },
-  {
-    "name": "G4RiS",
-    "implementation": "ReleaseGroupSpecification",
-    "negate": false,
-    "required": false,
-    "fields": {
-      "value": "^(G4RiS)$"
-    }
-  },
-  {
-    "name": "GUEIRA",
-    "implementation": "ReleaseGroupSpecification",
-    "negate": false,
-    "required": false,
-    "fields": {
-      "value": "^(GUEIRA)$"
-    }
-  },
-  {
-    "name": "N3G4N",
-    "implementation": "ReleaseGroupSpecification",
-    "negate": false,
-    "required": false,
-    "fields": {
-      "value": "^(N3G4N)$"
-    }
-  },
-  {
-    "name": "ONLYMOViE",
-    "implementation": "ReleaseGroupSpecification",
-    "negate": false,
-    "required": false,
-    "fields": {
-      "value": "^(ONLYMOViE)$"
-    }
-  },
-  {
-    "name": "PD",
-    "implementation": "ReleaseGroupSpecification",
-    "negate": false,
-    "required": false,
-    "fields": {
-      "value": "^(PD)$"
-    }
-  },
-  {
-    "name": "PTHome",
-    "implementation": "ReleaseGroupSpecification",
-    "negate": false,
-    "required": false,
-    "fields": {
-      "value": "^(PTHome)$"
-    }
-  },
-  {
-    "name": "RiPER",
-    "implementation": "ReleaseGroupSpecification",
-    "negate": false,
-    "required": false,
-    "fields": {
-      "value": "^(RiPER)$"
-    }
-  },
-  {
-    "name": "RK",
-    "implementation": "ReleaseGroupSpecification",
-    "negate": false,
-    "required": false,
-    "fields": {
-      "value": "^(RK)$"
-    }
-  },
-  {
-    "name": "SiGLA",
-    "implementation": "ReleaseGroupSpecification",
-    "negate": false,
-    "required": false,
-    "fields": {
-      "value": "^(SiGLA)$"
-    }
-  },
-  {
-    "name": "Tars",
-    "implementation": "ReleaseGroupSpecification",
-    "negate": false,
-    "required": false,
-    "fields": {
-      "value": "^(Tars)$"
-    }
-  },
-  {
-    "name": "TvR",
-    "implementation": "ReleaseGroupSpecification",
-    "negate": false,
-    "required": false,
-    "fields": {
-      "value": "^(TvR)$"
-    }
-  },
-  {
-    "name": "WTV",
-    "implementation": "ReleaseGroupSpecification",
-    "negate": false,
-    "required": false,
-    "fields": {
-      "value": "^(WTV)$"
-    }
-  },
-  {
-    "name": "Yatogam1",
-    "implementation": "ReleaseGroupSpecification",
-    "negate": false,
-    "required": false,
-    "fields": {
-      "value": "^(Yatogam1)$"
-    }
-  },
-  {
-    "name": "YusukeFLA",
-    "implementation": "ReleaseGroupSpecification",
-    "negate": false,
-    "required": false,
-    "fields": {
-      "value": "^(YusukeFLA)$"
-    }
-  },
-  {
-    "name": "ZigZag",
-    "implementation": "ReleaseGroupSpecification",
-    "negate": false,
-    "required": false,
-    "fields": {
-      "value": "^(ZigZag)$"
-    }
-  },
-  {
-    "name": "ZNM",
-    "implementation": "ReleaseGroupSpecification",
-    "negate": false,
-    "required": false,
-    "fields": {
-      "value": "^(ZNM)$"
-    }
-  }
-]
+  ]
 }

--- a/docs/json/sonarr/cf/bad-dual-groups.json
+++ b/docs/json/sonarr/cf/bad-dual-groups.json
@@ -170,6 +170,15 @@
       }
     },
     {
+      "name": "vnlls",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(vnlls)$"
+      }
+    },
+    {
       "name": "WTV",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->

This group adds Portuguese as the default audio and subtitle language

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

Add them to CF `Bad Dual Groups`

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
