### PR TITLE
feat(guide): SQP-1 - Add CF `10bit` to unwanted to block `Hi10P`

### DIFF
--- a/docs/json/radarr/cf/10bit.json
+++ b/docs/json/radarr/cf/10bit.json
@@ -1,5 +1,9 @@
 {
   "trash_id": "a5d148168c4506b55cf53984107c396e",
+  "trash_scores": {
+    "sqp-1-1080p": -10000,
+    "sqp-1-2160p": -10000
+  },
   "name": "10bit",
   "includeCustomFormatWhenRenaming": false,
   "specifications": [

--- a/includes/sqp/1-4k-cf-scoring-sqp1.md
+++ b/includes/sqp/1-4k-cf-scoring-sqp1.md
@@ -94,7 +94,7 @@
 
 {! include-markdown "../../includes/cf/radarr-misc.md" !}
 
-{! include-markdown "../../includes/cf/radarr-unwanted-uhd.md" !}
+{! include-markdown "../../includes/sqp/radarr-unwanted-uhd-sqp1.md" !}
 
 ??? abstract "Optional - [Click to show/hide]"
     | Custom Format                                                                                                       |                                    Score                                     | Trash ID                                          |

--- a/includes/sqp/1-cf-scoring.md
+++ b/includes/sqp/1-cf-scoring.md
@@ -53,7 +53,7 @@
 
 {! include-markdown "../../includes/cf/radarr-misc.md" !}
 
-{! include-markdown "../../includes/cf/radarr-unwanted.md" !}
+{! include-markdown "../../includes/sqp/radarr-unwanted-sqp1.md" !}
 
 {! include-markdown "../../includes/sqp/hd-radarr-optional.md" !}
 

--- a/includes/sqp/radarr-unwanted-sqp1.md
+++ b/includes/sqp/radarr-unwanted-sqp1.md
@@ -1,0 +1,25 @@
+??? abstract "Unwanted - [Click to show/hide]"
+    | Custom Format                                                                                                   |                               Score                               | Trash ID                                           |
+    | --------------------------------------------------------------------------------------------------------------- | :---------------------------------------------------------------: | -------------------------------------------------- |
+    | [{{ radarr['cf']['br-disk']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#br-disk)                   |     {{ radarr['cf']['br-disk']['trash_scores']['default'] }}      | {{ radarr['cf']['br-disk']['trash_id'] }}          |
+    | [{{ radarr['cf']['lq']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#lq)                             |        {{ radarr['cf']['lq']['trash_scores']['default'] }}        | {{ radarr['cf']['lq']['trash_id'] }}               |
+    | [{{ radarr['cf']['lq-release-title']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#lq-release-title) | {{ radarr['cf']['lq-release-title']['trash_scores']['default'] }} | {{ radarr['cf']['lq-release-title']['trash_id'] }} |
+    | [{{ radarr['cf']['x265-hd']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#x265-hd) :warning:         |     {{ radarr['cf']['x265-hd']['trash_scores']['default'] }}      | {{ radarr['cf']['x265-hd']['trash_id'] }}          |
+    | [{{ radarr['cf']['3d']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#3d)                             |        {{ radarr['cf']['3d']['trash_scores']['default'] }}        | {{ radarr['cf']['3d']['trash_id'] }}               |
+    | [{{ radarr['cf']['extras']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#extras)                     |      {{ radarr['cf']['extras']['trash_scores']['default'] }}      | {{ radarr['cf']['extras']['trash_id'] }}           |
+    | [{{ radarr['cf']['10bit']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#10bit)                       |   {{ radarr['cf']['10bit']['trash_scores']['sqp-1-1080p'] }}    | {{ radarr['cf']['10bit']['trash_id'] }}            |
+
+    ------
+
+    Breakdown and Why
+
+    - **{{ radarr['cf']['br-disk']['name'] }} :** This is a custom format to help Radarr recognize & ignore BR-DISK (ISO's and Blu-ray folder structure) in addition to the standard BR-DISK quality.
+    - **{{ radarr['cf']['lq']['name'] }}:** A collection of known Low Quality groups that are often banned from the the top trackers because the lack of quality or other reasons.
+    - **{{ radarr['cf']['lq-release-title']['name'] }}:** A collection of terms seen in the titles of Low Quality releases that are not captured by using a release group name.
+    - **{{ radarr['cf']['x265-hd']['name'] }}:** This blocks 720/1080p (HD) releases that are encoded in x265. - More info [HERE](/Misc/x265-4k/){:target="_blank" rel="noopener noreferrer"}.
+
+        !!! Danger "Don't use this together with [{{ radarr['cf']['x265-no-hdrdv']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#x265-no-hdrdv), Only ever include one of them :warning:"
+
+    - **{{ radarr['cf']['3d']['name'] }}:** Is 3D still a thing for home use ?
+    - **{{ radarr['cf']['extras']['name'] }}:** Blocks releases that only contain extras
+    - **{{ radarr['cf']['10bit']['name'] }}:** Blocks releases that uses Hi10P

--- a/includes/sqp/radarr-unwanted-sqp1.md
+++ b/includes/sqp/radarr-unwanted-sqp1.md
@@ -22,4 +22,4 @@
 
     - **{{ radarr['cf']['3d']['name'] }}:** Is 3D still a thing for home use ?
     - **{{ radarr['cf']['extras']['name'] }}:** Blocks releases that only contain extras
-    - **{{ radarr['cf']['10bit']['name'] }}:** Blocks releases that uses Hi10P
+    - **{{ radarr['cf']['10bit']['name'] }}:** Blocks releases that use Hi10P

--- a/includes/sqp/radarr-unwanted-uhd-sqp1.md
+++ b/includes/sqp/radarr-unwanted-uhd-sqp1.md
@@ -1,0 +1,27 @@
+??? abstract "Unwanted - [Click to show/hide]"
+    | Custom Format                                                                                                  |                               Score                               | Trash ID                                           |
+    | -------------------------------------------------------------------------------------------------------------- | :---------------------------------------------------------------: | -------------------------------------------------- |
+    | [{{ radarr['cf']['br-disk']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#br-disk)                  |     {{ radarr['cf']['br-disk']['trash_scores']['default'] }}      | {{ radarr['cf']['br-disk']['trash_id'] }}          |
+    | [{{ radarr['cf']['lq']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#lq)                            |        {{ radarr['cf']['lq']['trash_scores']['default'] }}        | {{ radarr['cf']['lq']['trash_id'] }}               |
+    | [{{ radarr['cf']['lq-release-title']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#lq-release-title) | {{ radarr['cf']['lq-release-title']['trash_scores']['default'] }} | {{ radarr['cf']['lq-release-title']['trash_id'] }} |
+    | [{{ radarr['cf']['x265-hd']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#x265-hd) :warning:        |     {{ radarr['cf']['x265-hd']['trash_scores']['default'] }}      | {{ radarr['cf']['x265-hd']['trash_id'] }}          |
+    | [{{ radarr['cf']['3d']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#3d)                            |        {{ radarr['cf']['3d']['trash_scores']['default'] }}        | {{ radarr['cf']['3d']['trash_id'] }}               |
+    | [{{ radarr['cf']['upscaled']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#upscaled)                |     {{ radarr['cf']['upscaled']['trash_scores']['default'] }}     | {{ radarr['cf']['upscaled']['trash_id'] }}         |
+    | [{{ radarr['cf']['extras']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#extras)                    |      {{ radarr['cf']['extras']['trash_scores']['default'] }}      | {{ radarr['cf']['extras']['trash_id'] }}           |
+    | [{{ radarr['cf']['10bit']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#10bit)                       |   {{ radarr['cf']['10bit']['trash_scores']['sqp-1-2160p'] }}    | {{ radarr['cf']['10bit']['trash_id'] }}            |
+
+    ------
+
+    Breakdown and Why
+
+    - **{{ radarr['cf']['br-disk']['name'] }} :** This is a custom format to help Radarr recognize & ignore BR-DISK (ISO's and Blu-ray folder structure) in addition to the standard BR-DISK quality.
+    - **{{ radarr['cf']['lq']['name'] }}:** A collection of known Low Quality groups that are often banned from the the top trackers because the lack of quality or other reasons.
+    - **{{ radarr['cf']['lq-release-title']['name'] }}:** A collection of terms seen in the titles of Low Quality releases that are not captured by using a release group name.
+    - **{{ radarr['cf']['x265-hd']['name'] }}:** This blocks 720/1080p (HD) releases that are encoded in x265. - More info [HERE](/Misc/x265-4k/){:target="_blank" rel="noopener noreferrer"}.
+
+        !!! Danger "Don't use this together with [{{ radarr['cf']['x265-no-hdrdv']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#x265-no-hdrdv), Only ever include one of them :warning:"
+
+    - **{{ radarr['cf']['3d']['name'] }}:** Is 3D still a thing for home use ?
+    - **{{ radarr['cf']['upscaled']['name'] }}:** A custom format to prevent Radarr from grabbing upscaled releases.
+    - **{{ radarr['cf']['extras']['name'] }}:** Blocks releases that only contain extras
+    - **{{ radarr['cf']['10bit']['name'] }}:** Blocks releases that uses Hi10P

--- a/includes/sqp/radarr-unwanted-uhd-sqp1.md
+++ b/includes/sqp/radarr-unwanted-uhd-sqp1.md
@@ -24,4 +24,4 @@
     - **{{ radarr['cf']['3d']['name'] }}:** Is 3D still a thing for home use ?
     - **{{ radarr['cf']['upscaled']['name'] }}:** A custom format to prevent Radarr from grabbing upscaled releases.
     - **{{ radarr['cf']['extras']['name'] }}:** Blocks releases that only contain extras
-    - **{{ radarr['cf']['10bit']['name'] }}:** Blocks releases that uses Hi10P
+    - **{{ radarr['cf']['10bit']['name'] }}:** Blocks releases that use Hi10P


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->

Add CF `10bit` to unwanted to block `Hi10P`

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

Certain releases use the weird Hi10P for their encodes and this gives you often playback issues..

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
