### PR TITLE
build(strict-mode): comments and strict mode for broken link build failure

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -84,7 +84,7 @@ plugins:
       j2_variable_end_string: "]]"
   - redirects:
       redirect_maps:
-        updates.txt: updates.txt
+        #updates.txt: updates.txt
         discord.md: https://discord.gg/4K2kdvwzFh
         syno-script.md: https://github.com/TRaSH-/Guides-Synology-Templates/blob/main/script/trash_syno_installer.sh
         # Radarr redirects

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,10 +6,14 @@ site_url: https://trash-guides.info/
 repo_url: https://github.com/TRaSH-Guides/Guides
 repo_name: TRaSH-Guides
 
+# ignores absolute warnings we have
+# warns on missing/broken links
 validation:
   omitted_files: warn
   not_found: warn
   absolute_links: ignore
+# fails to build on warnings
+strict: true
 
 copyright: Copyright &copy; 2022 TRaSH
 


### PR DESCRIPTION
# Pull Request

## Purpose

currently we have no warnings on building that would affect building, this adds strict mode in mkdocs.yml and will fail building if broken links or previously unfound warnings are introduced

after adding the validation settings to ignore absolute, this should not be an issue unless new warnings or broken links are introduced

## Approach

https://mkdocs.readthedocs.io/en/0.13.3/user-guide/configuration/?q=strict&check_keywords=yes&area=default#strict

- [x] tested against broken links and normal build - functions as intended


## TODO
- [x] fix the following errors
```
WARNING -  redirects plugin: 'updates.txt' is not a valid markdown file!
WARNING -  Redirect target 'updates.txt' does not exist!
```
it is possible that the map in redirects (mkdocs.yml) actually is doing nothing based on these errors - besides warning - and its mere existence in the docs directory is why it works?

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
