### PR TITLE
fix(guide): SABnzbd Scripts - Updated Clean.py

### DIFF
--- a/docs/Downloaders/SABnzbd/scripts/Clean/Clean.py
+++ b/docs/Downloaders/SABnzbd/scripts/Clean/Clean.py
@@ -20,13 +20,11 @@
 import sys
 import re
 
+# normalize argv to scriptname and just first 8 arguments to maintain compatibility
+sys.argv = sys.argv[:9]
 try:
-    # Parse the 18 input variables for SABnzbd version >= 4.0.0
-    (scriptname, nzbname, postprocflags, category, script, prio, downloadsize, grouplist, showname, season, episodenumber, episodename, is_proper, resolution, decade, year, month, day, job_type) = sys.argv
-    downloadsize = int(downloadsize)
-except ValueError:
-    # ...or 11 variables for earlier versions
-    (scriptname, nzbname, postprocflags, category, script, prio, downloadsize, grouplist, showname, season, episodenumber, episodename) = sys.argv
+    # Parse the input variables for SABnzbd version >= 4.2.0
+    (scriptname, nzbname, postprocflags, category, script, prio, downloadsize, grouplist) = sys.argv
 except:
     sys.exit(1)    # exit with 1 causes SABnzbd to ignore the output of this script
 


### PR DESCRIPTION
normalize sys arguments
as pre-queue arguments were changed again in 4.2.0, so rather than handle all three variants (which isnt needed for this script as those fields arent used) can simplify to just focus on the ones that are.

# Pull Request

## Purpose

make pre-q script work again 

## Approach

solve issue with pre-q not working once sab was updated to 4.2.x

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
