### PR TITLE
fix(starr): TheUpscaler not matching

### DIFF
--- a/docs/json/radarr/cf/upscaled.json
+++ b/docs/json/radarr/cf/upscaled.json
@@ -31,7 +31,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "\\b(The[ ._-]Upscaler)\\b"
+        "value": "\\b(The[ ._-]?Upscaler)\\b"
       }
     },
     {

--- a/docs/json/sonarr/cf/upscaled.json
+++ b/docs/json/sonarr/cf/upscaled.json
@@ -31,7 +31,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "\\b(The[ ._-]Upscaler)\\b"
+        "value": "\\b(The[ ._-]?Upscaler)\\b"
       }
     },
     {


### PR DESCRIPTION
# Pull Request

## Purpose

Fixes matching of TheUpscaler releases named in the format `TheUpscaler`, where previously it would only match if there was a space, period, underscore or hyphen between the two words.

## Approach

Updated the regex to match `TheUpscaler`.

https://regex101.com/r/hRrgEh/1

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
