### PR TITLE
Feat (guides): Add Underscore to Token-Matching Custom Format Separators

### DIFF
--- a/docs/json/radarr/cf/aac.json
+++ b/docs/json/radarr/cf/aac.json
@@ -67,7 +67,7 @@
           "negate": true,
           "required": true,
           "fields": {
-              "value": "True[ .-]?HD|\\bATMOS(\\b|\\d)"
+              "value": "True[ ._-]?HD|\\bATMOS(\\b|\\d)"
           }
       }
   ]

--- a/docs/json/radarr/cf/atmos-undefined.json
+++ b/docs/json/radarr/cf/atmos-undefined.json
@@ -86,7 +86,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "True[ .-]?HD"
+        "value": "True[ ._-]?HD"
       }
     }
   ]

--- a/docs/json/radarr/cf/dd.json
+++ b/docs/json/radarr/cf/dd.json
@@ -31,7 +31,7 @@
           "negate": true,
           "required": true,
           "fields": {
-              "value": "True[ .-]?HD|\\bATMOS(\\b|\\d)"
+              "value": "True[ ._-]?HD|\\bATMOS(\\b|\\d)"
           }
       },
       {

--- a/docs/json/radarr/cf/ddplus-atmos.json
+++ b/docs/json/radarr/cf/ddplus-atmos.json
@@ -32,7 +32,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "True[ .-]?HD"
+        "value": "True[ ._-]?HD"
       }
     },
     {

--- a/docs/json/radarr/cf/ddplus.json
+++ b/docs/json/radarr/cf/ddplus.json
@@ -22,7 +22,7 @@
           "negate": true,
           "required": true,
           "fields": {
-              "value": "True[ .-]?HD|\\bATMOS(\\b|\\d)"
+              "value": "True[ ._-]?HD|\\bATMOS(\\b|\\d)"
           }
       },
       {

--- a/docs/json/radarr/cf/dts-es.json
+++ b/docs/json/radarr/cf/dts-es.json
@@ -40,7 +40,7 @@
           "negate": true,
           "required": true,
           "fields": {
-              "value": "DTS[ .]?[1-9]"
+              "value": "DTS[ ._-]?[1-9]"
           }
       },
       {

--- a/docs/json/radarr/cf/dts-es.json
+++ b/docs/json/radarr/cf/dts-es.json
@@ -13,7 +13,7 @@
           "negate": false,
           "required": true,
           "fields": {
-              "value": "dts[-. ]?es\\b"
+              "value": "dts[ ._-]?es\\b"
           }
       },
       {
@@ -22,7 +22,7 @@
           "negate": true,
           "required": true,
           "fields": {
-              "value": "True[ .-]?HD|\\bATMOS(\\b|\\d)"
+              "value": "True[ ._-]?HD|\\bATMOS(\\b|\\d)"
           }
       },
       {

--- a/docs/json/radarr/cf/dts-hd-hra.json
+++ b/docs/json/radarr/cf/dts-hd-hra.json
@@ -14,7 +14,7 @@
           "negate": false,
           "required": true,
           "fields": {
-              "value": "dts[-. ]?(hd[. ]?)?(hra?|hi\\b)"
+              "value": "dts[ ._-]?(hd[ ._-]?)?(hra?|hi\\b)"
           }
       },
       {
@@ -23,7 +23,7 @@
           "negate": true,
           "required": true,
           "fields": {
-              "value": "True[ .-]?HD|\\bATMOS(\\b|\\d)"
+              "value": "True[ ._-]?HD|\\bATMOS(\\b|\\d)"
           }
       },
       {

--- a/docs/json/radarr/cf/dts-hd-hra.json
+++ b/docs/json/radarr/cf/dts-hd-hra.json
@@ -41,7 +41,7 @@
           "negate": true,
           "required": true,
           "fields": {
-              "value": "DTS[ .]?[1-9]"
+              "value": "DTS[ ._-]?[1-9]"
           }
       },
       {

--- a/docs/json/radarr/cf/dts-hd-ma.json
+++ b/docs/json/radarr/cf/dts-hd-ma.json
@@ -24,7 +24,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "True[ .-]?HD|\\bATMOS(\\b|\\d)"
+        "value": "True[ ._-]?HD|\\bATMOS(\\b|\\d)"
       }
     },
     {
@@ -87,7 +87,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "dts[-. ]?(es|(hd[. ]?)?(hr|hi))"
+        "value": "dts[ ._-]?(es|(hd[ ._-]?)?(hr|hi))"
       }
     }
   ]

--- a/docs/json/radarr/cf/dts-x.json
+++ b/docs/json/radarr/cf/dts-x.json
@@ -22,7 +22,7 @@
           "negate": true,
           "required": true,
           "fields": {
-              "value": "DTS[ .]?[1-9]"
+              "value": "DTS[ ._-]?[1-9]"
           }
       },
       {

--- a/docs/json/radarr/cf/dts-x.json
+++ b/docs/json/radarr/cf/dts-x.json
@@ -49,7 +49,7 @@
           "negate": true,
           "required": true,
           "fields": {
-              "value": "True[ .-]?HD|\\bATMOS(\\b|\\d)"
+              "value": "True[ ._-]?HD|\\bATMOS(\\b|\\d)"
           }
       },
       {

--- a/docs/json/radarr/cf/dts.json
+++ b/docs/json/radarr/cf/dts.json
@@ -32,7 +32,7 @@
           "negate": true,
           "required": true,
           "fields": {
-              "value": "dts[-. ]?(es|(hd[. ]?)?(hr|hi))"
+              "value": "dts[ ._-]?(es|(hd[ ._-]?)?(hr|hi))"
           }
       },
       {
@@ -50,7 +50,7 @@
           "negate": true,
           "required": true,
           "fields": {
-              "value": "True[ .-]?HD|\\bATMOS(\\b|\\d)"
+              "value": "True[ ._-]?HD|\\bATMOS(\\b|\\d)"
           }
       },
       {

--- a/docs/json/radarr/cf/dv-disk.json
+++ b/docs/json/radarr/cf/dv-disk.json
@@ -21,7 +21,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\b(dv|dovi|dolby[ .]?v(ision)?)\\b"
+        "value": "\\b(dv|dovi|dolby[ ._-]?v(ision)?)\\b"
       }
     },
     {

--- a/docs/json/radarr/cf/dv-hdr10.json
+++ b/docs/json/radarr/cf/dv-hdr10.json
@@ -13,7 +13,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "^(?=.*\\b(DV|DoVi|Dolby[ .]?V(ision)?)\\b)(?=.*\\b((HDR10(?!(P(lus)?)\\b|\\+))|(HDR))\\b)"
+        "value": "^(?=.*\\b(DV|DoVi|Dolby[ ._-]?V(ision)?)\\b)(?=.*\\b((HDR10(?!(P(lus)?)\\b|\\+))|(HDR))\\b)"
       }
     },
     {
@@ -22,7 +22,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "^(?=.*\\b(DV|DoVi|Dolby[ .]?V(ision)?)\\b)(?=.*\\b((HDR10(?=(P(lus)?)\\b|\\+))))"
+        "value": "^(?=.*\\b(DV|DoVi|Dolby[ ._-]?V(ision)?)\\b)(?=.*\\b((HDR10(?=(P(lus)?)\\b|\\+))))"
       }
     },
     {
@@ -31,7 +31,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "\\b(DV[ .]HLG)\\b"
+        "value": "\\b(DV[ ._-]HLG)\\b"
       }
     },
     {
@@ -40,7 +40,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "\\b(DV[ .]SDR)\\b"
+        "value": "\\b(DV[ ._-]SDR)\\b"
       }
     }
   ]

--- a/docs/json/radarr/cf/dv-hdr10plus-boost.json
+++ b/docs/json/radarr/cf/dv-hdr10plus-boost.json
@@ -13,7 +13,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "^(?=.*\\b(DV|DoVi|Dolby[ .]?V(ision)?)\\b)(?=.*\\b((HDR10(?=(P(lus)?)\\b|\\+))))"
+        "value": "^(?=.*\\b(DV|DoVi|Dolby[ ._-]?V(ision)?)\\b)(?=.*\\b((HDR10(?=(P(lus)?)\\b|\\+))))"
       }
     },
     {
@@ -22,7 +22,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "\\b(DV[ .]HLG)\\b"
+        "value": "\\b(DV[ ._-]HLG)\\b"
       }
     },
     {
@@ -31,7 +31,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "\\b(DV[ .]SDR)\\b"
+        "value": "\\b(DV[ ._-]SDR)\\b"
       }
     }
   ]

--- a/docs/json/radarr/cf/dv-hdr10plus.json
+++ b/docs/json/radarr/cf/dv-hdr10plus.json
@@ -13,7 +13,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "^(?=.*\\b(DV|DoVi|Dolby[ .]?V(ision)?)\\b)(?=.*\\b((HDR10(?=(P(lus)?)\\b|\\+))))"
+        "value": "^(?=.*\\b(DV|DoVi|Dolby[ ._-]?V(ision)?)\\b)(?=.*\\b((HDR10(?=(P(lus)?)\\b|\\+))))"
       }
     },
     {
@@ -22,7 +22,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "\\b(DV[ .]HLG)\\b"
+        "value": "\\b(DV[ ._-]HLG)\\b"
       }
     },
     {
@@ -31,7 +31,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "\\b(DV[ .]SDR)\\b"
+        "value": "\\b(DV[ ._-]SDR)\\b"
       }
     }
   ]

--- a/docs/json/radarr/cf/dv-hlg.json
+++ b/docs/json/radarr/cf/dv-hlg.json
@@ -12,7 +12,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\b(DV[ .]HLG)\\b"
+        "value": "\\b(DV[ ._-]HLG)\\b"
       }
     },
     {
@@ -21,7 +21,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "^(?=.*\\b(DV|DoVi|Dolby[ .]?V(ision)?)\\b)(?=.*\\b(HDR(10)?(P(lus)?)?)\\b)"
+        "value": "^(?=.*\\b(DV|DoVi|Dolby[ ._-]?V(ision)?)\\b)(?=.*\\b(HDR(10)?(P(lus)?)?)\\b)"
       }
     },
     {
@@ -30,7 +30,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "\\b(DV[ .]SDR)\\b"
+        "value": "\\b(DV[ ._-]SDR)\\b"
       }
     }
   ]

--- a/docs/json/radarr/cf/dv-sdr.json
+++ b/docs/json/radarr/cf/dv-sdr.json
@@ -12,7 +12,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\b(DV[ .]SDR)\\b"
+        "value": "\\b(DV[ ._-]SDR)\\b"
       }
     },
     {
@@ -21,7 +21,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "^(?=.*\\b(DV|DoVi|Dolby[ .]?V(ision)?)\\b)(?=.*\\b(HDR(10)?(P(lus)?)?)\\b)"
+        "value": "^(?=.*\\b(DV|DoVi|Dolby[ ._-]?V(ision)?)\\b)(?=.*\\b(HDR(10)?(P(lus)?)?)\\b)"
       }
     },
     {
@@ -30,7 +30,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "\\b(DV[ .]HLG)\\b"
+        "value": "\\b(DV[ ._-]HLG)\\b"
       }
     }
   ]

--- a/docs/json/radarr/cf/dv-webdl.json
+++ b/docs/json/radarr/cf/dv-webdl.json
@@ -12,7 +12,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\b(dv|dovi|dolby[ .]?V(ision)?)\\b"
+        "value": "\\b(dv|dovi|dolby[ ._-]?V(ision)?)\\b"
       }
     },
     {

--- a/docs/json/radarr/cf/dv.json
+++ b/docs/json/radarr/cf/dv.json
@@ -12,7 +12,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\b(dv|dovi|dolby[ .]?v(ision)?)\\b"
+        "value": "\\b(dv|dovi|dolby[ ._-]?v(ision)?)\\b"
       }
     },
     {
@@ -21,7 +21,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "^(?=.*\\b(DV|DoVi|Dolby[ .]?V(ision)?)\\b)(?=.*\\b(HDR(10)?(P(lus)?)?)\\b)"
+        "value": "^(?=.*\\b(DV|DoVi|Dolby[ ._-]?V(ision)?)\\b)(?=.*\\b(HDR(10)?(P(lus)?)?)\\b)"
       }
     },
     {
@@ -30,7 +30,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "\\b(DV[ .]HLG)\\b"
+        "value": "\\b(DV[ ._-]HLG)\\b"
       }
     },
     {
@@ -39,7 +39,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "\\b(DV[ .]SDR)\\b"
+        "value": "\\b(DV[ ._-]SDR)\\b"
       }
     }
   ]

--- a/docs/json/radarr/cf/flac.json
+++ b/docs/json/radarr/cf/flac.json
@@ -49,7 +49,7 @@
           "negate": true,
           "required": true,
           "fields": {
-              "value": "True[ .-]?HD|\\bATMOS(\\b|\\d)"
+              "value": "True[ ._-]?HD|\\bATMOS(\\b|\\d)"
           }
       },
       {

--- a/docs/json/radarr/cf/hdr-undefined.json
+++ b/docs/json/radarr/cf/hdr-undefined.json
@@ -30,7 +30,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "\\b(dv|dovi|dolby[ .]?v(ision)?)\\b"
+        "value": "\\b(dv|dovi|dolby[ ._-]?v(ision)?)\\b"
       }
     },
     {

--- a/docs/json/radarr/cf/hdr.json
+++ b/docs/json/radarr/cf/hdr.json
@@ -21,7 +21,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "\\b(dv|dovi|dolby[ .]?v(ision)?)\\b"
+        "value": "\\b(dv|dovi|dolby[ ._-]?v(ision)?)\\b"
       }
     },
     {

--- a/docs/json/radarr/cf/hdr10.json
+++ b/docs/json/radarr/cf/hdr10.json
@@ -21,7 +21,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "^(?=.*\\b(DV|DoVi|Dolby[ .]?V(ision)?)\\b)(?=.*\\b(HDR(10)?(P(lus)?)?)\\b)"
+        "value": "^(?=.*\\b(DV|DoVi|Dolby[ ._-]?V(ision)?)\\b)(?=.*\\b(HDR(10)?(P(lus)?)?)\\b)"
       }
     },
     {
@@ -57,7 +57,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "\\b(dv|dovi|dolby[ .]?v(ision)?)\\b"
+        "value": "\\b(dv|dovi|dolby[ ._-]?v(ision)?)\\b"
       }
     }
   ]

--- a/docs/json/radarr/cf/hdr10plus-boost.json
+++ b/docs/json/radarr/cf/hdr10plus-boost.json
@@ -22,7 +22,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "^(?=.*\\b(DV|DoVi|Dolby[ .]?V(ision)?)\\b)(?=.*\\b(HDR(10)?(P(lus)?)?)\\b)"
+        "value": "^(?=.*\\b(DV|DoVi|Dolby[ ._-]?V(ision)?)\\b)(?=.*\\b(HDR(10)?(P(lus)?)?)\\b)"
       }
     },
     {
@@ -58,7 +58,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "\\b(dv|dovi|dolby[ .]?v(ision)?)\\b"
+        "value": "\\b(dv|dovi|dolby[ ._-]?v(ision)?)\\b"
       }
     }
   ]

--- a/docs/json/radarr/cf/hdr10plus.json
+++ b/docs/json/radarr/cf/hdr10plus.json
@@ -22,7 +22,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "^(?=.*\\b(DV|DoVi|Dolby[ .]?V(ision)?)\\b)(?=.*\\b(HDR(10)?(P(lus)?)?)\\b)"
+        "value": "^(?=.*\\b(DV|DoVi|Dolby[ ._-]?V(ision)?)\\b)(?=.*\\b(HDR(10)?(P(lus)?)?)\\b)"
       }
     },
     {
@@ -58,7 +58,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "\\b(dv|dovi|dolby[ .]?v(ision)?)\\b"
+        "value": "\\b(dv|dovi|dolby[ ._-]?v(ision)?)\\b"
       }
     }
   ]

--- a/docs/json/radarr/cf/hlg.json
+++ b/docs/json/radarr/cf/hlg.json
@@ -21,7 +21,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "\\b(dv|dovi|dolby[ .]?v(ision)?)\\b"
+        "value": "\\b(dv|dovi|dolby[ ._-]?v(ision)?)\\b"
       }
     },
     {

--- a/docs/json/radarr/cf/pcm.json
+++ b/docs/json/radarr/cf/pcm.json
@@ -49,7 +49,7 @@
           "negate": true,
           "required": true,
           "fields": {
-              "value": "True[ .-]?HD|\\bATMOS(\\b|\\d)"
+              "value": "True[ ._-]?HD|\\bATMOS(\\b|\\d)"
           }
       },
       {

--- a/docs/json/radarr/cf/pq.json
+++ b/docs/json/radarr/cf/pq.json
@@ -21,7 +21,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "\\b(dv|dovi|dolby[ .]?v(ision)?)\\b"
+        "value": "\\b(dv|dovi|dolby[ ._-]?v(ision)?)\\b"
       }
     },
     {

--- a/docs/json/radarr/cf/sdr-no-webdl.json
+++ b/docs/json/radarr/cf/sdr-no-webdl.json
@@ -21,7 +21,7 @@
       "negate": true,
       "required": false,
       "fields": {
-        "value": "\\bHDR(\\b|\\d)|\\b(dv|dovi|dolby[ .]?v(ision)?)\\b|\\b(FraMeSToR|HQMUX|SICFoI)\\b|\\b(PQ)\\b|\\bHLG(\\b|\\d)"
+        "value": "\\bHDR(\\b|\\d)|\\b(dv|dovi|dolby[ ._-]?v(ision)?)\\b|\\b(FraMeSToR|HQMUX|SICFoI)\\b|\\b(PQ)\\b|\\bHLG(\\b|\\d)"
       }
     },
     {

--- a/docs/json/radarr/cf/sdr.json
+++ b/docs/json/radarr/cf/sdr.json
@@ -21,7 +21,7 @@
       "negate": true,
       "required": false,
       "fields": {
-        "value": "\\bHDR(\\b|\\d)|\\b(dv|dovi|dolby[ .]?v(ision)?)\\b|\\b(FraMeSToR|HQMUX|SICFoI)\\b|\\b(PQ)\\b|\\bHLG(\\b|\\d)"
+        "value": "\\bHDR(\\b|\\d)|\\b(dv|dovi|dolby[ ._-]?v(ision)?)\\b|\\b(FraMeSToR|HQMUX|SICFoI)\\b|\\b(PQ)\\b|\\bHLG(\\b|\\d)"
       }
     },
     {

--- a/docs/json/radarr/cf/sic.json
+++ b/docs/json/radarr/cf/sic.json
@@ -48,7 +48,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\b(dv|dovi|dolby[ .]?v(ision)?)\\b"
+        "value": "\\b(dv|dovi|dolby[ ._-]?v(ision)?)\\b"
       }
     }
   ]

--- a/docs/json/radarr/cf/truehd-atmos.json
+++ b/docs/json/radarr/cf/truehd-atmos.json
@@ -14,7 +14,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "True[ .-]?HD|W4NK3R|HQMUX"
+        "value": "True[ ._-]?HD|W4NK3R|HQMUX"
       }
     },
     {

--- a/docs/json/radarr/cf/truehd.json
+++ b/docs/json/radarr/cf/truehd.json
@@ -14,7 +14,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "True[ .-]?HD"
+        "value": "True[ ._-]?HD"
       }
     },
     {

--- a/docs/json/radarr/cf/x265-no-hdrdv.json
+++ b/docs/json/radarr/cf/x265-no-hdrdv.json
@@ -22,7 +22,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "\\b(dv|dovi|dolby[ .]?v(ision)?|hdr(10(P(lus)?)?)?|pq)\\b"
+        "value": "\\b(dv|dovi|dolby[ ._-]?v(ision)?|hdr(10(P(lus)?)?)?|pq)\\b"
       }
     },
     {

--- a/docs/json/sonarr/cf/aac.json
+++ b/docs/json/sonarr/cf/aac.json
@@ -65,7 +65,7 @@
           "negate": true,
           "required": true,
           "fields": {
-              "value": "True[ .-]?HD|\\bATMOS(\\b|\\d)"
+              "value": "True[ ._-]?HD|\\bATMOS(\\b|\\d)"
           }
       }
   ]

--- a/docs/json/sonarr/cf/atmos-undefined.json
+++ b/docs/json/sonarr/cf/atmos-undefined.json
@@ -75,7 +75,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "True[ .-]?HD"
+        "value": "True[ ._-]?HD"
       }
     }
   ]

--- a/docs/json/sonarr/cf/dd.json
+++ b/docs/json/sonarr/cf/dd.json
@@ -29,7 +29,7 @@
           "negate": true,
           "required": true,
           "fields": {
-              "value": "True[ .-]?HD|\\bATMOS(\\b|\\d)"
+              "value": "True[ ._-]?HD|\\bATMOS(\\b|\\d)"
           }
       },
       {

--- a/docs/json/sonarr/cf/ddplus-atmos.json
+++ b/docs/json/sonarr/cf/ddplus-atmos.json
@@ -30,7 +30,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "True[ .-]?HD"
+        "value": "True[ ._-]?HD"
       }
     },
     {

--- a/docs/json/sonarr/cf/ddplus.json
+++ b/docs/json/sonarr/cf/ddplus.json
@@ -20,7 +20,7 @@
           "negate": true,
           "required": true,
           "fields": {
-              "value": "True[ .-]?HD|\\bATMOS(\\b|\\d)"
+              "value": "True[ ._-]?HD|\\bATMOS(\\b|\\d)"
           }
       },
       {

--- a/docs/json/sonarr/cf/dts-es.json
+++ b/docs/json/sonarr/cf/dts-es.json
@@ -38,7 +38,7 @@
           "negate": true,
           "required": true,
           "fields": {
-              "value": "DTS[ .]?[1-9]"
+              "value": "DTS[ ._-]?[1-9]"
           }
       },
       {

--- a/docs/json/sonarr/cf/dts-es.json
+++ b/docs/json/sonarr/cf/dts-es.json
@@ -11,7 +11,7 @@
           "negate": false,
           "required": true,
           "fields": {
-              "value": "dts[-. ]?es\\b"
+              "value": "dts[ ._-]?es\\b"
           }
       },
       {
@@ -20,7 +20,7 @@
           "negate": true,
           "required": true,
           "fields": {
-              "value": "True[ .-]?HD|\\bATMOS(\\b|\\d)"
+              "value": "True[ ._-]?HD|\\bATMOS(\\b|\\d)"
           }
       },
       {

--- a/docs/json/sonarr/cf/dts-hd-hra.json
+++ b/docs/json/sonarr/cf/dts-hd-hra.json
@@ -39,7 +39,7 @@
           "negate": true,
           "required": true,
           "fields": {
-              "value": "DTS[ .]?[1-9]"
+              "value": "DTS[ ._-]?[1-9]"
           }
       },
       {

--- a/docs/json/sonarr/cf/dts-hd-hra.json
+++ b/docs/json/sonarr/cf/dts-hd-hra.json
@@ -12,7 +12,7 @@
           "negate": false,
           "required": true,
           "fields": {
-              "value": "dts[-. ]?(hd[. ]?)?(hra?|hi\\b)"
+              "value": "dts[ ._-]?(hd[ ._-]?)?(hra?|hi\\b)"
           }
       },
       {
@@ -21,7 +21,7 @@
           "negate": true,
           "required": true,
           "fields": {
-              "value": "True[ .-]?HD|\\bATMOS(\\b|\\d)"
+              "value": "True[ ._-]?HD|\\bATMOS(\\b|\\d)"
           }
       },
       {

--- a/docs/json/sonarr/cf/dts-hd-ma.json
+++ b/docs/json/sonarr/cf/dts-hd-ma.json
@@ -22,7 +22,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "True[ .-]?HD|\\bATMOS(\\b|\\d)"
+        "value": "True[ ._-]?HD|\\bATMOS(\\b|\\d)"
       }
     },
     {
@@ -85,7 +85,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "dts[-. ]?(es|(hd[. ]?)?(hr|hi))"
+        "value": "dts[ ._-]?(es|(hd[ ._-]?)?(hr|hi))"
       }
     }
   ]

--- a/docs/json/sonarr/cf/dts-x.json
+++ b/docs/json/sonarr/cf/dts-x.json
@@ -20,7 +20,7 @@
           "negate": true,
           "required": true,
           "fields": {
-              "value": "DTS[ .]?[1-9]"
+              "value": "DTS[ ._-]?[1-9]"
           }
       },
       {

--- a/docs/json/sonarr/cf/dts-x.json
+++ b/docs/json/sonarr/cf/dts-x.json
@@ -47,7 +47,7 @@
           "negate": true,
           "required": true,
           "fields": {
-              "value": "True[ .-]?HD|\\bATMOS(\\b|\\d)"
+              "value": "True[ ._-]?HD|\\bATMOS(\\b|\\d)"
           }
       },
       {

--- a/docs/json/sonarr/cf/dts.json
+++ b/docs/json/sonarr/cf/dts.json
@@ -30,7 +30,7 @@
           "negate": true,
           "required": true,
           "fields": {
-              "value": "dts[-. ]?(es|(hd[. ]?)?(hr|hi))"
+              "value": "dts[ ._-]?(es|(hd[ ._-]?)?(hr|hi))"
           }
       },
       {
@@ -48,7 +48,7 @@
           "negate": true,
           "required": true,
           "fields": {
-              "value": "True[ .-]?HD|\\bATMOS(\\b|\\d)"
+              "value": "True[ ._-]?HD|\\bATMOS(\\b|\\d)"
           }
       },
       {

--- a/docs/json/sonarr/cf/dv-disk.json
+++ b/docs/json/sonarr/cf/dv-disk.json
@@ -21,7 +21,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\b(dv|dovi|dolby[ .]?v(ision)?)\\b"
+        "value": "\\b(dv|dovi|dolby[ ._-]?v(ision)?)\\b"
       }
     },
     {

--- a/docs/json/sonarr/cf/dv-hdr10.json
+++ b/docs/json/sonarr/cf/dv-hdr10.json
@@ -13,7 +13,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "^(?=.*\\b(DV|DoVi|Dolby[ .]?V(ision)?)\\b)(?=.*\\b((HDR10(?!(P(lus)?)\\b|\\+))|(HDR))\\b)"
+        "value": "^(?=.*\\b(DV|DoVi|Dolby[ ._-]?V(ision)?)\\b)(?=.*\\b((HDR10(?!(P(lus)?)\\b|\\+))|(HDR))\\b)"
       }
     },
     {
@@ -22,7 +22,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "^(?=.*\\b(DV|DoVi|Dolby[ .]?V(ision)?)\\b)(?=.*\\b((HDR10(?=(P(lus)?)\\b|\\+))))"
+        "value": "^(?=.*\\b(DV|DoVi|Dolby[ ._-]?V(ision)?)\\b)(?=.*\\b((HDR10(?=(P(lus)?)\\b|\\+))))"
       }
     },
     {
@@ -31,7 +31,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "\\b(DV[ .]HLG)\\b"
+        "value": "\\b(DV[ ._-]HLG)\\b"
       }
     },
     {
@@ -40,7 +40,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "\\b(DV[ .]SDR)\\b"
+        "value": "\\b(DV[ ._-]SDR)\\b"
       }
     }
   ]

--- a/docs/json/sonarr/cf/dv-hdr10plus-boost.json
+++ b/docs/json/sonarr/cf/dv-hdr10plus-boost.json
@@ -13,7 +13,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "^(?=.*\\b(DV|DoVi|Dolby[ .]?V(ision)?)\\b)(?=.*\\b((HDR10(?=(P(lus)?)\\b|\\+))))"
+        "value": "^(?=.*\\b(DV|DoVi|Dolby[ ._-]?V(ision)?)\\b)(?=.*\\b((HDR10(?=(P(lus)?)\\b|\\+))))"
       }
     },
     {
@@ -22,7 +22,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "\\b(DV[ .]HLG)\\b"
+        "value": "\\b(DV[ ._-]HLG)\\b"
       }
     },
     {
@@ -31,7 +31,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "\\b(DV[ .]SDR)\\b"
+        "value": "\\b(DV[ ._-]SDR)\\b"
       }
     }
   ]

--- a/docs/json/sonarr/cf/dv-hdr10plus.json
+++ b/docs/json/sonarr/cf/dv-hdr10plus.json
@@ -13,7 +13,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "^(?=.*\\b(DV|DoVi|Dolby[ .]?V(ision)?)\\b)(?=.*\\b((HDR10(?=(P(lus)?)\\b|\\+))))"
+        "value": "^(?=.*\\b(DV|DoVi|Dolby[ ._-]?V(ision)?)\\b)(?=.*\\b((HDR10(?=(P(lus)?)\\b|\\+))))"
       }
     },
     {
@@ -22,7 +22,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "\\b(DV[ .]HLG)\\b"
+        "value": "\\b(DV[ ._-]HLG)\\b"
       }
     },
     {
@@ -31,7 +31,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "\\b(DV[ .]SDR)\\b"
+        "value": "\\b(DV[ ._-]SDR)\\b"
       }
     }
   ]

--- a/docs/json/sonarr/cf/dv-hlg.json
+++ b/docs/json/sonarr/cf/dv-hlg.json
@@ -12,7 +12,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\b(DV[ .]HLG)\\b"
+        "value": "\\b(DV[ ._-]HLG)\\b"
       }
     },
     {
@@ -21,7 +21,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "^(?=.*\\b(DV|DoVi|Dolby[ .]?V(ision)?)\\b)(?=.*\\b(HDR(10)?(P(lus)?)?)\\b)"
+        "value": "^(?=.*\\b(DV|DoVi|Dolby[ ._-]?V(ision)?)\\b)(?=.*\\b(HDR(10)?(P(lus)?)?)\\b)"
       }
     },
     {
@@ -30,7 +30,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "\\b(DV[ .]SDR)\\b"
+        "value": "\\b(DV[ ._-]SDR)\\b"
       }
     }
   ]

--- a/docs/json/sonarr/cf/dv-sdr.json
+++ b/docs/json/sonarr/cf/dv-sdr.json
@@ -12,7 +12,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\b(DV[ .]SDR)\\b"
+        "value": "\\b(DV[ ._-]SDR)\\b"
       }
     },
     {
@@ -21,7 +21,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "^(?=.*\\b(DV|DoVi|Dolby[ .]?V(ision)?)\\b)(?=.*\\b(HDR(10)?(P(lus)?)?)\\b)"
+        "value": "^(?=.*\\b(DV|DoVi|Dolby[ ._-]?V(ision)?)\\b)(?=.*\\b(HDR(10)?(P(lus)?)?)\\b)"
       }
     },
     {
@@ -30,7 +30,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "\\b(DV[ .]HLG)\\b"
+        "value": "\\b(DV[ ._-]HLG)\\b"
       }
     }
   ]

--- a/docs/json/sonarr/cf/dv-webdl.json
+++ b/docs/json/sonarr/cf/dv-webdl.json
@@ -12,7 +12,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\b(dv|dovi|dolby[ .]?v(ision)?)\\b"
+        "value": "\\b(dv|dovi|dolby[ ._-]?v(ision)?)\\b"
       }
     },
     {

--- a/docs/json/sonarr/cf/dv.json
+++ b/docs/json/sonarr/cf/dv.json
@@ -12,7 +12,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\b(dv|dovi|dolby[ .]?v(ision)?)\\b"
+        "value": "\\b(dv|dovi|dolby[ ._-]?v(ision)?)\\b"
       }
     },
     {
@@ -21,7 +21,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "^(?=.*\\b(DV|DoVi|Dolby[ .]?V(ision)?)\\b)(?=.*\\b(HDR(10)?(P(lus)?)?)\\b)"
+        "value": "^(?=.*\\b(DV|DoVi|Dolby[ ._-]?V(ision)?)\\b)(?=.*\\b(HDR(10)?(P(lus)?)?)\\b)"
       }
     },
     {
@@ -30,7 +30,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "\\b(DV[ .]HLG)\\b"
+        "value": "\\b(DV[ ._-]HLG)\\b"
       }
     },
     {
@@ -39,7 +39,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "\\b(DV[ .]SDR)\\b"
+        "value": "\\b(DV[ ._-]SDR)\\b"
       }
     }
   ]

--- a/docs/json/sonarr/cf/flac.json
+++ b/docs/json/sonarr/cf/flac.json
@@ -47,7 +47,7 @@
           "negate": true,
           "required": true,
           "fields": {
-              "value": "True[ .-]?HD|\\bATMOS(\\b|\\d)"
+              "value": "True[ ._-]?HD|\\bATMOS(\\b|\\d)"
           }
       },
       {

--- a/docs/json/sonarr/cf/hdr-undefined.json
+++ b/docs/json/sonarr/cf/hdr-undefined.json
@@ -30,7 +30,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "\\b(dv|dovi|dolby[ .]?v(ision)?)\\b"
+        "value": "\\b(dv|dovi|dolby[ ._-]?v(ision)?)\\b"
       }
     },
     {

--- a/docs/json/sonarr/cf/hdr.json
+++ b/docs/json/sonarr/cf/hdr.json
@@ -21,7 +21,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "\\b(dv|dovi|dolby[ .]?v(ision)?)\\b"
+        "value": "\\b(dv|dovi|dolby[ ._-]?v(ision)?)\\b"
       }
     },
     {

--- a/docs/json/sonarr/cf/hdr10.json
+++ b/docs/json/sonarr/cf/hdr10.json
@@ -21,7 +21,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "^(?=.*\\b(DV|DoVi|Dolby[ .]?V(ision)?)\\b)(?=.*\\b(HDR(10)?(P(lus)?)?)\\b)"
+        "value": "^(?=.*\\b(DV|DoVi|Dolby[ ._-]?V(ision)?)\\b)(?=.*\\b(HDR(10)?(P(lus)?)?)\\b)"
       }
     },
     {
@@ -57,7 +57,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "\\b(dv|dovi|dolby[ .]?v(ision)?)\\b"
+        "value": "\\b(dv|dovi|dolby[ ._-]?v(ision)?)\\b"
       }
     }
   ]

--- a/docs/json/sonarr/cf/hdr10plus-boost.json
+++ b/docs/json/sonarr/cf/hdr10plus-boost.json
@@ -22,7 +22,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "^(?=.*\\b(DV|DoVi|Dolby[ .]?V(ision)?)\\b)(?=.*\\b(HDR(10)?(P(lus)?)?)\\b)"
+        "value": "^(?=.*\\b(DV|DoVi|Dolby[ ._-]?V(ision)?)\\b)(?=.*\\b(HDR(10)?(P(lus)?)?)\\b)"
       }
     },
     {
@@ -58,7 +58,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "\\b(dv|dovi|dolby[ .]?v(ision)?)\\b"
+        "value": "\\b(dv|dovi|dolby[ ._-]?v(ision)?)\\b"
       }
     }
   ]

--- a/docs/json/sonarr/cf/hdr10plus.json
+++ b/docs/json/sonarr/cf/hdr10plus.json
@@ -22,7 +22,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "^(?=.*\\b(DV|DoVi|Dolby[ .]?V(ision)?)\\b)(?=.*\\b(HDR(10)?(P(lus)?)?)\\b)"
+        "value": "^(?=.*\\b(DV|DoVi|Dolby[ ._-]?V(ision)?)\\b)(?=.*\\b(HDR(10)?(P(lus)?)?)\\b)"
       }
     },
     {
@@ -58,7 +58,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "\\b(dv|dovi|dolby[ .]?v(ision)?)\\b"
+        "value": "\\b(dv|dovi|dolby[ ._-]?v(ision)?)\\b"
       }
     }
   ]

--- a/docs/json/sonarr/cf/hlg.json
+++ b/docs/json/sonarr/cf/hlg.json
@@ -21,7 +21,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "\\b(dv|dovi|dolby[ .]?v(ision)?)\\b"
+        "value": "\\b(dv|dovi|dolby[ ._-]?v(ision)?)\\b"
       }
     },
     {

--- a/docs/json/sonarr/cf/pcm.json
+++ b/docs/json/sonarr/cf/pcm.json
@@ -47,7 +47,7 @@
           "negate": true,
           "required": true,
           "fields": {
-              "value": "True[ .-]?HD|\\bATMOS(\\b|\\d)"
+              "value": "True[ ._-]?HD|\\bATMOS(\\b|\\d)"
           }
       },
       {

--- a/docs/json/sonarr/cf/pq.json
+++ b/docs/json/sonarr/cf/pq.json
@@ -21,7 +21,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "\\b(dv|dovi|dolby[ .]?v(ision)?)\\b"
+        "value": "\\b(dv|dovi|dolby[ ._-]?v(ision)?)\\b"
       }
     },
     {

--- a/docs/json/sonarr/cf/sdr-no-webdl.json
+++ b/docs/json/sonarr/cf/sdr-no-webdl.json
@@ -21,7 +21,7 @@
       "negate": true,
       "required": false,
       "fields": {
-        "value": "\\bHDR(\\b|\\d)|\\b(dv|dovi|dolby[ .]?v(ision)?)\\b|\\b(FraMeSToR|HQMUX|SICFoI)\\b|\\b(PQ)\\b|\\bHLG(\\b|\\d)"
+        "value": "\\bHDR(\\b|\\d)|\\b(dv|dovi|dolby[ ._-]?v(ision)?)\\b|\\b(FraMeSToR|HQMUX|SICFoI)\\b|\\b(PQ)\\b|\\bHLG(\\b|\\d)"
       }
     },
     {

--- a/docs/json/sonarr/cf/sdr.json
+++ b/docs/json/sonarr/cf/sdr.json
@@ -21,7 +21,7 @@
       "negate": true,
       "required": false,
       "fields": {
-        "value": "\\bHDR(\\b|\\d)|\\b(dv|dovi|dolby[ .]?v(ision)?)\\b|\\b(FraMeSToR|HQMUX|SICFoI)\\b|\\b(PQ)\\b|\\bHLG(\\b|\\d)"
+        "value": "\\bHDR(\\b|\\d)|\\b(dv|dovi|dolby[ ._-]?v(ision)?)\\b|\\b(FraMeSToR|HQMUX|SICFoI)\\b|\\b(PQ)\\b|\\bHLG(\\b|\\d)"
       }
     },
     {

--- a/docs/json/sonarr/cf/truehd-atmos.json
+++ b/docs/json/sonarr/cf/truehd-atmos.json
@@ -12,7 +12,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "True[ .-]?HD"
+        "value": "True[ ._-]?HD"
       }
     },
     {

--- a/docs/json/sonarr/cf/truehd.json
+++ b/docs/json/sonarr/cf/truehd.json
@@ -12,7 +12,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "True[ .-]?HD"
+        "value": "True[ ._-]?HD"
       }
     },
     {

--- a/docs/json/sonarr/cf/x265-no-hdrdv.json
+++ b/docs/json/sonarr/cf/x265-no-hdrdv.json
@@ -22,7 +22,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "\\b(dv|dovi|dolby[ .]?v(ision)?|hdr(10(P(lus)?)?)?|pq)\\b"
+        "value": "\\b(dv|dovi|dolby[ ._-]?v(ision)?|hdr(10(P(lus)?)?)?|pq)\\b"
       }
     },
     {


### PR DESCRIPTION
# Pull Request

## Purpose

Fix: #1743 

## Approach

- Identify custom formats that would be used in guide's naming scheme, that match against a Radarr or Sonarr file naming token, that also feature word separators
- Replace appropriate word separators so they include ` `, `.`, `-` and `_`.

## Open Questions and Pre-Merge TODOs

- [ ] Confirm whether this is going ahead

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
