### PR TITLE
fix(starr): DTS-X CF mismatching

### DIFF
--- a/docs/json/radarr/cf/dts-es.json
+++ b/docs/json/radarr/cf/dts-es.json
@@ -58,7 +58,7 @@
           "negate": true,
           "required": true,
           "fields": {
-              "value": "\\b(dts[-_. ]?x)\\b(?!\\d)"
+              "value": "\\b(dts[-_.: ]?x7?)\\b(?![-_. ]?(26[456]))"
           }
       },
       {

--- a/docs/json/radarr/cf/dts-hd-hra.json
+++ b/docs/json/radarr/cf/dts-hd-hra.json
@@ -59,7 +59,7 @@
           "negate": true,
           "required": true,
           "fields": {
-              "value": "\\b(dts[-_. ]?x)\\b(?!\\d)"
+              "value": "\\b(dts[-_.: ]?x7?)\\b(?![-_. ]?(26[456]))"
           }
       },
       {

--- a/docs/json/radarr/cf/dts-hd-ma.json
+++ b/docs/json/radarr/cf/dts-hd-ma.json
@@ -51,7 +51,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "\\b(dts[-_. ]?x)\\b(?!\\d)"
+        "value": "\\b(dts[-_.: ]?x7?)\\b(?![-_. ]?(26[456]))"
       }
     },
     {

--- a/docs/json/radarr/cf/dts-x.json
+++ b/docs/json/radarr/cf/dts-x.json
@@ -5,6 +5,7 @@
     "sqp-1-1080p": -10000,
     "sqp-1-2160p": -10000
   },
+  "trash_regex": "https://regex101.com/r/GqubZM/1",
   "name": "DTS X",
   "includeCustomFormatWhenRenaming": false,
   "specifications": [{

--- a/docs/json/radarr/cf/dts-x.json
+++ b/docs/json/radarr/cf/dts-x.json
@@ -13,7 +13,7 @@
           "negate": false,
           "required": true,
           "fields": {
-              "value": "\\b(dts[-_. ]?x)\\b(?!\\d)"
+              "value": "\\b(dts[-_.: ]?x7?)\\b(?![-_. ]?(26[456]))"
           }
       },
       {

--- a/docs/json/radarr/cf/dts-x.json
+++ b/docs/json/radarr/cf/dts-x.json
@@ -5,7 +5,7 @@
     "sqp-1-1080p": -10000,
     "sqp-1-2160p": -10000
   },
-  "trash_regex": "https://regex101.com/r/GqubZM/1",
+  "trash_regex": "https://regex101.com/r/VWCW8c/1",
   "name": "DTS X",
   "includeCustomFormatWhenRenaming": false,
   "specifications": [{

--- a/docs/json/radarr/cf/dts.json
+++ b/docs/json/radarr/cf/dts.json
@@ -68,7 +68,7 @@
           "negate": true,
           "required": true,
           "fields": {
-              "value": "\\b(dts[-_. ]?x)\\b(?!\\d)"
+              "value": "\\b(dts[-_.: ]?x7?)\\b(?![-_. ]?(26[456]))"
           }
       },
       {

--- a/docs/json/radarr/cf/truehd-atmos.json
+++ b/docs/json/radarr/cf/truehd-atmos.json
@@ -59,7 +59,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "\\b(dts[-_. ]?x)\\b(?!\\d)"
+        "value": "\\b(dts[-_.: ]?x7?)\\b(?![-_. ]?(26[456]))"
       }
     },
     {

--- a/docs/json/sonarr/cf/dts-es.json
+++ b/docs/json/sonarr/cf/dts-es.json
@@ -56,7 +56,7 @@
           "negate": true,
           "required": true,
           "fields": {
-              "value": "\\b(dts[-_. ]?x)\\b(?!\\d)"
+              "value": "\\b(dts[-_.: ]?x7?)\\b(?![-_. ]?(26[456]))"
           }
       },
       {

--- a/docs/json/sonarr/cf/dts-hd-hra.json
+++ b/docs/json/sonarr/cf/dts-hd-hra.json
@@ -57,7 +57,7 @@
           "negate": true,
           "required": true,
           "fields": {
-              "value": "\\b(dts[-_. ]?x)\\b(?!\\d)"
+              "value": "\\b(dts[-_.: ]?x7?)\\b(?![-_. ]?(26[456]))"
           }
       },
       {

--- a/docs/json/sonarr/cf/dts-hd-ma.json
+++ b/docs/json/sonarr/cf/dts-hd-ma.json
@@ -49,7 +49,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "\\b(dts[-_. ]?x)\\b(?!\\d)"
+        "value": "\\b(dts[-_.: ]?x7?)\\b(?![-_. ]?(26[456]))"
       }
     },
     {

--- a/docs/json/sonarr/cf/dts-x.json
+++ b/docs/json/sonarr/cf/dts-x.json
@@ -11,7 +11,7 @@
           "negate": false,
           "required": true,
           "fields": {
-              "value": "\\b(dts[-_. ]?x)\\b(?!\\d)"
+              "value": "\\b(dts[-_.: ]?x7?)\\b(?![-_. ]?(26[456]))"
           }
       },
       {

--- a/docs/json/sonarr/cf/dts-x.json
+++ b/docs/json/sonarr/cf/dts-x.json
@@ -3,6 +3,7 @@
   "trash_scores": {
     "default": 4500
   },
+  "trash_regex": "https://regex101.com/r/GqubZM/1",
   "name": "DTS X",
   "includeCustomFormatWhenRenaming": false,
   "specifications": [{

--- a/docs/json/sonarr/cf/dts-x.json
+++ b/docs/json/sonarr/cf/dts-x.json
@@ -3,7 +3,7 @@
   "trash_scores": {
     "default": 4500
   },
-  "trash_regex": "https://regex101.com/r/GqubZM/1",
+  "trash_regex": "https://regex101.com/r/VWCW8c/1",
   "name": "DTS X",
   "includeCustomFormatWhenRenaming": false,
   "specifications": [{

--- a/docs/json/sonarr/cf/dts.json
+++ b/docs/json/sonarr/cf/dts.json
@@ -66,7 +66,7 @@
           "negate": true,
           "required": true,
           "fields": {
-              "value": "\\b(dts[-_. ]?x)\\b(?!\\d)"
+              "value": "\\b(dts[-_.: ]?x7?)\\b(?![-_. ]?(26[456]))"
           }
       },
       {

--- a/docs/json/sonarr/cf/truehd-atmos.json
+++ b/docs/json/sonarr/cf/truehd-atmos.json
@@ -57,7 +57,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "\\b(dts[-_. ]?x)\\b(?!\\d)"
+        "value": "\\b(dts[-_.: ]?x7?)\\b(?![-_. ]?(26[456]))"
       }
     },
     {


### PR DESCRIPTION
# Pull Request

## Purpose

Fix the `DTS X` CF mismatching and not matching on various different naming schemes.

## Approach

Update the regex to more accurately match `DTS X`.

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
