### PR TITLE
fix(Starr): Update HTSR Custom Formats

### DIFF
--- a/docs/json/radarr/cf/htsr.json
+++ b/docs/json/radarr/cf/htsr.json
@@ -10,7 +10,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\b(HTSR)\\b"
+        "value": "\\b(HTSR|HS)\\b"
       }
     },
     {

--- a/docs/json/sonarr/cf/htsr.json
+++ b/docs/json/sonarr/cf/htsr.json
@@ -13,7 +13,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\b(HTSR)\\b"
+        "value": "\\b(HTSR|HS)\\b"
       }
     },
     {


### PR DESCRIPTION
# Pull Request

## Purpose

Allow `HS` as a distinct word in release titles to match the HTSR custom formats

## Approach

- [x] Add `HS` as a pipe-separated match to the Release Title condition in the HTSR custom formats for Radarr and Sonarr

## Open Questions and Pre-Merge TODOs

None

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
