### PR TITLE
feat(starr): Added CF Streaming Services `Star+`, `NOW`, `TVING`, `Discovery+`

### DIFF
--- a/docs/Radarr/Radarr-collection-of-custom-formats.md
+++ b/docs/Radarr/Radarr-collection-of-custom-formats.md
@@ -71,9 +71,9 @@ We've made 3 guides related to this.
 | [Amazon](#amzn)            | [FOD](#fod)              | [Pathe Thuis](#pathe)    |
 | [Apple TV+](#atvp)         | [Disney+ Hotstar](#htsr) | [Videoland](#vdl)        |
 | [Bravia Core](#bcore)      | [TVer](#tver)            |                          |
-| [Criterion Channel](#crit) | [U-NEXT](#u-next)        |                          |
-| [Disney+](#dsnp)           | [VIU](#viu)              |                          |
-| [HBO](#hbo)                |                          |                          |
+| [Criterion Channel](#crit) | [TVING](#tving)          |                          |
+| [Disney+](#dsnp)           | [U-NEXT](#u-next)        |                          |
+| [HBO](#hbo)                | [VIU](#viu)              |                          |
 | [HBO Max](#hmax)           |                          |                          |
 | [Hulu](#hulu)              |                          |                          |
 | [Max](#max)                |                          |                          |
@@ -87,6 +87,7 @@ We've made 3 guides related to this.
 | --------------------- | ----------------------- | ------------------------ |
 | [BBC iPlayer](#ip)    | [Crave](#crav)          | [VRV](#vrv)              |
 | [ITVX](#itvx)         | [OViD](#ovid)           |                          |
+| [NOW](#now)           | [Star+](#strp)          |                          |
 
 ---
 
@@ -2093,12 +2094,30 @@ We've made 3 guides related to this.
 
 ??? question "TVer - [Click to show/hide]"
 
-    {! include-markdown "../../includes/cf-descriptions/fod.md" !}
+    {! include-markdown "../../includes/cf-descriptions/tver.md" !}
 
 ??? example "JSON - [Click to show/hide]"
 
     ```json
     [[% filter indent(width=4) %]][[% include 'json/radarr/cf/tver.json' %]][[% endfilter %]]
+    ```
+
+<sub><sup>[TOP](#index)</sup>
+
+---
+
+#### TVING
+
+<sub>TVING</sub>
+
+??? question "TVING - [Click to show/hide]"
+
+    {! include-markdown "../../includes/cf-descriptions/tving.md" !}
+
+??? example "JSON - [Click to show/hide]"
+
+    ```json
+    [[% filter indent(width=4) %]][[% include 'json/radarr/cf/tving.json' %]][[% endfilter %]]
     ```
 
 <sub><sup>[TOP](#index)</sup>
@@ -2221,6 +2240,24 @@ We've made 3 guides related to this.
 
 ---
 
+#### NOW
+
+<sub>NOW</sub>
+
+??? question "NOW - [Click to show/hide]"
+
+    {! include-markdown "../../includes/cf-descriptions/now.md" !}
+
+??? example "JSON - [Click to show/hide]"
+
+    ```json
+    [[% filter indent(width=4) %]][[% include 'json/radarr/cf/now.json' %]][[% endfilter %]]
+    ```
+
+<sub><sup>[TOP](#index)</sup>
+
+---
+
 ### Misc Streaming Services
 
 ---
@@ -2255,6 +2292,24 @@ We've made 3 guides related to this.
 
     ```json
     [[% filter indent(width=4) %]][[% include 'json/radarr/cf/ovid.json' %]][[% endfilter %]]
+    ```
+
+<sub><sup>[TOP](#index)</sup>
+
+---
+
+#### STRP
+
+<sub>Star+</sub>
+
+??? question "Star+ - [Click to show/hide]"
+
+    {! include-markdown "../../includes/cf-descriptions/strp.md" !}
+
+??? example "JSON - [Click to show/hide]"
+
+    ```json
+    [[% filter indent(width=4) %]][[% include 'json/radarr/cf/strp.json' %]][[% endfilter %]]
     ```
 
 <sub><sup>[TOP](#index)</sup>

--- a/docs/Sonarr/sonarr-collection-of-custom-formats.md
+++ b/docs/Sonarr/sonarr-collection-of-custom-formats.md
@@ -64,9 +64,9 @@ We've made 3 guides related to this.
 | [Amazon](#amzn)            | [CANAL+](#canalplus)      | [FOD](#fod)              | [NLZiet](#nlz)           |
 | [Apple TV+](#atvp)         | [RTBF](#rtbf)             | [Disney+ Hotstar](#htsr) | [Videoland](#vdl)        |
 | [Comedy Central](#cc)      | [SALTO](#salto)           | [TVer](#tver)            |                          |
-| [DC Universe](#dcu)        |                           | [U-NEXT](#u-next)        |                          |
-| [Disney+](#dsnp)           |                           | [VIU](#viu)              |                          |
-| [HBO Max](#hmax)           |                           |                          |                          |
+| [DC Universe](#dcu)        |                           | [TVING](#tving)          |                          |
+| [Disney+](#dsnp)           |                           | [U-NEXT](#u-next)        |                          |
+| [HBO Max](#hmax)           |                           | [VIU](#viu)              |                          |
 | [HBO](#hbo)                |                           |                          |                          |
 | [Hulu](#hulu)              |                           |                          |                          |
 | [iTunes](#it)              |                           |                          |                          |
@@ -80,11 +80,11 @@ We've made 3 guides related to this.
 | UK Streaming Services | Misc Streaming Services | Anime Streaming Services | Optional Streaming Services                 |
 | --------------------- | ----------------------- | ------------------------ | ------------------------------------------- |
 | [4OD](#4od)           | [Crave](#crav)          | [B-Global](#b-global)    | [UHD Streaming Boost](#uhd-streaming-boost) |
-| [ALL4](#all4)         | [OViD](#ovid)           | [Bilibili](#bilibili)    | [UHD Streaming Cut](#uhd-streaming-cut)     |
-| [BBC iPlayer](#ip)    | [YouTube Red](#red)     | [Crunchyroll](#cr)       |                                             |
-| [ITVX](#itvx)         | [Quibi](#qibi)          | [Funimation](#funi)      |                                             |
-|                       |                         | [HIDIVE](#hidive)        |                                             |
-|                       |                         | [VRV](#vrv)              |                                             |
+| [ALL4](#all4)         | [Discovery+](#dscp)     | [Bilibili](#bilibili)    | [UHD Streaming Cut](#uhd-streaming-cut)     |
+| [BBC iPlayer](#ip)    | [OViD](#ovid)           | [Crunchyroll](#cr)       |                                             |
+| [ITVX](#itvx)         | [Star+](#strp)          | [Funimation](#funi)      |                                             |
+| [NOW](#now)           | [YouTube Red](#red)     | [HIDIVE](#hidive)        |                                             |
+|                       | [Quibi](#qibi)          | [VRV](#vrv)              |                                             |
 |                       |                         | [ABEMA](#abema)          |                                             |
 |                       |                         | [ADN](#adn)              |                                             |
 |                       |                         | [WKN](#wkn)              |                                             |
@@ -92,7 +92,7 @@ We've made 3 guides related to this.
 ---
 
 | Misc                           | Optional                               | French Audio Version          | French Source Groups                          |
-|--------------------------------|----------------------------------------|-------------------------------|-----------------------------------------------|
+| ------------------------------ | -------------------------------------- | ----------------------------- | --------------------------------------------- |
 | [FreeLeech](#freeleech)        | [AV1](#av1)                            | [Multi-French](#multi-french) | [FR Remux Tier 01](#fr-remux-tier-01)         |
 | [MPEG2](#mpeg2)                | [Bad Dual Groups](#bad-dual-groups)    | [Multi-Audio](#multi-audio)   | [FR HD Bluray Tier 01](#fr-hd-bluray-tier-01) |
 | [Multi](#multi)                | [DV (Disk)](#dv-disk)                  | [French Audio](#french-audio) | [FR WEB Tier 01](#fr-web-tier-01)             |
@@ -1890,7 +1890,7 @@ We've made 3 guides related to this.
 
 ??? question "TVer - [Click to show/hide]"
 
-    {! include-markdown "../../includes/cf-descriptions/fod.md" !}
+    {! include-markdown "../../includes/cf-descriptions/tver.md" !}
 
 ??? example "JSON - [Click to show/hide]"
 
@@ -2054,6 +2054,24 @@ We've made 3 guides related to this.
 
 ---
 
+#### NOW
+
+<sub>NOW</sub>
+
+??? question "NOW - [Click to show/hide]"
+
+    {! include-markdown "../../includes/cf-descriptions/now.md" !}
+
+??? example "JSON - [Click to show/hide]"
+
+    ```json
+    [[% filter indent(width=4) %]][[% include 'json/sonarr/cf/now.json' %]][[% endfilter %]]
+    ```
+
+<sub><sup>[TOP](#index)</sup>
+
+---
+
 ### Misc Streaming Services
 
 ---
@@ -2076,6 +2094,24 @@ We've made 3 guides related to this.
 
 ---
 
+#### DSCP
+
+<sub>Discovery+</sub>
+
+??? question "Discovery+ - [Click to show/hide]"
+
+    {! include-markdown "../../includes/cf-descriptions/dscp.md" !}
+
+??? example "JSON - [Click to show/hide]"
+
+    ```json
+    [[% filter indent(width=4) %]][[% include 'json/sonarr/cf/dscp.json' %]][[% endfilter %]]
+    ```
+
+<sub><sup>[TOP](#index)</sup>
+
+---
+
 #### OViD
 
 <sub>OViD</sub>
@@ -2088,6 +2124,24 @@ We've made 3 guides related to this.
 
     ```json
     [[% filter indent(width=4) %]][[% include 'json/sonarr/cf/ovid.json' %]][[% endfilter %]]
+    ```
+
+<sub><sup>[TOP](#index)</sup>
+
+---
+
+#### STRP
+
+<sub>Star+</sub>
+
+??? question "Star+ - [Click to show/hide]"
+
+    {! include-markdown "../../includes/cf-descriptions/strp.md" !}
+
+??? example "JSON - [Click to show/hide]"
+
+    ```json
+    [[% filter indent(width=4) %]][[% include 'json/sonarr/cf/strp.json' %]][[% endfilter %]]
     ```
 
 <sub><sup>[TOP](#index)</sup>

--- a/docs/json/radarr/cf/now.json
+++ b/docs/json/radarr/cf/now.json
@@ -1,0 +1,34 @@
+{
+  "trash_id": "3dce1fce9ac06d1349dfbd9186289385",
+  "name": "NOW",
+  "includeCustomFormatWhenRenaming": true,
+  "specifications": [
+    {
+      "name": "NOW",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": true,
+      "fields": {
+        "value": "\\b(now)\\b[ ._-]web[ ._-]?(dl|rip)?\\b"
+      }
+    },
+    {
+      "name": "WEBDL",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 7
+      }
+    },
+    {
+      "name": "WEBRIP",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 8
+      }
+    }
+  ]
+}

--- a/docs/json/radarr/cf/strp.json
+++ b/docs/json/radarr/cf/strp.json
@@ -1,0 +1,34 @@
+{
+  "trash_id": "ab56ccdc473a1f2897c76187ea365be2",
+  "name": "STRP",
+  "includeCustomFormatWhenRenaming": true,
+  "specifications": [
+    {
+      "name": "Star+",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": true,
+      "fields": {
+        "value": "\\b(STRP)\\b"
+      }
+    },
+    {
+      "name": "WEBDL",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 7
+      }
+    },
+    {
+      "name": "WEBRIP",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 8
+      }
+    }
+  ]
+}

--- a/docs/json/radarr/cf/tving.json
+++ b/docs/json/radarr/cf/tving.json
@@ -1,0 +1,34 @@
+{
+  "trash_id": "26df36e3d2a96de2f8b7166ae37d3c33",
+  "name": "TVING",
+  "includeCustomFormatWhenRenaming": true,
+  "specifications": [
+    {
+      "name": "TVING",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": true,
+      "fields": {
+        "value": "\\b(tving)\\b[ ._-]web[ ._-]?(dl|rip)?\\b"
+      }
+    },
+    {
+      "name": "WEBDL",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 7
+      }
+    },
+    {
+      "name": "WEBRIP",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 8
+      }
+    }
+  ]
+}

--- a/docs/json/sonarr/cf/dscp.json
+++ b/docs/json/sonarr/cf/dscp.json
@@ -1,0 +1,37 @@
+{
+  "trash_id": "dc5f2bb0e0262155b5fedd0f6c5d2b55",
+  "trash_scores": {
+    "default": 50
+  },
+  "name": "DSCP",
+  "includeCustomFormatWhenRenaming": true,
+  "specifications": [
+    {
+      "name": "Discovery+",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": true,
+      "fields": {
+        "value": "\\b(dscp|dcp|disc)\\b[ ._-]web[ ._-]?(dl|rip)?\\b"
+      }
+    },
+    {
+      "name": "WEBDL",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 3
+      }
+    },
+    {
+      "name": "WEBRIP",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 4
+      }
+    }
+  ]
+}

--- a/docs/json/sonarr/cf/now.json
+++ b/docs/json/sonarr/cf/now.json
@@ -1,0 +1,37 @@
+{
+  "trash_id": "b66a699fba6f9df91becab798d7502e5",
+  "trash_scores": {
+    "default": 50
+  },
+  "name": "NOW",
+  "includeCustomFormatWhenRenaming": true,
+  "specifications": [
+    {
+      "name": "NOW",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": true,
+      "fields": {
+        "value": "\\b(now)\\b[ ._-]web[ ._-]?(dl|rip)?\\b"
+      }
+    },
+    {
+      "name": "WEBDL",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 3
+      }
+    },
+    {
+      "name": "WEBRIP",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 4
+      }
+    }
+  ]
+}

--- a/docs/json/sonarr/cf/strp.json
+++ b/docs/json/sonarr/cf/strp.json
@@ -1,0 +1,37 @@
+{
+  "trash_id": "fe4062eac43d4ea75955f8ae48adcf1e",
+  "trash_scores": {
+    "default": 50
+  },
+  "name": "STRP",
+  "includeCustomFormatWhenRenaming": true,
+  "specifications": [
+    {
+      "name": "Star+",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": true,
+      "fields": {
+        "value": "\\b(STRP)\\b"
+      }
+    },
+    {
+      "name": "WEBDL",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 3
+      }
+    },
+    {
+      "name": "WEBRIP",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 4
+      }
+    }
+  ]
+}

--- a/docs/json/sonarr/cf/tving.json
+++ b/docs/json/sonarr/cf/tving.json
@@ -1,0 +1,37 @@
+{
+  "trash_id": "86f8d3b8761de651aa355d46d5d8db3e",
+  "trash_scores": {
+    "default": 50
+  },
+  "name": "TVING",
+  "includeCustomFormatWhenRenaming": true,
+  "specifications": [
+    {
+      "name": "TVING",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": true,
+      "fields": {
+        "value": "\\b(tving)\\b[ ._-]web[ ._-]?(dl|rip)?\\b"
+      }
+    },
+    {
+      "name": "WEBDL",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 3
+      }
+    },
+    {
+      "name": "WEBRIP",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 4
+      }
+    }
+  ]
+}

--- a/includes/cf-descriptions/dscp.md
+++ b/includes/cf-descriptions/dscp.md
@@ -1,0 +1,5 @@
+**Discovery+**<br>
+
+[From Wikipedia, the free encyclopedia](https://en.wikipedia.org/wiki/Discovery%2B){:target="_blank" rel="noopener noreferrer"}
+
+Discovery+ (pronounced "Discovery Plus"; stylized as discovery+) is an American subscription video on-demand over-the-top streaming service owned by Warner Bros. Discovery (WBD). The service focuses on factual programming drawn from the libraries of Discovery's main channel brands, as well as original series (including spin-offs of programs from Discovery's television networks), and other acquired content.

--- a/includes/cf-descriptions/now.md
+++ b/includes/cf-descriptions/now.md
@@ -1,0 +1,5 @@
+**NOW**<br>
+
+[From Wikipedia, the free encyclopedia](https://en.wikipedia.org/wiki/Now_(Sky)){:target="_blank" rel="noopener noreferrer"}
+
+Now (formerly Now TV and often stylised as NOW) is a subscription over-the-top streaming television service operated by British satellite television provider Sky Group.

--- a/includes/cf-descriptions/strp.md
+++ b/includes/cf-descriptions/strp.md
@@ -1,0 +1,7 @@
+**Star+**<br>
+
+[From Wikipedia, the free encyclopedia](https://en.wikipedia.org/wiki/Star%2B){:target="_blank" rel="noopener noreferrer"}
+
+Star+ (Star Plus; stylized as ST★R+) is a subscription video on-demand over-the-top streaming service available in almost all Ibero-American states. The service is owned by The Walt Disney Company through the Disney Entertainment division and business segment.
+
+In December 2023, it was confirmed that Star+ will be merged into Disney+ in the second quarter of 2024 with all of its content, including live sports from ESPN, migrating to Disney+ and its standalone app being discontinued.

--- a/includes/cf-descriptions/tving.md
+++ b/includes/cf-descriptions/tving.md
@@ -1,0 +1,6 @@
+**TVING**<br>
+
+[From Wikipedia, the free encyclopedia](https://en.wikipedia.org/wiki/TVING){:target="_blank" rel="noopener noreferrer"}
+
+TVING (Korean: 티빙) is a South Korean subscription video on-demand over-the-top streaming service operated by TVING Corporation, It is a platform that streams dramas, entertainment shows, animations, exclusive television films, specials and documentaries.
+

--- a/includes/cf-descriptions/tving.md
+++ b/includes/cf-descriptions/tving.md
@@ -3,4 +3,3 @@
 [From Wikipedia, the free encyclopedia](https://en.wikipedia.org/wiki/TVING){:target="_blank" rel="noopener noreferrer"}
 
 TVING (Korean: 티빙) is a South Korean subscription video on-demand over-the-top streaming service operated by TVING Corporation, It is a platform that streams dramas, entertainment shows, animations, exclusive television films, specials and documentaries.
-

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -65,7 +65,7 @@ plugins:
   - git-revision-date-localized:
       type: datetime
       locale: en
-  #    fallback_to_build_date: false
+      fallback_to_build_date: false
   - awesome-pages
   - glightbox:
       touchNavigation: true


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->

Added CF Streaming Services `Star+`, `NOW`, `TVING`, `Discovery+`

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

Added CF Streaming Services `Star+`, `NOW`, `TVING`, `Discovery+`

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

- [x] trash_id check: Sonarr - Star+
- [x]  trash_id check: Radarr - Star+
- [x] trash_id check: Sonarr - NOW
- [x]  trash_id check: Radarr - NOW
- [x] NOW test regex so it doesn't match on episode titles with now in it
- [x] trash_id check: Sonarr - TVING
- [x]  trash_id check: Radarr - TVING
- [x] trash_id check: Sonarr - Discovery+
- [x] Discovery+ test regex so it doesn't match on bonus discs



<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
