### PR TITLE
fix: anime-dual audio regex.

### DIFF
--- a/docs/json/sonarr/cf/anime-dual-audio.json
+++ b/docs/json/sonarr/cf/anime-dual-audio.json
@@ -9,7 +9,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "dual[ ._-]?audio|[\\[(]dual[\\])]|(JA|ZH)\\+EN|EN\\+(JA|ZH)"
+        "value": "(?:[Dd]ual|[Aa]udio)[ ._-]?(?:[Aa]udio)|[\\[(]dual[\\])]|(JA|ZH)\\+EN|EN\\+(JA|ZH)"
       }
     },
     {


### PR DESCRIPTION
## Purpose

I am encountering issues with Sonarr incorrectly identifying quality upgrades, resulting in false positives. A specific case involved the anime `"Frieren"` where after its final episode aired, the group `LostYears` released a Dual Audio version for episode 26. Although this should have been recognized as a quality upgrade, Sonarr failed to import it automatically. This mishap occurred because the existing regex pattern was only designed to match `"dual-audio"` in lowercase, not accounting for variations where the 'D' and 'A' in "Dual Audio" were capitalized or if there is a space in between of them.

An example would be [this ](https://nyaa.si/view/1797597) release.
Which have the title:
`[LostYears] Frieren Beyond Journey's End - S01E26 (WEB 1080p x265 10-bit AAC E-AC-3) [Dual Audio] | (Sousou no Frieren)`

Previous regex: `dual[ ._-]?audio|[\[(]dual[\])]|(JA|ZH)\+EN|EN\+(JA|ZH)`
Updated regex: `(?:[Dd]ual|[Aa]udio)[ ._-]?(?:[Aa]udio)|[\[(]dual[\])]|(JA|ZH)\+EN|EN\+(JA|ZH)`

## Approach

To resolve this, the regex pattern needs to be adjusted to accommodate both uppercase and lowercase letters for "Dual Audio," as well as to handle potential spaces or hyphens that might appear in the term.

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
