### PR TITLE
feat (Starr): Add BEN THE MEN to LQ (Release Title) Custom Formats

### DIFF
--- a/docs/json/radarr/cf/lq-release-title.json
+++ b/docs/json/radarr/cf/lq-release-title.json
@@ -16,6 +16,15 @@
       }
     },
     {
+      "name": "BEN THE MEN",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(BEN[ ._-]THE[ ._-]MEN)\\b"
+      }
+    },
+    {
       "name": "BiTOR (2160p)",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,

--- a/docs/json/sonarr/cf/lq-release-title.json
+++ b/docs/json/sonarr/cf/lq-release-title.json
@@ -23,6 +23,15 @@
       "fields": {
         "value": "(?=.*?(\\b2160p\\b))(?=.*?(\\bBiTOR\\b))"
       }
+    },
+    {
+      "name": "BEN THE MEN",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(BEN[ ._-]THE[ ._-]MEN)\\b"
+      }
     }
   ]
 }


### PR DESCRIPTION
# Pull Request

## Purpose

Update the LQ (Release Title) custom formats to add the BEN THE MEN release group, as their release titles don't format the release group name properly, or include the quality of the release (e.g., Bluray, WEBDL etc). This results in the breaking of automation.

## Approach

- Add the rlsgrp BEN THE MEN to the LQ (Release Title) custom formats for Radarr and Sonarr

## Open Questions and Pre-Merge TODOs

None

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
