### PR TITLE
fix(radarr): Vinegar Syndrome not matching VinSyn

### DIFF
--- a/docs/json/radarr/cf/vinegar-syndrome.json
+++ b/docs/json/radarr/cf/vinegar-syndrome.json
@@ -23,6 +23,15 @@
       "fields": {
         "value": "\\b(V-S)\\b"
       }
+    },
+    {
+      "name": "VinSyn",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(VinSyn)\\b"
+      }
     }
   ]
 }


### PR DESCRIPTION
# Pull Request

## Purpose

Fix `Vinegar Syndrome` CF not matching `VinSyn`.

## Approach

Add condition to `Vinegar Syndrome` CF for matching `VinSyn`.

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
