### PR TITLE
feat(guides): Add HTSR Streaming Service

### DIFF
--- a/docs/Radarr/Radarr-collection-of-custom-formats.md
+++ b/docs/Radarr/Radarr-collection-of-custom-formats.md
@@ -69,10 +69,10 @@ We've made 3 guides related to this.
 | General Streaming Services | Asian Streaming Services | Dutch Streaming Services |
 | -------------------------- | ------------------------ | ------------------------ |
 | [Amazon](#amzn)            | [FOD](#fod)              | [Pathe Thuis](#pathe)    |
-| [Apple TV+](#atvp)         | [TVer](#tver)            | [Videoland](#vdl)        |
-| [Bravia Core](#bcore)      | [U-NEXT](#u-next)        |                          |
-| [Criterion Channel](#crit) | [VIU](#viu)              |                          |
-| [Disney+](#dsnp)           |                          |                          |
+| [Apple TV+](#atvp)         | [Disney+ Hotstar](#htsr) | [Videoland](#vdl)        |
+| [Bravia Core](#bcore)      | [TVer](#tver)            |                          |
+| [Criterion Channel](#crit) | [U-NEXT](#u-next)        |                          |
+| [Disney+](#dsnp)           | [VIU](#viu)              |                          |
 | [HBO](#hbo)                |                          |                          |
 | [HBO Max](#hmax)           |                          |                          |
 | [Hulu](#hulu)              |                          |                          |
@@ -2028,7 +2028,7 @@ We've made 3 guides related to this.
 
 ---
 
-### Asian Streamin Services
+### Asian Streaming Services
 
 ---
 
@@ -2044,6 +2044,24 @@ We've made 3 guides related to this.
 
     ```json
     [[% filter indent(width=4) %]][[% include 'json/radarr/cf/fod.json' %]][[% endfilter %]]
+    ```
+
+<sub><sup>[TOP](#index)</sup>
+
+---
+
+#### HTSR
+
+<sub>Disney+ Hotstar</sub>
+
+??? question "Disney+ Hotstar - [Click to show/hide]"
+
+    {! include-markdown "../../includes/cf-descriptions/htsr.md" !}
+
+??? example "JSON - [Click to show/hide]"
+
+    ```json
+    [[% filter indent(width=4) %]][[% include 'json/radarr/cf/htsr.json' %]][[% endfilter %]]
     ```
 
 <sub><sup>[TOP](#index)</sup>

--- a/docs/Sonarr/sonarr-collection-of-custom-formats.md
+++ b/docs/Sonarr/sonarr-collection-of-custom-formats.md
@@ -61,7 +61,7 @@ We've made 3 guides related to this.
 
 | General Streaming Services | French Streaming Services | Asian Streaming Services | Dutch Streaming Services |
 | -------------------------- | ------------------------- | ------------------------ | ------------------------ |
-| [Amazon](#amzn)            | [CANAL+](#canalplus)      | [FOD](#fod)              | [NLZiet](#nlz)           | 
+| [Amazon](#amzn)            | [CANAL+](#canalplus)      | [FOD](#fod)              | [NLZiet](#nlz)           |
 | [Apple TV+](#atvp)         | [RTBF](#rtbf)             | [Disney+ Hotstar](#htsr) | [Videoland](#vdl)        |
 | [Comedy Central](#cc)      | [SALTO](#salto)           | [TVer](#tver)            |                          |
 | [DC Universe](#dcu)        |                           | [U-NEXT](#u-next)        |                          |

--- a/docs/Sonarr/sonarr-collection-of-custom-formats.md
+++ b/docs/Sonarr/sonarr-collection-of-custom-formats.md
@@ -61,11 +61,11 @@ We've made 3 guides related to this.
 
 | General Streaming Services | French Streaming Services | Asian Streaming Services | Dutch Streaming Services |
 | -------------------------- | ------------------------- | ------------------------ | ------------------------ |
-| [Amazon](#amzn)            | [CANAL+](#canalplus)      | [FOD](#fod)              | [NLZiet](#nlz)           |
-| [Apple TV+](#atvp)         | [RTBF](#rtbf)             | [TVer](#tver)            | [Videoland](#vdl)        |
-| [Comedy Central](#cc)      | [SALTO](#salto)           | [U-NEXT](#u-next)        |                          |
-| [DC Universe](#dcu)        |                           | [VIU](#viu)              |                          |
-| [Disney+](#dsnp)           |                           |                          |                          |
+| [Amazon](#amzn)            | [CANAL+](#canalplus)      | [FOD](#fod)              | [NLZiet](#nlz)           | 
+| [Apple TV+](#atvp)         | [RTBF](#rtbf)             | [Disney+ Hotstar](#htsr) | [Videoland](#vdl)        |
+| [Comedy Central](#cc)      | [SALTO](#salto)           | [TVer](#tver)            |                          |
+| [DC Universe](#dcu)        |                           | [U-NEXT](#u-next)        |                          |
+| [Disney+](#dsnp)           |                           | [VIU](#viu)              |                          |
 | [HBO Max](#hmax)           |                           |                          |                          |
 | [HBO](#hbo)                |                           |                          |                          |
 | [Hulu](#hulu)              |                           |                          |                          |
@@ -1821,6 +1821,24 @@ We've made 3 guides related to this.
 
     ```json
     [[% filter indent(width=4) %]][[% include 'json/sonarr/cf/fod.json' %]][[% endfilter %]]
+    ```
+
+<sub><sup>[TOP](#index)</sup>
+
+---
+
+#### HTSR
+
+<sub>Disney+ Hotstar</sub>
+
+??? question "Disney+ Hotstar - [Click to show/hide]"
+
+    {! include-markdown "../../includes/cf-descriptions/htsr.md" !}
+
+??? example "JSON - [Click to show/hide]"
+
+    ```json
+    [[% filter indent(width=4) %]][[% include 'json/sonarr/cf/htsr.json' %]][[% endfilter %]]
     ```
 
 <sub><sup>[TOP](#index)</sup>

--- a/docs/json/radarr/cf/htsr.json
+++ b/docs/json/radarr/cf/htsr.json
@@ -1,0 +1,35 @@
+{
+  "trash_id": "834b2c0ba0a8596029b4479a29e1a032",
+  "trash_regex": "https://regex101.com/r/PNiRKh/1",
+  "name": "HTSR",
+  "includeCustomFormatWhenRenaming": true,
+  "specifications": [
+    {
+      "name": "Hotstar",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": true,
+      "fields": {
+        "value": "\\b(HTSR)\\b"
+      }
+    },
+    {
+      "name": "WEBDL",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 7
+      }
+    },
+    {
+      "name": "WEBRIP",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 8
+      }
+    }
+  ]
+}

--- a/docs/json/sonarr/cf/htsr.json
+++ b/docs/json/sonarr/cf/htsr.json
@@ -1,0 +1,38 @@
+{
+  "trash_id": "4404ad44d87ccbb82746e180713112fb",
+  "trash_regex": "https://regex101.com/r/PNiRKh/1",
+  "trash_scores": {
+    "default": 50
+  },
+  "name": "HTSR",
+  "includeCustomFormatWhenRenaming": true,
+  "specifications": [
+    {
+      "name": "Hotstar",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": true,
+      "fields": {
+        "value": "\\b(HTSR)\\b"
+      }
+    },
+    {
+      "name": "WEBDL",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 3
+      }
+    },
+    {
+      "name": "WEBRIP",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 4
+      }
+    }
+  ]
+}

--- a/includes/cf-descriptions/htsr.md
+++ b/includes/cf-descriptions/htsr.md
@@ -1,0 +1,5 @@
+**Disney+ Hotstar**<br>
+
+[From Wikipedia, the free encyclopedia](https://en.wikipedia.org/wiki/Disney%2B_Hotstar){:target="_blank" rel="noopener noreferrer"}
+
+Disney+ Hotstar is an Indian subscription video-on-demand over-the-top streaming service owned by Disney Star, a subsidiary of the Disney Entertainment business segment of The Walt Disney Company, featuring domestic Indian film, television and sports content for India itself and its worldwide diaspora. It also includes imported content from and serves Southeast Asia as well.


### PR DESCRIPTION
# Pull Request

## Purpose

- Add a new custom format to match the Disney+ Hotstar streaming service.
- Resolve: #1603  

## Approach

- [x] Create new custom format jsons for HTSR, for both Radarr and Sonarr
- [x] Add HTSR custom format to Radarr and Sonarr collection of custom formats pages
- [x] Create new description include for HTSR
- [x] Correct one small typo on the Radarr collection of custom formats page
- [x] Build and test locally

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
