### PR TITLE
fix(cf-collection): BBC iPlayer named in collection table

### DIFF
--- a/docs/Radarr/Radarr-collection-of-custom-formats.md
+++ b/docs/Radarr/Radarr-collection-of-custom-formats.md
@@ -52,13 +52,13 @@ I also made 3 guides related to this one.
 | --------------------------------------------- | --------------------------------------- | ----------------------------------------- | -------------------------- |
 | [Hybrid](#hybrid)                             | [BR-DISK](#br-disk)                     | [Remux Tier 01](#remux-tier-01)           | [Amazon](#amzn)            |
 | [Remaster](#remaster)                         | [LQ](#lq)                               | [Remux Tier 02](#remux-tier-02)           | [Apple TV+](#atvp)         |
-| [4K Remaster](#4k-remaster)                   | [LQ (Release Title)](#lq-release-title) | [Remux Tier 03](#remux-tier-03)           | [Criterion Channel](#crit) |
-| [Special Edition](#special-edition)           | [3D](#3d)                               | [UHD Bluray Tier 01](#uhd-bluray-tier-01) | [Disney+](#dsnp)           |
-| [Criterion Collection](#criterion-collection) | [x265 (HD)](#x265-hd)                   | [UHD Bluray Tier 02](#uhd-bluray-tier-02) | [HBO](#hbo)                |
-| [Masters of Cinema](#masters-of-cinema)       | [Upscaled](#upscaled)                   | [UHD Bluray Tier 03](#uhd-bluray-tier-03) | [HBO Max](#hmax)           |
-| [Vinegar Syndrome](#vinegar-syndrome)         | [Extras](#extras)                       | [HD Bluray Tier 01](#hd-bluray-tier-01)   | [Max](#max)                |
+| [4K Remaster](#4k-remaster)                   | [LQ (Release Title)](#lq-release-title) | [Remux Tier 03](#remux-tier-03)           | [BBC iPlayer (iP)](#ip)    |
+| [Special Edition](#special-edition)           | [3D](#3d)                               | [UHD Bluray Tier 01](#uhd-bluray-tier-01) | [Criterion Channel](#crit) |
+| [Criterion Collection](#criterion-collection) | [x265 (HD)](#x265-hd)                   | [UHD Bluray Tier 02](#uhd-bluray-tier-02) | [Disney+](#dsnp)           |
+| [Masters of Cinema](#masters-of-cinema)       | [Upscaled](#upscaled)                   | [UHD Bluray Tier 03](#uhd-bluray-tier-03) | [HBO](#hbo)                |
+| [Vinegar Syndrome](#vinegar-syndrome)         | [Extras](#extras)                       | [HD Bluray Tier 01](#hd-bluray-tier-01)   | [HBO Max](#hmax)           |
 | [Theatrical Cut](#theatrical-cut)             |                                         | [HD Bluray Tier 02](#hd-bluray-tier-02)   | [Hulu](#hulu)              |
-| [IMAX](#imax)                                 |                                         | [HD Bluray Tier 03](#hd-bluray-tier-03)   | [IP](#ip)                  |
+| [IMAX](#imax)                                 |                                         | [HD Bluray Tier 03](#hd-bluray-tier-03)   | [Max](#max)                |
 | [IMAX Enhanced](#imax-enhanced)               |                                         | [WEB Tier 01](#web-tier-01)               | [Netflix](#nf)             |
 | [Open Matte](#open-matte)                     |                                         | [WEB Tier 02](#web-tier-02)               | [Peacock TV](#pcok)        |
 |                                               |                                         | [WEB Tier 03](#web-tier-03)               | [Paramount+](#pmtp)        |

--- a/docs/Sonarr/sonarr-collection-of-custom-formats.md
+++ b/docs/Sonarr/sonarr-collection-of-custom-formats.md
@@ -50,13 +50,13 @@ I also made 3 guides related to this one.
 | --------------------- | --------------------------------------- | --------------------------------------- | ------------------------------------------- |
 | [Hybrid](#hybrid)     | [BR-DISK](#br-disk)                     | [Remux Tier 01](#remux-tier-01)         | [Amazon](#amzn)                             |
 | [Remaster](#remaster) | [LQ](#lq)                               | [Remux Tier 02](#remux-tier-02)         | [Apple TV+](#atvp)                          |
-|                       | [LQ (Release Title)](#lq-release-title) | [HD Bluray Tier 01](#hd-bluray-tier-01) | [DC Universe](#dcu)                         |
-|                       | [x265 (HD)](#x265-hd)                   | [HD Bluray Tier 02](#hd-bluray-tier-02) | [Disney+](#dsnp)                            |
-|                       | [Extras](#extras)                       | [WEB Tier 01](#web-tier-01)             | [HBO Max](#hmax)                            |
+|                       | [LQ (Release Title)](#lq-release-title) | [HD Bluray Tier 01](#hd-bluray-tier-01) | [BBC iPlayer (iP)](#ip)                     |
+|                       | [x265 (HD)](#x265-hd)                   | [HD Bluray Tier 02](#hd-bluray-tier-02) | [DC Universe](#dcu)                         |
+|                       | [Extras](#extras)                       | [WEB Tier 01](#web-tier-01)             | [Disney+](#dsnp)                            |
 |                       |                                         | [WEB Tier 02](#web-tier-02)             | [HBO](#hbo)                                 |
-|                       |                                         | [WEB Tier 03](#web-tier-03)             | [Max](#max)                                 |
+|                       |                                         | [WEB Tier 03](#web-tier-03)             | [HBO Max](#hmax)                            |
 |                       |                                         | [WEB Scene](#web-scene)                 | [Hulu](#hulu)                               |
-|                       |                                         |                                         | [IP](#ip)                                   |
+|                       |                                         |                                         | [Max](#max)                                 |
 |                       |                                         |                                         | [NLZiet](#nlz)                              |
 |                       |                                         |                                         | [Netflix](#nf)                              |
 |                       |                                         |                                         | [Paramount+](#pmtp)                         |


### PR DESCRIPTION
# Pull Request

## Purpose

specifies full streaming service name for BBC iPlayer in collections tables

## Approach

rename and sorted to B's spot in the list/table

## Future PR TODO

- Needs entire list sorted

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
