### PR TITLE
fix(starr): AMZN CF should also match AmazonHD

### DIFF
--- a/docs/json/radarr/cf/amzn.json
+++ b/docs/json/radarr/cf/amzn.json
@@ -9,7 +9,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\b(amzn|amazon)\\b"
+        "value": "\\b(amzn|amazon(hd)?)\\b"
       }
     },
     {

--- a/docs/json/sonarr/cf/amzn.json
+++ b/docs/json/sonarr/cf/amzn.json
@@ -13,7 +13,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\b(amzn|amazon)\\b"
+        "value": "\\b(amzn|amazon(hd)?)\\b"
       }
     },
     {


### PR DESCRIPTION
# Pull Request

## Purpose

A lot of the german releases coming from amazon video contain the keyword "AmazonHD" in the release title, which is currently not matched by the CF AMZN, which only searches for "amazon" or "amzn".

Regex test: https://regex101.com/r/aNiJfh/1

## Approach

This PR adds "AmazonHD" for the AMZN CF for both, sonarr and radarr

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
