### PR TITLE
style(guide): Plex make tips always seen

### DIFF
--- a/docs/Plex/.pages
+++ b/docs/Plex/.pages
@@ -1,4 +1,6 @@
 nav:
     - Home: index.md
-    - Tips
+    - Suggested Plex Media Server Settings: /Plex/Tips/Plex-media-server/
+    - Optimal Plex Client Settings: /Plex/Tips/Optimal-plex-client-settings/
+    - Stop 4k Video Transcoding: /Plex/Tips/4k-transcoding/
     - Profiles: /Plex/profiles/

--- a/docs/Plex/Tips/.pages
+++ b/docs/Plex/Tips/.pages
@@ -1,4 +1,0 @@
-nav:
-    - Suggested Plex Media Server Settings: Plex-media-server.md
-    - Optimal Plex Client Settings: Optimal-plex-client-settings.md
-    - JBOPS 4K Transcode Stopping with Tautulli: 4k-transcoding.md


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->

Make the plex  tips section always seen (non collapse)

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

![image](https://github.com/TRaSH-Guides/Guides/assets/6155095/a72409a3-fcab-45fd-991e-a1f46fb52042)

vs

![image](https://github.com/TRaSH-Guides/Guides/assets/6155095/d0ff4311-4031-4835-8ac4-f0770c01933e)


## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
