### PR TITLE
feat(guide): SQP - Add `DV HDR10+ Boost` to SQP-1 4k optional

### DIFF
--- a/docs/updates.txt
+++ b/docs/updates.txt
@@ -1,3 +1,11 @@
+# 2024-02-18 00:00
+- [feat(starr): Add Custom Format for streaming service VIU](https://github.com/TRaSH-Guides/Guides/pull/1795)
+- [feat(guide): SQP-1 - Add CF 10bit to unwanted to block Hi10P](https://github.com/TRaSH-Guides/Guides/pull/1798)
+- [feat(starr): Add Custom Format for streaming service ITVX](https://github.com/TRaSH-Guides/Guides/pull/1799)
+- [feat(guide): Recommended naming scheme - Add Enable Rename instructions](https://github.com/TRaSH-Guides/Guides/pull/1800)
+- [feat(guide): hardlinks - add links to the full downloader guide](https://github.com/TRaSH-Guides/Guides/pull/1801)
+- [feat(guide): SQP - Add DV HDR10+ Boost to SQP-1 4k optional](https://github.com/TRaSH-Guides/Guides/pull/1796)
+
 # 2024-02-04 21:00
 - [feat(guide): Collection of Custom Formats - Streaming Services- Improve description](https://github.com/TRaSH-Guides/Guides/pull/1775)
 - [feat(guide): Downloaders Qbt - Updated instructions to use new arguments for unRaid Qbt Mover](https://github.com/TRaSH-Guides/Guides/pull/1781)

--- a/includes/sqp/1-4k-cf-scoring-sqp1.md
+++ b/includes/sqp/1-4k-cf-scoring-sqp1.md
@@ -97,23 +97,26 @@
 {! include-markdown "../../includes/cf/radarr-unwanted-uhd.md" !}
 
 ??? abstract "Optional - [Click to show/hide]"
-    | Custom Format                                                                                                       |                                    Score                                     | Trash ID                                          |
-    | ------------------------------------------------------------------------------------------------------------------- | :--------------------------------------------------------------------------: | ------------------------------------------------- |
-    | [{{ radarr['cf']['bad-dual-groups']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#bad-dual-groups)       |       {{ radarr['cf']['bad-dual-groups']['trash_scores']['default'] }}       | {{ radarr['cf']['bad-dual-groups']['trash_id'] }} |
-    | [{{ radarr['cf']['hdr10plus-boost']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#hdr10plus-boost)       |       {{ radarr['cf']['hdr10plus-boost']['trash_scores']['default'] }}       | {{ radarr['cf']['hdr10plus-boost']['trash_id'] }} |
-    | [{{ radarr['cf']['evo-no-webdl']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#evo-no-webdl)             |        {{ radarr['cf']['evo-no-webdl']['trash_scores']['default'] }}         | {{ radarr['cf']['evo-no-webdl']['trash_id'] }}    |
-    | [{{ radarr['cf']['no-rlsgroup']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#no-rlsgroup)               |         {{ radarr['cf']['no-rlsgroup']['trash_scores']['default'] }}         | {{ radarr['cf']['no-rlsgroup']['trash_id'] }}     |
-    | [{{ radarr['cf']['obfuscated']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#obfuscated)                 |         {{ radarr['cf']['obfuscated']['trash_scores']['default'] }}          | {{ radarr['cf']['obfuscated']['trash_id'] }}      |
-    | [{{ radarr['cf']['retags']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#retags)                         |           {{ radarr['cf']['retags']['trash_scores']['default'] }}            | {{ radarr['cf']['retags']['trash_id'] }}          |
-    | [{{ radarr['cf']['scene']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#scene)                           |            {{ radarr['cf']['scene']['trash_scores']['default'] }}            | {{ radarr['cf']['scene']['trash_id'] }}           |
-    | [{{ radarr['cf']['x265-no-hdrdv']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#x265-no-hdrdv) :warning: |        {{ radarr['cf']['x265-no-hdrdv']['trash_scores']['default'] }}        | {{ radarr['cf']['x265-no-hdrdv']['trash_id'] }}   |
-    | [{{ radarr['cf']['av1']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#av1)                               | :warning: {{ radarr['cf']['av1']['trash_scores']['sqp-1-2160p'] }} :warning: | {{ radarr['cf']['av1']['trash_id'] }}             |
-    | [{{ radarr['cf']['sdr']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#sdr)                               |             {{ radarr['cf']['sdr']['trash_scores']['default'] }}             | {{ radarr['cf']['sdr']['trash_id'] }}             |
+    | Custom Format                                                                                                       |                                    Score                                     | Trash ID                                             |
+    | ------------------------------------------------------------------------------------------------------------------- | :--------------------------------------------------------------------------: | ---------------------------------------------------- |
+    | [{{ radarr['cf']['bad-dual-groups']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#bad-dual-groups)       |       {{ radarr['cf']['bad-dual-groups']['trash_scores']['default'] }}       | {{ radarr['cf']['bad-dual-groups']['trash_id'] }}    |
+    | [{{ radarr['cf']['hdr10plus-boost']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#hdr10plus-boost)       |       {{ radarr['cf']['hdr10plus-boost']['trash_scores']['default'] }}       | {{ radarr['cf']['hdr10plus-boost']['trash_id'] }}    |
+    | [{{ radarr['cf']['dv-hdr10plus-boost']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#dv-hdr10plus-boost) |     {{ radarr['cf']['dv-hdr10plus-boost']['trash_scores']['default'] }}      | {{ radarr['cf']['dv-hdr10plus-boost']['trash_id'] }} |
+    | [{{ radarr['cf']['evo-no-webdl']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#evo-no-webdl)             |        {{ radarr['cf']['evo-no-webdl']['trash_scores']['default'] }}         | {{ radarr['cf']['evo-no-webdl']['trash_id'] }}       |
+    | [{{ radarr['cf']['no-rlsgroup']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#no-rlsgroup)               |         {{ radarr['cf']['no-rlsgroup']['trash_scores']['default'] }}         | {{ radarr['cf']['no-rlsgroup']['trash_id'] }}        |
+    | [{{ radarr['cf']['obfuscated']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#obfuscated)                 |         {{ radarr['cf']['obfuscated']['trash_scores']['default'] }}          | {{ radarr['cf']['obfuscated']['trash_id'] }}         |
+    | [{{ radarr['cf']['retags']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#retags)                         |           {{ radarr['cf']['retags']['trash_scores']['default'] }}            | {{ radarr['cf']['retags']['trash_id'] }}             |
+    | [{{ radarr['cf']['scene']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#scene)                           |            {{ radarr['cf']['scene']['trash_scores']['default'] }}            | {{ radarr['cf']['scene']['trash_id'] }}              |
+    | [{{ radarr['cf']['x265-no-hdrdv']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#x265-no-hdrdv) :warning: |        {{ radarr['cf']['x265-no-hdrdv']['trash_scores']['default'] }}        | {{ radarr['cf']['x265-no-hdrdv']['trash_id'] }}      |
+    | [{{ radarr['cf']['av1']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#av1)                               | :warning: {{ radarr['cf']['av1']['trash_scores']['sqp-1-2160p'] }} :warning: | {{ radarr['cf']['av1']['trash_id'] }}                |
+    | [{{ radarr['cf']['sdr']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#sdr)                               |             {{ radarr['cf']['sdr']['trash_scores']['default'] }}             | {{ radarr['cf']['sdr']['trash_id'] }}                |
 
     !!! tip "I recommend to use the the following Custom Formats"
         - `x265 (no HDR/DV)` over the `x265 (HD)`, Read the Why below and don't forget to read the warning,<br>:warning: Only ever include one of them :warning:
         - `SDR` This will help to prevent to grab UHD/4k releases without HDR Formats
-        - `AV1` This will help to prevent to grab AV1 releases
+        - `AV1` This will help to prevent to grab AV1 releases.
+
+    !!! danger "Adding any of the `HDR10+ Boosts` could result in less streaming optimized releases :warning:"
 
     ------
 
@@ -121,7 +124,8 @@
 
     - **{{ radarr['cf']['bad-dual-groups']['name'] }}:** [*Optional*] These groups take the original release, then they add their own preferred language (ex. Portuguese) as the main audio track (AAC 2.0), What results after renaming and FFprobe that the media file will be recognized as Portuguese AAC audio. It's a common rule that you add the best audio as first.
     Also they often even rename the release name in to Portuguese.
-    - **{{ radarr['cf']['hdr10plus-boost']['name'] }}:** [*Optional*] (use this one only if you have a (Samsung) TV that supports HDR10+ and you don't have a Setup that supports DV or you prefer HDR10+)
+    - **{{ radarr['cf']['hdr10plus-boost']['name'] }}:** [*Optional*] (use this one only if you have a (Samsung) TV that supports HDR10+ and don't mind the chance to get less streaming optimized releases)
+    - **{{ radarr['cf']['dv-hdr10plus-boost']['name'] }}:** [*Optional*] (use this one only if you don't mind the chance to get less streaming optimized releases)
     - **{{ radarr['cf']['evo-no-webdl']['name'] }}:** This group is often banned for the low quality Blu-ray releases, but their WEB-DL are okay.
     - **{{ radarr['cf']['no-rlsgroup']['name'] }}:** [*Optional*] Some indexers strip out the release group what could result in LQ groups getting a higher score. For example a lot of EVO releases end up stripping the group name, so they appear as "upgrades", and they end up getting a decent score if other things match.
     - **{{ radarr['cf']['obfuscated']['name'] }}:** [*Optional*] (use these only if you dislike renamed releases)

--- a/includes/sqp/1-4k-cf-scoring-sqp1.md
+++ b/includes/sqp/1-4k-cf-scoring-sqp1.md
@@ -111,10 +111,10 @@
     | [{{ radarr['cf']['av1']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#av1)                               | :warning: {{ radarr['cf']['av1']['trash_scores']['sqp-1-2160p'] }} :warning: | {{ radarr['cf']['av1']['trash_id'] }}                |
     | [{{ radarr['cf']['sdr']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#sdr)                               |             {{ radarr['cf']['sdr']['trash_scores']['default'] }}             | {{ radarr['cf']['sdr']['trash_id'] }}                |
 
-    !!! tip "I recommend to use the the following Custom Formats"
+    !!! tip "I recommend using the following Custom Formats"
         - `x265 (no HDR/DV)` over the `x265 (HD)`, Read the Why below and don't forget to read the warning,<br>:warning: Only ever include one of them :warning:
-        - `SDR` This will help to prevent to grab UHD/4k releases without HDR Formats
-        - `AV1` This will help to prevent to grab AV1 releases.
+        - `SDR` This will prevent grabbing UHD/4K releases without HDR Formats
+        - `AV1` This will prevent grabbing AV1 releases.
 
     !!! danger "Adding any of the `HDR10+ Boosts` could result in less streaming optimized releases :warning:"
 


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->

Added missing `DV HDR10+ Boost` to SQP-1 4k optional

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

Added `DV HDR10+ Boost` to SQP-1 4k optional and included warning and info

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
