### PR TITLE
fix(starr): fix Obfuscated CF mismatching

### DIFF
--- a/docs/json/radarr/cf/obfuscated.json
+++ b/docs/json/radarr/cf/obfuscated.json
@@ -111,7 +111,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "Scrambled\\b"
+        "value": "(?<=\\b[12]\\d{3}\\b).*(Scrambled)\\b"
       }
     },
     {

--- a/docs/json/sonarr/cf/obfuscated.json
+++ b/docs/json/sonarr/cf/obfuscated.json
@@ -111,7 +111,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "Scrambled\\b"
+        "value": "(?<=\\bS\\d+\\b).*(Scrambled)\\b"
       }
     },
     {


### PR DESCRIPTION
# Pull Request

## Purpose

Fix #1842 

## Approach

Adjust regex of `Obfuscated` CF to not match `Scrambled` in the title.

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
