### PR TITLE
feat(guide): Move RlsGrps Between Tiers

### DIFF
--- a/docs/json/radarr/cf/remux-tier-01.json
+++ b/docs/json/radarr/cf/remux-tier-01.json
@@ -53,6 +53,15 @@
       }
     },
     {
+      "name": "CiNEPHiLES",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(CiNEPHiLES)$"
+      }
+    },
+    {
       "name": "FraMeSToR",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,
@@ -68,15 +77,6 @@
       "required": false,
       "fields": {
         "value": "^(PmP)$"
-      }
-    },
-    {
-      "name": "SiCFoI",
-      "implementation": "ReleaseGroupSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "^(SiCFoI)$"
       }
     },
     {

--- a/docs/json/radarr/cf/remux-tier-02.json
+++ b/docs/json/radarr/cf/remux-tier-02.json
@@ -17,15 +17,6 @@
       }
     },
     {
-      "name": "CiNEPHiLES",
-      "implementation": "ReleaseGroupSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "^(CiNEPHiLES)$"
-      }
-    },
-    {
       "name": "Flights",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,
@@ -59,6 +50,15 @@
       "required": false,
       "fields": {
         "value": "^(playBD)$"
+      }
+    },
+    {
+      "name": "SiCFoI",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(SiCFoI)$"
       }
     },
     {

--- a/docs/json/radarr/cf/uhd-bluray-tier-01.json
+++ b/docs/json/radarr/cf/uhd-bluray-tier-01.json
@@ -55,6 +55,15 @@
       }
     },
     {
+      "name": "MainFrame",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(MainFrame)$"
+      }
+    },
+    {
       "name": "DON",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,

--- a/docs/json/radarr/cf/uhd-bluray-tier-02.json
+++ b/docs/json/radarr/cf/uhd-bluray-tier-02.json
@@ -53,15 +53,6 @@
       "fields": {
         "value": "^(HQMUX)$"
       }
-    },
-    {
-      "name": "MainFrame",
-      "implementation": "ReleaseGroupSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "^(MainFrame)$"
-      }
     }
   ]
 }

--- a/docs/updates.txt
+++ b/docs/updates.txt
@@ -1,3 +1,6 @@
+# 2024-03-24 12:30
+- [feat(guide): Move RlsGrps Between Tiers](https://github.com/TRaSH-Guides/Guides/pull/1857)
+
 # 2024-03-23 17:15
 - [feat(guide): Add AppleTV audio info and updated flowcharts](https://github.com/TRaSH-Guides/Guides/pull/1847)
 - [feat(Starr:) Add New x266 Custom Formats](https://github.com/TRaSH-Guides/Guides/pull/1841)


### PR DESCRIPTION
# Pull Request

## Purpose

To enact the first round of the review of release groups, and move them between tiers as appropriate

## Approach

- [x] Move MainFrame to UHD Bluray Tier 01
- [x] Move CinePhiles to Remux Tier 01
- [x] Move SiCFoI to Remux Tier 02

## Open Questions and Pre-Merge TODOs

None

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
