### PR TITLE
fix(starr): Netflix CF to match NetflixHD and NetflixUHD in title

### DIFF
--- a/docs/json/radarr/cf/nf.json
+++ b/docs/json/radarr/cf/nf.json
@@ -9,7 +9,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\b(nf|netflix)\\b"
+        "value": "\\b(nf|netflix(hd)?)\\b"
       }
     },
     {

--- a/docs/json/radarr/cf/nf.json
+++ b/docs/json/radarr/cf/nf.json
@@ -9,7 +9,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\b(nf|netflix(hd)?)\\b"
+        "value": "\\b(nf|netflix(u)?(hd)?)\\b"
       }
     },
     {

--- a/docs/json/radarr/cf/nf.json
+++ b/docs/json/radarr/cf/nf.json
@@ -9,7 +9,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\b(nf|netflix(u)?(hd)?)\\b"
+        "value": "\\b(nf|netflix(u?hd)?)\\b"
       }
     },
     {

--- a/docs/json/sonarr/cf/nf.json
+++ b/docs/json/sonarr/cf/nf.json
@@ -13,7 +13,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\b(nf|netflix)\\b"
+        "value": "\\b(nf|netflix(hd)?)\\b"
       }
     },
     {

--- a/docs/json/sonarr/cf/nf.json
+++ b/docs/json/sonarr/cf/nf.json
@@ -13,7 +13,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\b(nf|netflix(hd)?)\\b"
+        "value": "\\b(nf|netflix(u)?(hd)?)\\b"
       }
     },
     {

--- a/docs/json/sonarr/cf/nf.json
+++ b/docs/json/sonarr/cf/nf.json
@@ -13,7 +13,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\b(nf|netflix(u)?(hd)?)\\b"
+        "value": "\\b(nf|netflix(u?hd)?)\\b"
       }
     },
     {


### PR DESCRIPTION
# Pull Request

## Purpose

German releases often use NetflixHD in the release title, which is currently not matched by the custom format.
Basically the same as in https://github.com/TRaSH-Guides/Guides/pull/1829

## Approach

Added optional HD suffix to the custom format.

Regex Test: https://regex101.com/r/QpfWrs/1

## Open Questions and Pre-Merge TODOs

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
