### PR TITLE
feat(sonarr): Add Season Pack CF using ReleaseType Condition

### DIFF
--- a/docs/Sonarr/sonarr-collection-of-custom-formats.md
+++ b/docs/Sonarr/sonarr-collection-of-custom-formats.md
@@ -1167,12 +1167,11 @@ We've made 3 guides related to this.
 
     - Give it a score of `10` if you prefer a season pack.
     - Give it a score of `-10000` if you prefer to not download season packs.
-    - `/\bS\d+\b(?!E\d+\b)/i` season packs are preferred: however, given the folder name is ignored the error/warning/issue occurs as the file names would not be a season pack.
-    - Keep in mind this is the only way to prefer season packs. If you have preferred words, due to a long standing bug => Preferred Words overrule season pack preference [Sonarr/Sonarr#3562](https://github.com/Sonarr/Sonarr/issues/3562){:target="_blank" rel="noopener noreferrer"}
+    - Utilizing the "Release Type" custom format setting added in v4.0.2.1262, Season Pack source status is now persistently stored alongside episodes.
 
-    !!! danger "WARNING"
-        - This Custom Format could result in a download loop :bangbang:
-        - This will upgrade also your already downloaded single episodes :bangbang:
+    !!! info
+        - This Custom Format could previously result in download loops. The new "Release Type" CF now prevents this undesired behavior. :bangbang:
+        - This will upgrade your already downloaded single episodes :bangbang:
 
 ??? example "JSON - [Click to show/hide]"
 

--- a/docs/Sonarr/sonarr-collection-of-custom-formats.md
+++ b/docs/Sonarr/sonarr-collection-of-custom-formats.md
@@ -1167,16 +1167,46 @@ We've made 3 guides related to this.
 
     - Give it a score of `10` if you prefer a season pack.
     - Give it a score of `-10000` if you prefer to not download season packs.
-    - Utilizing the "Release Type" custom format setting added in v4.0.2.1262, Season Pack source status is now persistently stored alongside episodes.
+    - `/\bS\d+\b(?!E\d+\b)/i` season packs are preferred: however, given the folder name is ignored the issue occurs as the file names would not be a season pack.
 
-    !!! info
-        - This Custom Format could previously result in download loops. The new "Release Type" CF now prevents this undesired behavior. :bangbang:
-        - This will upgrade your already downloaded single episodes :bangbang:
+    !!! danger "WARNING"
+        - This Custom Format could result in a download loop :bangbang:
+        - This will upgrade also your already downloaded single episodes :bangbang:
 
 ??? example "JSON - [Click to show/hide]"
 
     ```json
     [[% filter indent(width=4) %]][[% include 'json/sonarr/cf/season-pack.json' %]][[% endfilter %]]
+    ```
+
+<sub><sup>[TOP](#index)</sup>
+
+---
+
+### Season Pack (New "Release Type" Handling, Sonarr v4.0.2.1262+ only)
+
+!!! danger "WARNING"
+
+    - This CF utilizes functionality only available starting in Sonarr v4.0.2.1262.
+    - This CF is currently "Guides Only" and does not have a `trash_id` for sync tools.
+    - This CF is currently "Guides Only" and does not yet have a `trash_id` for sync tools pending ReleaseType being released as stable / Sonarr `main`
+
+??? question "Season Pack - [Click to show/hide]"
+    This Custom Format can be used to prefer or exclude season packs
+
+    - Give it a score of `10` if you prefer a season pack.
+    - Give it a score of `-10000` if you prefer to not download season packs.
+    - Utilizing the "Release Type" custom format setting added in v4.0.2.1262, Season Pack source status is now persistently stored alongside episodes.
+
+    !!! info
+        - This Custom Format could previously result in download loops. The new "Release Type" CF now prevents this undesired behavior. :bangbang:
+        - This Custom Format will replace the current Season Pack Custom Format as a drop in replacement when the functionality reaches a full release version of Sonarr.
+        - This will upgrade your already downloaded single episodes :bangbang:
+
+??? example "JSON - [Click to show/hide]"
+
+    ```json
+    [[% filter indent(width=4) %]][[% include 'json/sonarr/cf/season-pack-spec.json' %]][[% endfilter %]]
     ```
 
 <sub><sup>[TOP](#index)</sup>

--- a/docs/json/sonarr/cf/season-pack-spec.json
+++ b/docs/json/sonarr/cf/season-pack-spec.json
@@ -1,15 +1,14 @@
 {
-  "trash_id": "3bc5f395426614e155e585a2f056cdf1",
   "name": "Season Pack",
   "includeCustomFormatWhenRenaming": false,
   "specifications": [
     {
       "name": "Season Packs",
-      "implementation": "ReleaseTitleSpecification",
+      "implementation": "ReleaseTypeSpecification",
       "negate": false,
       "required": false,
       "fields": {
-        "value": "\\bS\\d+\\b(?!E\\d+\\b)"
+        "value": 3
       }
     }
   ]

--- a/docs/json/sonarr/cf/season-pack.json
+++ b/docs/json/sonarr/cf/season-pack.json
@@ -7,7 +7,7 @@
       "name": "Season Packs",
       "implementation": "ReleaseTypeSpecification",
       "negate": false,
-      "required": true,
+      "required": false,
       "fields": {
         "value": 3
       }

--- a/docs/json/sonarr/cf/season-pack.json
+++ b/docs/json/sonarr/cf/season-pack.json
@@ -5,11 +5,11 @@
   "specifications": [
     {
       "name": "Season Packs",
-      "implementation": "ReleaseTitleSpecification",
+      "implementation": "ReleaseTypeSpecification",
       "negate": false,
-      "required": false,
+      "required": true,
       "fields": {
-        "value": "\\bS\\d+\\b(?!E\\d+\\b)"
+        "value": 3
       }
     }
   ]


### PR DESCRIPTION
# Pull Request

## Purpose

Utilizes the new Season Pack Release Type in the Custom Format for Sonarr. This changes the download loop behavior previously seen.

## Approach

Leaving this in draft currently until this addition hits master on Sonarr.

## Open Questions and Pre-Merge TODOs

- [x] Language and disclaimers might need expanding?

- [x] Handling trash_id and "blind-sync'rs"

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
