### PR TITLE
update(cf/repack-proper): separate repack and proper cfs in sonarr/radarr

### DIFF
--- a/docs/Radarr/Radarr-collection-of-custom-formats.md
+++ b/docs/Radarr/Radarr-collection-of-custom-formats.md
@@ -18,7 +18,7 @@ I also made 3 guides related to this one.
 
     I also suggest changing the Propers and Repacks settings in Radarr
 
-    `Media Management` => `File Management` to `Do Not Prefer` and use the [Repack and Proper](#proper) Custom Format.
+    `Media Management` => `File Management` to `Do Not Prefer` and use the [Repack](#repack) and [Proper](#proper) Custom Format.
 
     ![!cf-mm-propers-repacks-disable](images/cf-mm-propers-repacks-disable.png)
 

--- a/docs/Radarr/Radarr-collection-of-custom-formats.md
+++ b/docs/Radarr/Radarr-collection-of-custom-formats.md
@@ -18,7 +18,7 @@ I also made 3 guides related to this one.
 
     I also suggest changing the Propers and Repacks settings in Radarr
 
-    `Media Management` => `File Management` to `Do Not Prefer` and use the [Repack](#repack) and [Proper](#proper) Custom Format.
+    `Media Management` => `File Management` to `Do Not Prefer` and use the [Repack](#repack) and [Proper](#proper) Custom Formats.
 
     ![!cf-mm-propers-repacks-disable](images/cf-mm-propers-repacks-disable.png)
 

--- a/docs/Radarr/Radarr-collection-of-custom-formats.md
+++ b/docs/Radarr/Radarr-collection-of-custom-formats.md
@@ -16,9 +16,9 @@ I also made 3 guides related to this one.
 
 !!! tip
 
-    I also suggest to change the Propers and Repacks settings in Radarr
+    I also suggest changing the Propers and Repacks settings in Radarr
 
-    `Media Management` => `File Management` to `Do Not Prefer` and use the [Repack/Proper](#repackproper) Custom Format.
+    `Media Management` => `File Management` to `Do Not Prefer` and use the [Repack and Proper](#proper) Custom Format.
 
     ![!cf-mm-propers-repacks-disable](images/cf-mm-propers-repacks-disable.png)
 
@@ -74,25 +74,25 @@ I also made 3 guides related to this one.
 
 ------
 
-| Misc                           | Optional                            | French Audio Version          | French Source Groups                            |
-| ------------------------------ | ----------------------------------- | ----------------------------- | ----------------------------------------------- |
-| [Dutch Groups](#dutch-groups)  | [AV1](#av1)                         | [Multi-French](#multi-french) | [FR Remux Tier 01](#fr-remux-tier-01)           |
-| [FreeLeech](#freeleech)        | [Bad Dual Groups](#bad-dual-groups) | [Multi-Audio](#multi-audio)   | [FR Remux Tier 02](#fr-remux-tier-02)           |
-| [MPEG2](#mpeg2)                | [DV (Disk)](#dv-disk)               | [French Audio](#french-audio) | [FR UHD Bluray Tier 01](#fr-uhd-bluray-tier-01) |
-| [Multi](#multi)                | [DV (WEBDL)](#dv-webdl)             | [VFF](#vff)                   | [FR UHD Bluray Tier 02](#fr-uhd-bluray-tier-02) |
-| [Repack/Proper](#repackproper) | [EVO (no WEBDL)](#evo-no-webdl)     | [VOF](#vof)                   | [FR HD Bluray Tier 01](#fr-hd-bluray-tier-01)   |
-| [Repack2](#repack2)            | [HDR10+ Boost](#hdr10plus-boost)    | [VFI](#vfi)                   | [FR HD Bluray Tier 02](#fr-hd-bluray-tier-02)   |
-| [x264](#x264)                  | [HFR](#hfr)                         | [VF2](#vf2)                   | [FR WEB Tier 01](#fr-web-tier-01)               |
-| [x265](#x265)                  | [Internal](#internal)               | [VFQ](#vfq)                   | [FR WEB Tier 02](#fr-web-tier-02)               |
-|                                | [Line/Mic Dubbed](#linemic-dubbed)  | [VOQ](#voq)                   | [FR Scene Groups](#fr-scene-groups)             |
-|                                | [No-RlsGroup](#no-rlsgroup)         | [VQ](#vq)                     | [FR LQ](#fr-lq)                                 |
-|                                | [Obfuscated](#obfuscated)           | [VFB](#vfb)                   |                                                 |
-|                                | [Retags](#retags)                   | [VOSTFR](#vostfr)             |                                                 |
-|                                | [Scene](#scene)                     | [FanSUB](#fansub)             |                                                 |
-|                                | [SDR (no WEBDL)](#sdr-no-webdl)     | [FastSUB](#fastsub)           |                                                 |
-|                                | [SDR](#sdr)                         |                               |                                                 |
-|                                | [VP9](#vp9)                         |                               |                                                 |
-|                                | [x265 (no HDR/DV)](#x265-no-hdrdv)  |                               |                                                 |
+| Misc                          | Optional                            | French Audio Version          | French Source Groups                            |
+| ----------------------------- | ----------------------------------- | ----------------------------- | ----------------------------------------------- |
+| [Dutch Groups](#dutch-groups) | [AV1](#av1)                         | [Multi-French](#multi-french) | [FR Remux Tier 01](#fr-remux-tier-01)           |
+| [FreeLeech](#freeleech)       | [Bad Dual Groups](#bad-dual-groups) | [Multi-Audio](#multi-audio)   | [FR Remux Tier 02](#fr-remux-tier-02)           |
+| [MPEG2](#mpeg2)               | [DV (Disk)](#dv-disk)               | [French Audio](#french-audio) | [FR UHD Bluray Tier 01](#fr-uhd-bluray-tier-01) |
+| [Multi](#multi)               | [DV (WEBDL)](#dv-webdl)             | [VFF](#vff)                   | [FR UHD Bluray Tier 02](#fr-uhd-bluray-tier-02) |
+| [Proper](#proper)             | [EVO (no WEBDL)](#evo-no-webdl)     | [VOF](#vof)                   | [FR HD Bluray Tier 01](#fr-hd-bluray-tier-01)   |
+| [Repack](#repack)             | [HDR10+ Boost](#hdr10plus-boost)    | [VFI](#vfi)                   | [FR HD Bluray Tier 02](#fr-hd-bluray-tier-02)   |
+| [Repack2](#repack2)           | [HFR](#hfr)                         | [VF2](#vf2)                   | [FR WEB Tier 01](#fr-web-tier-01)               |
+| [x264](#x264)                 | [Internal](#internal)               | [VFQ](#vfq)                   | [FR WEB Tier 02](#fr-web-tier-02)               |
+| [x265](#x265)                 | [Line/Mic Dubbed](#linemic-dubbed)  | [VOQ](#voq)                   | [FR Scene Groups](#fr-scene-groups)             |
+|                               | [No-RlsGroup](#no-rlsgroup)         | [VQ](#vq)                     | [FR LQ](#fr-lq)                                 |
+|                               | [Obfuscated](#obfuscated)           | [VFB](#vfb)                   |                                                 |
+|                               | [Retags](#retags)                   | [VOSTFR](#vostfr)             |                                                 |
+|                               | [Scene](#scene)                     | [FanSUB](#fansub)             |                                                 |
+|                               | [SDR (no WEBDL)](#sdr-no-webdl)     | [FastSUB](#fastsub)           |                                                 |
+|                               | [SDR](#sdr)                         |                               |                                                 |
+|                               | [VP9](#vp9)                         |                               |                                                 |
+|                               | [x265 (no HDR/DV)](#x265-no-hdrdv)  |                               |                                                 |
 
 ------
 
@@ -1393,13 +1393,24 @@ I also made 3 guides related to this one.
 ## Misc
 
 ------
-
-### Repack/Proper
+### Proper
 
 ??? example "JSON - [Click to show/hide]"
 
     ```json
-    [[% filter indent(width=4) %]][[% include 'json/radarr/cf/repack-proper.json' %]][[% endfilter %]]
+    [[% filter indent(width=4) %]][[% include 'json/radarr/cf/proper.json' %]][[% endfilter %]]
+    ```
+
+<sub><sup>[TOP](#index)</sup>
+
+------
+
+### Repack
+
+??? example "JSON - [Click to show/hide]"
+
+    ```json
+    [[% filter indent(width=4) %]][[% include 'json/radarr/cf/repack.json' %]][[% endfilter %]]
     ```
 
 <sub><sup>[TOP](#index)</sup>

--- a/docs/Radarr/radarr-setup-quality-profiles.md
+++ b/docs/Radarr/radarr-setup-quality-profiles.md
@@ -297,7 +297,7 @@ The following custom format groups should be combined with the Quality Profiles 
 
     I also suggest changing the Propers and Repacks settings in Radarr
 
-    `Media Management` => `File Management` to `Do Not Prefer` and use the [Repack](/Radarr/Radarr-collection-of-custom-formats/#repack) and [Proper](/Radarr/Radarr-collection-of-custom-formats/#proper) Custom Format.
+    `Media Management` => `File Management` to `Do Not Prefer` and use the [Repack](/Radarr/Radarr-collection-of-custom-formats/#repack) and [Proper](/Radarr/Radarr-collection-of-custom-formats/#proper) Custom Formats.
 
     ![!cf-mm-propers-repacks-disable](images/cf-mm-propers-repacks-disable.png)
 

--- a/docs/Radarr/radarr-setup-quality-profiles.md
+++ b/docs/Radarr/radarr-setup-quality-profiles.md
@@ -295,9 +295,9 @@ The following custom format groups should be combined with the Quality Profiles 
 
 ??? tip "Proper and Repacks - [Click to show/hide]"
 
-    I also suggest that you change the Propers and Repacks settings in Radarr
+    I also suggest changing the Propers and Repacks settings in Radarr
 
-    `Media Management` => `File Management` to `Do Not Prefer` and use the [Repack/Proper](/Radarr/Radarr-collection-of-custom-formats/#repackproper) Custom Format.
+    `Media Management` => `File Management` to `Do Not Prefer` and use the [Repack and Proper](/Radarr/Radarr-collection-of-custom-formats/#proper) Custom Format.
 
     ![!cf-mm-propers-repacks-disable](images/cf-mm-propers-repacks-disable.png)
 

--- a/docs/Radarr/radarr-setup-quality-profiles.md
+++ b/docs/Radarr/radarr-setup-quality-profiles.md
@@ -297,7 +297,7 @@ The following custom format groups should be combined with the Quality Profiles 
 
     I also suggest changing the Propers and Repacks settings in Radarr
 
-    `Media Management` => `File Management` to `Do Not Prefer` and use the [Repack and Proper](/Radarr/Radarr-collection-of-custom-formats/#proper) Custom Format.
+    `Media Management` => `File Management` to `Do Not Prefer` and use the [Repack](/Radarr/Radarr-collection-of-custom-formats/#repack) and [Proper](/Radarr/Radarr-collection-of-custom-formats/#proper) Custom Format.
 
     ![!cf-mm-propers-repacks-disable](images/cf-mm-propers-repacks-disable.png)
 

--- a/docs/Sonarr/sonarr-collection-of-custom-formats.md
+++ b/docs/Sonarr/sonarr-collection-of-custom-formats.md
@@ -16,7 +16,7 @@ I also made 3 guides related to this one.
 
     I also suggest changing the Propers and Repacks settings in Sonarr
 
-    `Media Management` => `File Management` to `Do Not Prefer` and use the [Repack and Proper](#proper) Custom Format.
+    `Media Management` => `File Management` to `Do Not Prefer` and use the [Repack](#repack) and [Proper](#proper) Custom Format.
 
     ![!cf-mm-propers-repacks-disable](images/cf-mm-propers-repacks-disable.png)
 

--- a/docs/Sonarr/sonarr-collection-of-custom-formats.md
+++ b/docs/Sonarr/sonarr-collection-of-custom-formats.md
@@ -16,7 +16,7 @@ I also made 3 guides related to this one.
 
     I also suggest changing the Propers and Repacks settings in Sonarr
 
-    `Media Management` => `File Management` to `Do Not Prefer` and use the [Repack](#repack) and [Proper](#proper) Custom Format.
+    `Media Management` => `File Management` to `Do Not Prefer` and use the [Repack](#repack) and [Proper](#proper) Custom Formats.
 
     ![!cf-mm-propers-repacks-disable](images/cf-mm-propers-repacks-disable.png)
 

--- a/docs/Sonarr/sonarr-collection-of-custom-formats.md
+++ b/docs/Sonarr/sonarr-collection-of-custom-formats.md
@@ -14,9 +14,9 @@ I also made 3 guides related to this one.
 
 !!! tip
 
-    I also suggest to change the Propers and Repacks settings in Sonarr
+    I also suggest changing the Propers and Repacks settings in Sonarr
 
-    `Media Management` => `File Management` to `Do Not Prefer` and use the [Repack/Proper](#repackproper) Custom Format.
+    `Media Management` => `File Management` to `Do Not Prefer` and use the [Repack and Proper](#proper) Custom Format.
 
     ![!cf-mm-propers-repacks-disable](images/cf-mm-propers-repacks-disable.png)
 
@@ -83,25 +83,25 @@ I also made 3 guides related to this one.
 
 ------
 
-| Misc                           | Optional                            | French Audio Version          | French Source Groups                          |
-| ------------------------------ | ----------------------------------- | ----------------------------- | --------------------------------------------- |
-| [MPEG2](#mpeg2)                | [AV1](#av1)                         | [Multi-French](#multi-french) | [FR Remux Tier 01](#fr-remux-tier-01)         |
-| [Multi](#multi)                | [Bad Dual Groups](#bad-dual-groups) | [Multi-Audio](#multi-audio)   | [FR HD Bluray Tier 01](#fr-hd-bluray-tier-01) |
-| [Repack v2](#repack-v2)        | [DV (Disk)](#dv-disk)               | [French Audio](#french-audio) | [FR WEB Tier 01](#fr-web-tier-01)             |
-| [Repack v3](#repack-v3)        | [DV (WEBDL)](#dv-webdl)             | [VFF](#vff)                   | [FR WEB Tier 02](#fr-web-tier-02)             |
-| [Repack/Proper](#repackproper) | [HDR10+ Boost](#hdr10plus-boost)    | [VOF](#vof)                   | [FR WEB Tier 03](#fr-web-tier-03)             |
-| [x264](#x264)                  | [HFR](#hfr)                         | [VFI](#vfi)                   | [FR Anime Tier 01](#fr-anime-tier-01)         |
-| [x265](#x265)                  | [Internal](#internal)               | [VF2](#vf2)                   | [FR Anime Tier 02](#fr-anime-tier-02)         |
-|                                | [No-RlsGroup](#no-rlsgroup)         | [VFQ](#vfq)                   | [FR Anime Tier 03](#fr-anime-tier-03)         |
-|                                | [Obfuscated](#obfuscated)           | [VOQ](#voq)                   | [FR Anime FanSub](#fr-anime-fansub)           |
-|                                | [Retags](#retags)                   | [VQ](#vq)                     | [FR Scene Groups](#fr-scene-groups)           |
-|                                | [Scene](#scene)                     | [VFB](#vfb)                   | [FR LQ](#fr-lq)                               |
-|                                | [SDR (no WEBDL)](#sdr-no-webdl)     | [VOSTFR](#vostfr)             |                                               |
-|                                | [SDR](#sdr)                         | [FanSUB](#fansub)             |                                               |
-|                                | [Season Packs](#season-pack)        | [FastSUB](#fastsub)           |                                               |
-|                                | [VP9](#vp9)                         |                               |                                               |
-|                                | [x265 (no HDR/DV)](#x265-no-hdrdv)  |                               |                                               |
-|                                | [x265 (no HDR/DV)](#x265-no-hdrdv)  |                               |                                               |
+| Misc                     | Optional                            | French Audio Version          | French Source Groups                          |
+| ------------------------ | ----------------------------------- | ----------------------------- | --------------------------------------------- |
+| [MPEG2](#mpeg2)          | [AV1](#av1)                         | [Multi-French](#multi-french) | [FR Remux Tier 01](#fr-remux-tier-01)         |
+| [Multi](#multi)          | [Bad Dual Groups](#bad-dual-groups) | [Multi-Audio](#multi-audio)   | [FR HD Bluray Tier 01](#fr-hd-bluray-tier-01) |
+| [Proper](#proper)        | [DV (Disk)](#dv-disk)               | [French Audio](#french-audio) | [FR WEB Tier 01](#fr-web-tier-01)             |
+| [Repack](#repack)        | [DV (WEBDL)](#dv-webdl)             | [VFF](#vff)                   | [FR WEB Tier 02](#fr-web-tier-02)             |
+| [Repack v2](#repack-v2)  | [HDR10+ Boost](#hdr10plus-boost)    | [VOF](#vof)                   | [FR WEB Tier 03](#fr-web-tier-03)             |
+| [Repack v3](#repack-v3)  | [HFR](#hfr)                         | [VFI](#vfi)                   | [FR Anime Tier 01](#fr-anime-tier-01)         |
+| [x264](#x264)            | [Internal](#internal)               | [VF2](#vf2)                   | [FR Anime Tier 02](#fr-anime-tier-02)         |
+| [x265](#x265)            | [No-RlsGroup](#no-rlsgroup)         | [VFQ](#vfq)                   | [FR Anime Tier 03](#fr-anime-tier-03)         |
+|                          | [Obfuscated](#obfuscated)           | [VOQ](#voq)                   | [FR Anime FanSub](#fr-anime-fansub)           |
+|                          | [Retags](#retags)                   | [VQ](#vq)                     | [FR Scene Groups](#fr-scene-groups)           |
+|                          | [Scene](#scene)                     | [VFB](#vfb)                   | [FR LQ](#fr-lq)                               |
+|                          | [SDR (no WEBDL)](#sdr-no-webdl)     | [VOSTFR](#vostfr)             |                                               |
+|                          | [SDR](#sdr)                         | [FanSUB](#fansub)             |                                               |
+|                          | [Season Packs](#season-pack)        | [FastSUB](#fastsub)           |                                               |
+|                          | [VP9](#vp9)                         |                               |                                               |
+|                          | [x265 (no HDR/DV)](#x265-no-hdrdv)  |                               |                                               |
+|                          | [x265 (no HDR/DV)](#x265-no-hdrdv)  |                               |                                               |
 
 ------
 
@@ -907,12 +907,23 @@ I also made 3 guides related to this one.
 
 ------
 
-### Repack/Proper
+### Proper
 
 ??? example "JSON - [Click to show/hide]"
 
     ```json
-    [[% filter indent(width=4) %]][[% include 'json/sonarr/cf/repack-proper.json' %]][[% endfilter %]]
+    [[% filter indent(width=4) %]][[% include 'json/sonarr/cf/proper.json' %]][[% endfilter %]]
+    ```
+
+<sub><sup>[TOP](#index)</sup>
+
+------
+### Repack
+
+??? example "JSON - [Click to show/hide]"
+
+    ```json
+    [[% filter indent(width=4) %]][[% include 'json/sonarr/cf/repack.json' %]][[% endfilter %]]
     ```
 
 <sub><sup>[TOP](#index)</sup>

--- a/docs/Sonarr/sonarr-setup-quality-profiles.md
+++ b/docs/Sonarr/sonarr-setup-quality-profiles.md
@@ -198,9 +198,9 @@ The following custom format groups should be combined with the Quality Profiles 
 
 ??? tip "Proper and Repacks - [Click to show/hide]"
 
-    I also suggest that you change the Propers and Repacks settings in Radarr
+    I also suggest changing the Propers and Repacks settings in Sonarr
 
-    `Media Management` => `File Management` to `Do Not Prefer` and use the [Repack/Proper](/Sonarr/sonarr-collection-of-custom-formats/#repackproper) Custom Format.
+    `Media Management` => `File Management` to `Do Not Prefer` and use the [Repack](/Sonarr/sonarr-collection-of-custom-formats/#repack) and [Proper](/Sonarr/sonarr-collection-of-custom-formats/#proper) Custom Format.
 
     ![!cf-mm-propers-repacks-disable](images/cf-mm-propers-repacks-disable.png)
 

--- a/docs/Sonarr/sonarr-setup-quality-profiles.md
+++ b/docs/Sonarr/sonarr-setup-quality-profiles.md
@@ -200,7 +200,7 @@ The following custom format groups should be combined with the Quality Profiles 
 
     I also suggest changing the Propers and Repacks settings in Sonarr
 
-    `Media Management` => `File Management` to `Do Not Prefer` and use the [Repack](/Sonarr/sonarr-collection-of-custom-formats/#repack) and [Proper](/Sonarr/sonarr-collection-of-custom-formats/#proper) Custom Format.
+    `Media Management` => `File Management` to `Do Not Prefer` and use the [Repack](/Sonarr/sonarr-collection-of-custom-formats/#repack) and [Proper](/Sonarr/sonarr-collection-of-custom-formats/#proper) Custom Formats.
 
     ![!cf-mm-propers-repacks-disable](images/cf-mm-propers-repacks-disable.png)
 

--- a/docs/json/radarr/cf/proper.json
+++ b/docs/json/radarr/cf/proper.json
@@ -1,5 +1,5 @@
 {
-  "trash_id": "28ebdc2cdf002d9458e41f9f60e216a2",
+  "trash_id": "482da74d7594524acd1cd9de5d5fb0dc",
   "trash_scores": {
     "default": 7
   },

--- a/docs/json/radarr/cf/proper.json
+++ b/docs/json/radarr/cf/proper.json
@@ -1,0 +1,20 @@
+{
+  "trash_id": "28ebdc2cdf002d9458e41f9f60e216a2",
+  "trash_scores": {
+    "default": 8
+  },
+  "trash_regex": "https://regex101.com/r/S91wR8/2",
+  "name": "Proper",
+  "includeCustomFormatWhenRenaming": false,
+  "specifications": [
+      {
+          "name": "Proper",
+          "implementation": "ReleaseTitleSpecification",
+          "negate": false,
+          "required": false,
+          "fields": {
+              "value": "\\b(Proper)\\b"
+          }
+      }
+  ]
+}

--- a/docs/json/radarr/cf/proper.json
+++ b/docs/json/radarr/cf/proper.json
@@ -1,7 +1,7 @@
 {
   "trash_id": "28ebdc2cdf002d9458e41f9f60e216a2",
   "trash_scores": {
-    "default": 8
+    "default": 7
   },
   "trash_regex": "https://regex101.com/r/S91wR8/2",
   "name": "Proper",

--- a/docs/json/radarr/cf/repack.json
+++ b/docs/json/radarr/cf/repack.json
@@ -1,10 +1,10 @@
 {
-  "trash_id": "e7718d7a3ce595f289bfee26adc178f5",
+  "trash_id": "a06f27e686bda44e19515ccf51af279f",
   "trash_scores": {
     "default": 5
   },
-  "trash_regex": "https://regex101.com/r/S91wR8/2",
-  "name": "Repack/Proper",
+  "trash_regex": "https://regex101.com/r/S91wR8/3",
+  "name": "Repack",
   "includeCustomFormatWhenRenaming": false,
   "specifications": [{
           "name": "Repack",
@@ -13,15 +13,6 @@
           "required": false,
           "fields": {
               "value": "\\b(Repack)\\b"
-          }
-      },
-      {
-          "name": "Proper",
-          "implementation": "ReleaseTitleSpecification",
-          "negate": false,
-          "required": false,
-          "fields": {
-              "value": "\\b(Proper)\\b"
           }
       },
       {

--- a/docs/json/sonarr/cf/proper.json
+++ b/docs/json/sonarr/cf/proper.json
@@ -1,0 +1,20 @@
+{
+  "trash_id": "003262633471ef9477b1d685a73b5e93",
+  "trash_scores": {
+    "default": 7
+  },
+  "trash_regex": "https://regex101.com/r/S91wR8/2",
+  "name": "Proper",
+  "includeCustomFormatWhenRenaming": false,
+  "specifications": [
+      {
+          "name": "Proper",
+          "implementation": "ReleaseTitleSpecification",
+          "negate": false,
+          "required": false,
+          "fields": {
+              "value": "\\b(Proper)\\b"
+          }
+      }
+  ]
+}

--- a/docs/json/sonarr/cf/proper.json
+++ b/docs/json/sonarr/cf/proper.json
@@ -1,7 +1,7 @@
 {
   "trash_id": "003262633471ef9477b1d685a73b5e93",
   "trash_scores": {
-    "default": 7
+    "default": 8
   },
   "trash_regex": "https://regex101.com/r/S91wR8/2",
   "name": "Proper",

--- a/docs/json/sonarr/cf/repack.json
+++ b/docs/json/sonarr/cf/repack.json
@@ -1,10 +1,10 @@
 {
-  "trash_id": "ec8fa7296b64e8cd390a1600981f3923",
+  "trash_id": "f11b533d6db941b84f36cab756b29ea5",
   "trash_scores": {
     "default": 5
   },
-  "trash_regex": "https://regex101.com/r/S91wR8/2",
-  "name": "Repack/Proper",
+  "trash_regex": "https://regex101.com/r/S91wR8/3",
+  "name": "Repack",
   "includeCustomFormatWhenRenaming": false,
   "specifications": [{
           "name": "Repack",
@@ -13,15 +13,6 @@
           "required": false,
           "fields": {
               "value": "\\b(Repack)\\b"
-          }
-      },
-      {
-          "name": "Proper",
-          "implementation": "ReleaseTitleSpecification",
-          "negate": false,
-          "required": false,
-          "fields": {
-              "value": "\\b(Proper)\\b"
           }
       },
       {

--- a/includes/cf/radarr-misc.md
+++ b/includes/cf/radarr-misc.md
@@ -1,10 +1,9 @@
 ??? abstract "Misc - [Click to show/hide]"
-| Custom Format | Score                                                                                         | Trash ID                                                 |                                           |
-| ------------- | --------------------------------------------------------------------------------------------- | -------------------------------------------------------- | ----------------------------------------- |
-|               | [{{ radarr['cf']['proper']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#proper)   | {{ radarr['cf']['proper']['trash_scores']['default'] }}  | {{ radarr['cf']['proper']['trash_id'] }}  |
-|               | [{{ radarr['cf']['repack']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#repack)   | {{ radarr['cf']['repack']['trash_scores']['default'] }}  | {{ radarr['cf']['repack']['trash_id'] }}  |
-|               | [{{ radarr['cf']['repack2']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#repack2) | {{ radarr['cf']['repack2']['trash_scores']['default'] }} | {{ radarr['cf']['repack2']['trash_id'] }} |
-|               |                                                                                               |                                                          |                                           |
+    | Custom Format | Score                                                                                         | Trash ID                                                 |                                           |
+    | ------------- | --------------------------------------------------------------------------------------------- | -------------------------------------------------------- | ----------------------------------------- |
+    |               | [{{ radarr['cf']['proper']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#proper)   | {{ radarr['cf']['proper']['trash_scores']['default'] }}  | {{ radarr['cf']['proper']['trash_id'] }}  |
+    |               | [{{ radarr['cf']['repack']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#repack)   | {{ radarr['cf']['repack']['trash_scores']['default'] }}  | {{ radarr['cf']['repack']['trash_id'] }}  |
+    |               | [{{ radarr['cf']['repack2']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#repack2) | {{ radarr['cf']['repack2']['trash_scores']['default'] }} | {{ radarr['cf']['repack2']['trash_id'] }} |
 
     ??? tip "Proper and Repacks - [Click to show/hide]"
 

--- a/includes/cf/radarr-misc.md
+++ b/includes/cf/radarr-misc.md
@@ -1,6 +1,6 @@
 ??? abstract "Misc - [Click to show/hide]"
-    | Custom Format | Score                                                                                         | Trash ID                                                 |
-    | ------------- | :-------------------------------------------------------------------------------------------: | -------------------------------------------------------- |
+    | Custom Format                                                                                 |                          Score                           | Trash ID                                  |
+    | --------------------------------------------------------------------------------------------- | :------------------------------------------------------: | ----------------------------------------- |
     | [{{ radarr['cf']['proper']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#proper)   | {{ radarr['cf']['proper']['trash_scores']['default'] }}  | {{ radarr['cf']['proper']['trash_id'] }}  |
     | [{{ radarr['cf']['repack']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#repack)   | {{ radarr['cf']['repack']['trash_scores']['default'] }}  | {{ radarr['cf']['repack']['trash_id'] }}  |
     | [{{ radarr['cf']['repack2']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#repack2) | {{ radarr['cf']['repack2']['trash_scores']['default'] }} | {{ radarr['cf']['repack2']['trash_id'] }} |

--- a/includes/cf/radarr-misc.md
+++ b/includes/cf/radarr-misc.md
@@ -1,12 +1,14 @@
 ??? abstract "Misc - [Click to show/hide]"
-    | Custom Format                                                                                            |                             Score                              | Trash ID                                        |
-    | -------------------------------------------------------------------------------------------------------- | :------------------------------------------------------------: | ----------------------------------------------- |
-    | [{{ radarr['cf']['repack-proper']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#repackproper) | {{ radarr['cf']['repack-proper']['trash_scores']['default'] }} | {{ radarr['cf']['repack-proper']['trash_id'] }} |
-    | [{{ radarr['cf']['repack2']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#repack2)            |    {{ radarr['cf']['repack2']['trash_scores']['default'] }}    | {{ radarr['cf']['repack2']['trash_id'] }}       |
+| Custom Format | Score                                                                                         | Trash ID                                                 |                                           |
+| ------------- | --------------------------------------------------------------------------------------------- | -------------------------------------------------------- | ----------------------------------------- |
+|               | [{{ radarr['cf']['proper']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#proper)   | {{ radarr['cf']['proper']['trash_scores']['default'] }}  | {{ radarr['cf']['proper']['trash_id'] }}  |
+|               | [{{ radarr['cf']['repack']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#repack)   | {{ radarr['cf']['repack']['trash_scores']['default'] }}  | {{ radarr['cf']['repack']['trash_id'] }}  |
+|               | [{{ radarr['cf']['repack2']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#repack2) | {{ radarr['cf']['repack2']['trash_scores']['default'] }} | {{ radarr['cf']['repack2']['trash_id'] }} |
+|               |                                                                                               |                                                          |                                           |
 
     ??? tip "Proper and Repacks - [Click to show/hide]"
 
-        I also suggest to change the Propers and Repacks settings in Radarr
+        I also suggest changing the Propers and Repacks settings in Radarr
 
         `Media Management` => `File Management` to `Do Not Prefer` and use the [Repack/Proper](/Radarr/Radarr-collection-of-custom-formats/#repackproper) Custom Format.
 

--- a/includes/cf/radarr-misc.md
+++ b/includes/cf/radarr-misc.md
@@ -9,7 +9,7 @@
 
         I also suggest changing the Propers and Repacks settings in Radarr
 
-        `Media Management` => `File Management` to `Do Not Prefer` and use the [Repack/Proper](/Radarr/Radarr-collection-of-custom-formats/#repackproper) Custom Format.
+        `Media Management` => `File Management` to `Do Not Prefer` and use the [Repack](/Radarr/Radarr-collection-of-custom-formats/#repack) and [Proper](/Radarr/Radarr-collection-of-custom-formats/#proper) Custom Formats.
 
         ![!cf-mm-propers-repacks-disable](/Radarr/images/cf-mm-propers-repacks-disable.png)
 

--- a/includes/cf/radarr-misc.md
+++ b/includes/cf/radarr-misc.md
@@ -1,9 +1,9 @@
 ??? abstract "Misc - [Click to show/hide]"
-    | Custom Format | Score                                                                                         | Trash ID                                                 |                                           |
-    | ------------- | --------------------------------------------------------------------------------------------- | -------------------------------------------------------- | ----------------------------------------- |
-    |               | [{{ radarr['cf']['proper']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#proper)   | {{ radarr['cf']['proper']['trash_scores']['default'] }}  | {{ radarr['cf']['proper']['trash_id'] }}  |
-    |               | [{{ radarr['cf']['repack']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#repack)   | {{ radarr['cf']['repack']['trash_scores']['default'] }}  | {{ radarr['cf']['repack']['trash_id'] }}  |
-    |               | [{{ radarr['cf']['repack2']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#repack2) | {{ radarr['cf']['repack2']['trash_scores']['default'] }} | {{ radarr['cf']['repack2']['trash_id'] }} |
+    | Custom Format | Score                                                                                         | Trash ID                                                 |
+    | ------------- | :-------------------------------------------------------------------------------------------: | -------------------------------------------------------- |
+    | [{{ radarr['cf']['proper']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#proper)   | {{ radarr['cf']['proper']['trash_scores']['default'] }}  | {{ radarr['cf']['proper']['trash_id'] }}  |
+    | [{{ radarr['cf']['repack']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#repack)   | {{ radarr['cf']['repack']['trash_scores']['default'] }}  | {{ radarr['cf']['repack']['trash_id'] }}  |
+    | [{{ radarr['cf']['repack2']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#repack2) | {{ radarr['cf']['repack2']['trash_scores']['default'] }} | {{ radarr['cf']['repack2']['trash_id'] }} |
 
     ??? tip "Proper and Repacks - [Click to show/hide]"
 

--- a/includes/cf/sonarr-misc.md
+++ b/includes/cf/sonarr-misc.md
@@ -1,8 +1,8 @@
 ??? abstract "Misc - [Click to show/hide]"
-    | Custom Format | Score                                                                                             | Trash ID                                                   |
-    | ------------- | :-----------------------------------------------------------------------------------------------: | ---------------------------------------------------------- |
-    | [{{ sonarr['cf']['proper']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#proper)       | {{ sonarr['cf']['proper']['trash_scores']['default'] }}    | {{ sonarr['cf']['proper']['trash_id'] }}    |
-    | [{{ sonarr['cf']['repack']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#repack)       | {{ sonarr['cf']['repack']['trash_scores']['default'] }}    | {{ sonarr['cf']['repack']['trash_id'] }}    |
+    | Custom Format                                                                                     |                           Score                            | Trash ID                                    |
+    | ------------------------------------------------------------------------------------------------- | :--------------------------------------------------------: | ------------------------------------------- |
+    | [{{ sonarr['cf']['proper']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#proper)       |  {{ sonarr['cf']['proper']['trash_scores']['default'] }}   | {{ sonarr['cf']['proper']['trash_id'] }}    |
+    | [{{ sonarr['cf']['repack']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#repack)       |  {{ sonarr['cf']['repack']['trash_scores']['default'] }}   | {{ sonarr['cf']['repack']['trash_id'] }}    |
     | [{{ sonarr['cf']['repack-v2']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#repack-v2) | {{ sonarr['cf']['repack-v2']['trash_scores']['default'] }} | {{ sonarr['cf']['repack-v2']['trash_id'] }} |
     | [{{ sonarr['cf']['repack-v3']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#repack-v3) | {{ sonarr['cf']['repack-v3']['trash_scores']['default'] }} | {{ sonarr['cf']['repack-v3']['trash_id'] }} |
 

--- a/includes/cf/sonarr-misc.md
+++ b/includes/cf/sonarr-misc.md
@@ -1,13 +1,15 @@
 ??? abstract "Misc - [Click to show/hide]"
-    | Custom Format                                                                                            |                             Score                              | Trash ID                                        |
-    | -------------------------------------------------------------------------------------------------------- | :------------------------------------------------------------: | ----------------------------------------------- |
-    | [{{ sonarr['cf']['repack-proper']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#repackproper) | {{ sonarr['cf']['repack-proper']['trash_scores']['default'] }} | {{ sonarr['cf']['repack-proper']['trash_id'] }} |
-    | [{{ sonarr['cf']['repack-v2']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#repack-v2)        |   {{ sonarr['cf']['repack-v2']['trash_scores']['default'] }}   | {{ sonarr['cf']['repack-v2']['trash_id'] }}     |
-    | [{{ sonarr['cf']['repack-v3']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#repack-v3)        |   {{ sonarr['cf']['repack-v3']['trash_scores']['default'] }}   | {{ sonarr['cf']['repack-v3']['trash_id'] }}     |
+| Custom Format | Score                                                                                             | Trash ID                                                   |                                             |
+| ------------- | ------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- | ------------------------------------------- |
+|               | [{{ sonarr['cf']['proper']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#proper)       | {{ sonarr['cf']['proper']['trash_scores']['default'] }}    | {{ sonarr['cf']['proper']['trash_id'] }}    |
+|               | [{{ sonarr['cf']['repack']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#repack)       | {{ sonarr['cf']['repack']['trash_scores']['default'] }}    | {{ sonarr['cf']['repack']['trash_id'] }}    |
+|               | [{{ sonarr['cf']['repack-v2']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#repack-v2) | {{ sonarr['cf']['repack-v2']['trash_scores']['default'] }} | {{ sonarr['cf']['repack-v2']['trash_id'] }} |
+|               | [{{ sonarr['cf']['repack-v3']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#repack-v3) | {{ sonarr['cf']['repack-v3']['trash_scores']['default'] }} | {{ sonarr['cf']['repack-v3']['trash_id'] }} |
+
 
     ??? tip "Proper and Repacks - [Click to show/hide]"
 
-        I also suggest to change the Propers and Repacks settings in Sonarr
+        I also suggest changing the Propers and Repacks settings in Sonarr
 
         `Media Management` => `File Management` to `Do Not Prefer` and use the [Repack/Proper](/Sonarr/sonarr-collection-of-custom-formats/#repackproper) Custom Format.
 

--- a/includes/cf/sonarr-misc.md
+++ b/includes/cf/sonarr-misc.md
@@ -1,10 +1,10 @@
 ??? abstract "Misc - [Click to show/hide]"
-    | Custom Format | Score                                                                                             | Trash ID                                                   |                                             |
-    | ------------- | ------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- | ------------------------------------------- |
-    |               | [{{ sonarr['cf']['proper']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#proper)       | {{ sonarr['cf']['proper']['trash_scores']['default'] }}    | {{ sonarr['cf']['proper']['trash_id'] }}    |
-    |               | [{{ sonarr['cf']['repack']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#repack)       | {{ sonarr['cf']['repack']['trash_scores']['default'] }}    | {{ sonarr['cf']['repack']['trash_id'] }}    |
-    |               | [{{ sonarr['cf']['repack-v2']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#repack-v2) | {{ sonarr['cf']['repack-v2']['trash_scores']['default'] }} | {{ sonarr['cf']['repack-v2']['trash_id'] }} |
-    |               | [{{ sonarr['cf']['repack-v3']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#repack-v3) | {{ sonarr['cf']['repack-v3']['trash_scores']['default'] }} | {{ sonarr['cf']['repack-v3']['trash_id'] }} |
+    | Custom Format | Score                                                                                             | Trash ID                                                   |
+    | ------------- | :-----------------------------------------------------------------------------------------------: | ---------------------------------------------------------- |
+    | [{{ sonarr['cf']['proper']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#proper)       | {{ sonarr['cf']['proper']['trash_scores']['default'] }}    | {{ sonarr['cf']['proper']['trash_id'] }}    |
+    | [{{ sonarr['cf']['repack']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#repack)       | {{ sonarr['cf']['repack']['trash_scores']['default'] }}    | {{ sonarr['cf']['repack']['trash_id'] }}    |
+    | [{{ sonarr['cf']['repack-v2']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#repack-v2) | {{ sonarr['cf']['repack-v2']['trash_scores']['default'] }} | {{ sonarr['cf']['repack-v2']['trash_id'] }} |
+    | [{{ sonarr['cf']['repack-v3']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#repack-v3) | {{ sonarr['cf']['repack-v3']['trash_scores']['default'] }} | {{ sonarr['cf']['repack-v3']['trash_id'] }} |
 
     ??? tip "Proper and Repacks - [Click to show/hide]"
 

--- a/includes/cf/sonarr-misc.md
+++ b/includes/cf/sonarr-misc.md
@@ -10,7 +10,7 @@
 
         I also suggest changing the Propers and Repacks settings in Sonarr
 
-        `Media Management` => `File Management` to `Do Not Prefer` and use the [Repack/Proper](/Sonarr/sonarr-collection-of-custom-formats/#repackproper) Custom Format.
+        `Media Management` => `File Management` to `Do Not Prefer` and use the [Repack](/Sonarr/sonarr-collection-of-custom-formats/#repack) and [Proper](/Sonarr/sonarr-collection-of-custom-formats/#proper) Custom Formats.
 
         ![!cf-mm-propers-repacks-disable](/Sonarr/images/cf-mm-propers-repacks-disable.png)
 

--- a/includes/cf/sonarr-misc.md
+++ b/includes/cf/sonarr-misc.md
@@ -1,11 +1,10 @@
 ??? abstract "Misc - [Click to show/hide]"
-| Custom Format | Score                                                                                             | Trash ID                                                   |                                             |
-| ------------- | ------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- | ------------------------------------------- |
-|               | [{{ sonarr['cf']['proper']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#proper)       | {{ sonarr['cf']['proper']['trash_scores']['default'] }}    | {{ sonarr['cf']['proper']['trash_id'] }}    |
-|               | [{{ sonarr['cf']['repack']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#repack)       | {{ sonarr['cf']['repack']['trash_scores']['default'] }}    | {{ sonarr['cf']['repack']['trash_id'] }}    |
-|               | [{{ sonarr['cf']['repack-v2']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#repack-v2) | {{ sonarr['cf']['repack-v2']['trash_scores']['default'] }} | {{ sonarr['cf']['repack-v2']['trash_id'] }} |
-|               | [{{ sonarr['cf']['repack-v3']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#repack-v3) | {{ sonarr['cf']['repack-v3']['trash_scores']['default'] }} | {{ sonarr['cf']['repack-v3']['trash_id'] }} |
-
+    | Custom Format | Score                                                                                             | Trash ID                                                   |                                             |
+    | ------------- | ------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- | ------------------------------------------- |
+    |               | [{{ sonarr['cf']['proper']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#proper)       | {{ sonarr['cf']['proper']['trash_scores']['default'] }}    | {{ sonarr['cf']['proper']['trash_id'] }}    |
+    |               | [{{ sonarr['cf']['repack']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#repack)       | {{ sonarr['cf']['repack']['trash_scores']['default'] }}    | {{ sonarr['cf']['repack']['trash_id'] }}    |
+    |               | [{{ sonarr['cf']['repack-v2']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#repack-v2) | {{ sonarr['cf']['repack-v2']['trash_scores']['default'] }} | {{ sonarr['cf']['repack-v2']['trash_id'] }} |
+    |               | [{{ sonarr['cf']['repack-v3']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#repack-v3) | {{ sonarr['cf']['repack-v3']['trash_scores']['default'] }} | {{ sonarr['cf']['repack-v3']['trash_id'] }} |
 
     ??? tip "Proper and Repacks - [Click to show/hide]"
 

--- a/includes/sqp/uhd-radarr-misc.md
+++ b/includes/sqp/uhd-radarr-misc.md
@@ -19,7 +19,7 @@
 
         I also suggest changing the Propers and Repacks settings in Radarr
 
-        `Media Management` => `File Management` to `Do Not Prefer` and use the [Repack/Proper](/Radarr/Radarr-collection-of-custom-formats/#repackproper) Custom Format.
+        `Media Management` => `File Management` to `Do Not Prefer` and use the [Repack](/Radarr/Radarr-collection-of-custom-formats/#repack) and [Proper](/Radarr/Radarr-collection-of-custom-formats/#proper) Custom Formats.
 
         ![!cf-mm-propers-repacks-disable](/Radarr/images/cf-mm-propers-repacks-disable.png)
 

--- a/includes/sqp/uhd-radarr-misc.md
+++ b/includes/sqp/uhd-radarr-misc.md
@@ -1,14 +1,15 @@
 ??? abstract "Misc - [Click to show/hide]"
-    | Custom Format | Score                                                                                         | Trash ID                                                                |                                           |
-    | ------------- | --------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- | ----------------------------------------- |
-    |               | [{{ radarr['cf']['proper']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#proper)   | {{ radarr['cf']['proper']['trash_scores']['default'] }}                 | {{ radarr['cf']['proper']['trash_id'] }}  |
-    |               | [{{ radarr['cf']['repack']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#repack)   | {{ radarr['cf']['repack']['trash_scores']['default'] }}                 | {{ radarr['cf']['repack']['trash_id'] }}  |
-    |               | [{{ radarr['cf']['repack2']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#repack2) | {{ radarr['cf']['repack2']['trash_scores']['default'] }}                | {{ radarr['cf']['repack2']['trash_id'] }} |
-    |               | [{{ radarr['cf']['x264']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#x264)       | :warning: {{ radarr['cf']['x264']['trash_scores']['sqp-2'] }} :warning: | {{ radarr['cf']['x264']['trash_id'] }}    |
+    | Custom Format                                                                                 | Score                                                                   | Trash ID                                  |     |
+    | --------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- | ----------------------------------------- | --- |
+    | [{{ radarr['cf']['proper']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#proper)   | {{ radarr['cf']['proper']['trash_scores']['default'] }}                 | {{ radarr['cf']['proper']['trash_id'] }}  |     |
+    | [{{ radarr['cf']['repack']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#repack)   | {{ radarr['cf']['repack']['trash_scores']['default'] }}                 | {{ radarr['cf']['repack']['trash_id'] }}  |     |
+    | [{{ radarr['cf']['repack2']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#repack2) | {{ radarr['cf']['repack2']['trash_scores']['default'] }}                | {{ radarr['cf']['repack2']['trash_id'] }} |     |
+    | [{{ radarr['cf']['x264']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#x264)       | :warning: {{ radarr['cf']['x264']['trash_scores']['sqp-2'] }} :warning: | {{ radarr['cf']['x264']['trash_id'] }}    |     |
 
     !!! warning "Scores marked with a :warning: warning :warning: are different to those used in the main guide"
 
     ------
+
     Breakdown and Why
 
     - `x264` has a score of `-10000` because we only want the HDR/DV versions of the `WEBDL-1080p`

--- a/includes/sqp/uhd-radarr-misc.md
+++ b/includes/sqp/uhd-radarr-misc.md
@@ -1,9 +1,11 @@
 ??? abstract "Misc - [Click to show/hide]"
-    | Custom Format                                                                                            |                                  Score                                  | Trash ID                                        |
-    | -------------------------------------------------------------------------------------------------------- | :---------------------------------------------------------------------: | ----------------------------------------------- |
-    | [{{ radarr['cf']['repack-proper']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#repackproper) |     {{ radarr['cf']['repack-proper']['trash_scores']['default'] }}      | {{ radarr['cf']['repack-proper']['trash_id'] }} |
-    | [{{ radarr['cf']['repack2']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#repack2)            |        {{ radarr['cf']['repack2']['trash_scores']['default'] }}         | {{ radarr['cf']['repack2']['trash_id'] }}       |
-    | [{{ radarr['cf']['x264']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#x264)                  | :warning: {{ radarr['cf']['x264']['trash_scores']['sqp-2'] }} :warning: | {{ radarr['cf']['x264']['trash_id'] }}          |
+| Custom Format | Score                                                                                         | Trash ID                                                                |                                           |
+| ------------- | --------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- | ----------------------------------------- |
+|               | [{{ radarr['cf']['proper']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#proper)   | {{ radarr['cf']['proper']['trash_scores']['default'] }}                 | {{ radarr['cf']['proper']['trash_id'] }}  |
+|               | [{{ radarr['cf']['repack']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#repack)   | {{ radarr['cf']['repack']['trash_scores']['default'] }}                 | {{ radarr['cf']['repack']['trash_id'] }}  |
+|               | [{{ radarr['cf']['repack2']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#repack2) | {{ radarr['cf']['repack2']['trash_scores']['default'] }}                | {{ radarr['cf']['repack2']['trash_id'] }} |
+|               | [{{ radarr['cf']['x264']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#x264)       | :warning: {{ radarr['cf']['x264']['trash_scores']['sqp-2'] }} :warning: | {{ radarr['cf']['x264']['trash_id'] }}    |
+|               |                                                                                               |                                                                         |                                           |
 
     !!! warning "Scores marked with a :warning: warning :warning: are different to those used in the main guide"
 
@@ -15,7 +17,7 @@
 
     ??? tip "Proper and Repacks - [Click to show/hide]"
 
-        I also suggest to change the Propers and Repacks settings in Radarr
+        I also suggest changing the Propers and Repacks settings in Radarr
 
         `Media Management` => `File Management` to `Do Not Prefer` and use the [Repack/Proper](/Radarr/Radarr-collection-of-custom-formats/#repackproper) Custom Format.
 

--- a/includes/sqp/uhd-radarr-misc.md
+++ b/includes/sqp/uhd-radarr-misc.md
@@ -1,11 +1,10 @@
 ??? abstract "Misc - [Click to show/hide]"
-| Custom Format | Score                                                                                         | Trash ID                                                                |                                           |
-| ------------- | --------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- | ----------------------------------------- |
-|               | [{{ radarr['cf']['proper']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#proper)   | {{ radarr['cf']['proper']['trash_scores']['default'] }}                 | {{ radarr['cf']['proper']['trash_id'] }}  |
-|               | [{{ radarr['cf']['repack']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#repack)   | {{ radarr['cf']['repack']['trash_scores']['default'] }}                 | {{ radarr['cf']['repack']['trash_id'] }}  |
-|               | [{{ radarr['cf']['repack2']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#repack2) | {{ radarr['cf']['repack2']['trash_scores']['default'] }}                | {{ radarr['cf']['repack2']['trash_id'] }} |
-|               | [{{ radarr['cf']['x264']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#x264)       | :warning: {{ radarr['cf']['x264']['trash_scores']['sqp-2'] }} :warning: | {{ radarr['cf']['x264']['trash_id'] }}    |
-|               |                                                                                               |                                                                         |                                           |
+    | Custom Format | Score                                                                                         | Trash ID                                                                |                                           |
+    | ------------- | --------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- | ----------------------------------------- |
+    |               | [{{ radarr['cf']['proper']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#proper)   | {{ radarr['cf']['proper']['trash_scores']['default'] }}                 | {{ radarr['cf']['proper']['trash_id'] }}  |
+    |               | [{{ radarr['cf']['repack']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#repack)   | {{ radarr['cf']['repack']['trash_scores']['default'] }}                 | {{ radarr['cf']['repack']['trash_id'] }}  |
+    |               | [{{ radarr['cf']['repack2']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#repack2) | {{ radarr['cf']['repack2']['trash_scores']['default'] }}                | {{ radarr['cf']['repack2']['trash_id'] }} |
+    |               | [{{ radarr['cf']['x264']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#x264)       | :warning: {{ radarr['cf']['x264']['trash_scores']['sqp-2'] }} :warning: | {{ radarr['cf']['x264']['trash_id'] }}    |
 
     !!! warning "Scores marked with a :warning: warning :warning: are different to those used in the main guide"
 


### PR DESCRIPTION
# Pull Request

## Purpose

separates the current repack/proper CF into two and scores it above all repacks.

closes #1734 

Live preview: https://dox.ary.dev

## Approach

bunch of search and replace and table rebuilding

## Note

After discussing with nitsua, this shouldn't break anything locally or on notifarr. He did not review changes, just their structure and the affect it would have on his site.

## Open Questions and Pre-Merge TODOs

- [ ] scoring for proper needs to be confirmed (scoring above all repacks)
- [ ] make sure i didn't miss any references

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
