### PR TITLE
fix(Starr-Anime): remove Kaerizaki-Fansub to Anime LQ groups and update FR regex 

### DIFF
--- a/docs/json/radarr/cf/anime-lq-groups.json
+++ b/docs/json/radarr/cf/anime-lq-groups.json
@@ -484,15 +484,6 @@
       }
     },
     {
-      "name": "Kaerizaki-Fansub",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "\\b(Kaerizaki-Fansub)\\b"
-      }
-    },
-    {
       "name": "Kanjouteki",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,

--- a/docs/json/sonarr/cf/anime-lq-groups.json
+++ b/docs/json/sonarr/cf/anime-lq-groups.json
@@ -484,15 +484,6 @@
       }
     },
     {
-      "name": "Kaerizaki-Fansub",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "\\b(Kaerizaki-Fansub)\\b"
-      }
-    },
-    {
       "name": "Kanjouteki",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,

--- a/docs/json/sonarr/cf/french-anime-fansub.json
+++ b/docs/json/sonarr/cf/french-anime-fansub.json
@@ -16,6 +16,15 @@
       }
     },
     {
+      "name": "Kaerizaki-Fansub",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Kaerizaki[ .-]?Fansub)\\b"
+      }
+    },
+    {
       "name": "Natsumi-no-Sekai",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,
@@ -58,15 +67,6 @@
       "required": false,
       "fields": {
         "value": "\\b(Pikari[ .-]?Teshima)\\b"
-      }
-    },
-    {
-      "name": "Kaerizaki-Fansub",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "\\b(Kaerizaki[ .-]?Fansub)\\b"
       }
     },
     {

--- a/docs/json/sonarr/cf/french-anime-fansub.json
+++ b/docs/json/sonarr/cf/french-anime-fansub.json
@@ -16,15 +16,6 @@
       }
     },
     {
-      "name": "Kaerizaki-Fansub",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "\\b(Kaerizaki[ .-]?Fansub)\\b"
-      }
-    },
-    {
       "name": "Natsumi-no-Sekai",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,
@@ -67,6 +58,15 @@
       "required": false,
       "fields": {
         "value": "\\b(Pikari[ .-]?Teshima)\\b"
+      }
+    },
+    {
+      "name": "Kaerizaki-Fansub",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Kaerizaki[ .-]?Fansub)\\b"
       }
     },
     {

--- a/docs/json/sonarr/cf/french-anime-fansub.json
+++ b/docs/json/sonarr/cf/french-anime-fansub.json
@@ -16,12 +16,12 @@
       }
     },
     {
-      "name": "KaeriZaki",
+      "name": "Kaerizaki-Fansub",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,
       "required": false,
       "fields": {
-        "value": "\\b(KaeriZaki)\\b"
+        "value": "\\b(Kaerizaki[ .-]?Fansub)\\b"
       }
     },
     {


### PR DESCRIPTION
# Pull Request

## Purpose

Currently, the French Guide has the `Kaerizaki-Fansub` team in the CF `FR Anime FanSub` but it is also in the CF `Anime LQ Groups`. This is because the team make VOSTFR release (#1822)

## Approach

We can remove `Kaerizaki-Fansub` in the CF `Anime LQ Groups` because the release name contains `VOSTFR` so it has no impact on the Anime English Guide.

Also I have updated the regex in the french guide of `KaeriZaki` to `Kaerizaki[ .-]?Fansub` for better matching !

## Open Questions and Pre-Merge TODOs

## Requirements

- [X] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [X] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
