### PR TITLE
fix (Sonarr): Fix x265 (no HDR/DV) section on Sonarr collection of custom formats page

### DIFF
--- a/docs/Sonarr/sonarr-collection-of-custom-formats.md
+++ b/docs/Sonarr/sonarr-collection-of-custom-formats.md
@@ -1167,7 +1167,7 @@ We've made 3 guides related to this.
 
 ??? question "x265 (no HDR/DV) - [Click to show/hide]"
 
-  This blocks most 720/1080p (HD) releases that are encoded in x265.
+    This blocks most 720/1080p (HD) releases that are encoded in x265.
 
     **But it will allow 720/1080p x265 releases if they have HDR and/or DV**
 


### PR DESCRIPTION
# Pull Request

## Purpose

Fix x265 (no HDR/DV) toggle so content correctly appears inside the selector.

## Approach

- Fix indentation in x265 (no HDR/DV) description text.

## Open Questions and Pre-Merge TODOs

- [x] Build and test locally

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
