### PR TITLE
feat(radarr:) Remove `LEGi0N` from UHD Blu-ray Tier 03

### DIFF
--- a/docs/json/radarr/cf/uhd-bluray-tier-03.json
+++ b/docs/json/radarr/cf/uhd-bluray-tier-03.json
@@ -64,15 +64,6 @@
       }
     },
     {
-      "name": "LEGi0N",
-      "implementation": "ReleaseGroupSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "^(LEGi0N)$"
-      }
-    },
-    {
       "name": "SPHD",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,


### PR DESCRIPTION
# Pull Request

## Purpose

Remove `LEGi0N` from UHD Bluray Tier 03

## Approach

- Remove `LEGi0N` section from `uhd-bluray-tier-03.json`

## Open Questions and Pre-Merge TODOs

- [ ] Update changelog

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
