### PR TITLE
feat(guide): Starr language tips add German dual and multi

### DIFF
--- a/docs/Radarr/Tips/How-to-setup-language-custom-formats.md
+++ b/docs/Radarr/Tips/How-to-setup-language-custom-formats.md
@@ -33,7 +33,7 @@ Add the following json to your Radarr/Sonarr with a score in your profile of `-1
     ```
 
 !!! tip
-    Don't forget to take a look at [Language Special Cases](#language-special-cases)
+    Don't forget to take a look at [Language Special Cases](/Radarr/Tips/How-to-setup-language-custom-formats/#language-special-cases)
 
 ---
 
@@ -56,7 +56,7 @@ Add the following json to your Radarr/Sonarr with a score in your profile of `-1
     ```
 
 !!! tip
-    Don't forget to take a look at [Language Special Cases](#language-special-cases)
+    Don't forget to take a look at [Language Special Cases](/Radarr/Tips/How-to-setup-language-custom-formats/#language-special-cases)
 
 ---
 
@@ -110,7 +110,7 @@ Add the following json to your Radarr/Sonarr with a score in your profile of `10
     ```
 
 !!! tip
-    Don't forget to take a look at [Language Special Cases](#language-special-cases)
+    Don't forget to take a look at [Language Special Cases](/Radarr/Tips/How-to-setup-language-custom-formats/#language-special-cases)
 
 ---
 
@@ -131,7 +131,7 @@ Add the following json to your Radarr/Sonarr with a score in your profile of `10
     ```
 
 !!! tip
-    Don't forget to take a look at [Language Special Cases](#language-special-cases)
+    Don't forget to take a look at [Language Special Cases](/Radarr/Tips/How-to-setup-language-custom-formats/#language-special-cases)
 
 ---
 

--- a/docs/Radarr/Tips/How-to-setup-language-custom-formats.md
+++ b/docs/Radarr/Tips/How-to-setup-language-custom-formats.md
@@ -159,17 +159,17 @@ Add the following json to your Radarr/Sonarr with a score in your profile of `10
 
 ## Language Special Cases
 
-Here we will add special cases often related to a specific language.
-example: German Dual Language and Multi-language releases
+Here we will add special cases that often are related to specific languages.
+example: German Dual Language and/or Multi-language releases
 
-!!! info "In general Dual/Multi stands for original language (*movies/show original language*) + foreign language(s), which audio track is used as first track isn't always known."
+!!! info "In general, Dual/Multi stands for original language (*movies/show original language*) + foreign language(s). Which audio track being used as the first track isn't always known based on the naming."
 
 ### Language: German + Original
 
-This Custom Format can be used in several ways,
+This Custom Format can be used in several ways:
 
-- If you **DON'T WANT** that your media file has a German audio track included add this Custom Format with a score of `-10000`.
-- If you **PREFER** that your media file has a German audio track included then you can add this Custom Format with a positive score.
+- If you **DON'T WANT** your media file to have a German audio track included, add this Custom Format with a score of `-10000`.
+- If you **PREFER** your media file to have a German audio track included, add this Custom Format with a positive score.
 
 <sub><sub>Language: German Dual Language</sub>
 

--- a/docs/Radarr/Tips/How-to-setup-language-custom-formats.md
+++ b/docs/Radarr/Tips/How-to-setup-language-custom-formats.md
@@ -32,6 +32,9 @@ Add the following json to your Radarr/Sonarr with a score in your profile of `-1
     [[% filter indent(width=4) %]][[% include 'json/guide-only/language-not-original.json' %]][[% endfilter %]]
     ```
 
+!!! tip
+    Don't forget to take a look at [Language Special Cases](#language-special-cases)
+
 ---
 
 ### Language: English Only
@@ -51,6 +54,9 @@ Add the following json to your Radarr/Sonarr with a score in your profile of `-1
     ```json
     [[% filter indent(width=4) %]][[% include 'json/guide-only/language-not-english.json' %]][[% endfilter %]]
     ```
+
+!!! tip
+    Don't forget to take a look at [Language Special Cases](#language-special-cases)
 
 ---
 
@@ -80,8 +86,8 @@ Add the following json to your Radarr/Sonarr with a score in your profile of `-1
 
 ### Language: Prefer X but i'll take Y
 
-<sub><sub>Language: Not Original or German</sub>
-<sub><sub>Language: Prefer German</sub>
+<sub><sub>Language: Not Original or German<br>
+Language: Prefer German</sub>
 
 Let's say you want German, but if German is not available then fall back to Original language but don't accept any other translated languages.
 
@@ -103,6 +109,9 @@ Add the following json to your Radarr/Sonarr with a score in your profile of `10
     [[% filter indent(width=4) %]][[% include 'json/guide-only/language-prefer-german.json' %]][[% endfilter %]]
     ```
 
+!!! tip
+    Don't forget to take a look at [Language Special Cases](#language-special-cases)
+
 ---
 
 ### Language: Prefer Language X
@@ -120,6 +129,9 @@ Add the following json to your Radarr/Sonarr with a score in your profile of `10
     ```json
     [[% filter indent(width=4) %]][[% include 'json/guide-only/language-prefer-german.json' %]][[% endfilter %]]
     ```
+
+!!! tip
+    Don't forget to take a look at [Language Special Cases](#language-special-cases)
 
 ---
 
@@ -144,6 +156,28 @@ Add the following json to your Radarr/Sonarr with a score in your profile of `10
     ```
 
 ---
+
+## Language Special Cases
+
+Here we will add special cases often related to a specific language.
+example: German Dual Language and Multi-language releases
+
+!!! info "In general Dual/Multi stands for original language (*movies/show original language*) + foreign language(s), which audio track is used as first track isn't always known."
+
+### Language: German + Original
+
+This Custom Format can be used in several ways,
+
+- If you **DON'T WANT** that your media file has a German audio track included add this Custom Format with a score of `-10000`.
+- If you **PREFER** that your media file has a German audio track included then you can add this Custom Format with a positive score.
+
+<sub><sub>Language: German Dual Language</sub>
+
+??? example "JSON - [Click to show/hide]"
+
+    ```json
+    [[% filter indent(width=4) %]][[% include 'json/guide-only/language-german-and-original.json' %]][[% endfilter %]]
+    ```
 
 ## FAQ & INFO
 

--- a/docs/Radarr/Tips/How-to-setup-language-custom-formats.md
+++ b/docs/Radarr/Tips/How-to-setup-language-custom-formats.md
@@ -33,6 +33,7 @@ Add the following json to your Radarr/Sonarr with a score in your profile of `-1
     ```
 
 !!! tip
+
     Don't forget to take a look at [Language Special Cases](/Radarr/Tips/How-to-setup-language-custom-formats/#language-special-cases)
 
 ---
@@ -56,6 +57,7 @@ Add the following json to your Radarr/Sonarr with a score in your profile of `-1
     ```
 
 !!! tip
+
     Don't forget to take a look at [Language Special Cases](/Radarr/Tips/How-to-setup-language-custom-formats/#language-special-cases)
 
 ---
@@ -110,6 +112,7 @@ Add the following json to your Radarr/Sonarr with a score in your profile of `10
     ```
 
 !!! tip
+
     Don't forget to take a look at [Language Special Cases](/Radarr/Tips/How-to-setup-language-custom-formats/#language-special-cases)
 
 ---
@@ -131,6 +134,7 @@ Add the following json to your Radarr/Sonarr with a score in your profile of `10
     ```
 
 !!! tip
+
     Don't forget to take a look at [Language Special Cases](/Radarr/Tips/How-to-setup-language-custom-formats/#language-special-cases)
 
 ---

--- a/docs/Radarr/Tips/How-to-setup-language-custom-formats.md
+++ b/docs/Radarr/Tips/How-to-setup-language-custom-formats.md
@@ -162,11 +162,11 @@ Add the following json to your Radarr/Sonarr with a score in your profile of `10
 Here we will add special cases that often are related to specific languages.
 example: German Dual Language and/or Multi-language releases
 
-!!! info "In general, Dual/Multi stands for original language (*movies/show original language*) + foreign language(s). Which audio track being used as the first track isn't always known based on the naming."
+!!! info "In general, Dual/Multi in a release title stands for original language (*movies/show original language*) + foreign language(s). Which audio track is used for the first track isn't always known based solely on the naming."
 
 ### Language: German + Original
 
-This Custom Format can be used in several ways:
+This Custom Format can be used in two ways:
 
 - If you **DON'T WANT** your media file to have a German audio track included, add this Custom Format with a score of `-10000`.
 - If you **PREFER** your media file to have a German audio track included, add this Custom Format with a positive score.

--- a/docs/json/guide-only/language-german-and-original.json
+++ b/docs/json/guide-only/language-german-and-original.json
@@ -1,0 +1,38 @@
+{
+  "trash_id": "guide-only",
+  "trash_scores": {
+    "default": -10000
+  },
+  "trash_description": "Language: German Dual Language and Multi-language releases",
+  "name": "Language: German + Original",
+  "includeCustomFormatWhenRenaming": false,
+  "specifications": [
+    {
+      "name": "German",
+      "implementation": "LanguageSpecification",
+      "negate": false,
+      "required": true,
+      "fields": {
+        "value": 4
+      }
+    },
+    {
+      "name": "DL",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "(?<!WEB[-_. ]?)\\b(DL)\\b"
+      }
+    },
+    {
+      "name": "ML",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(ML)\\b"
+      }
+    }
+  ]
+}

--- a/docs/json/guide-only/language-german-and-original.json
+++ b/docs/json/guide-only/language-german-and-original.json
@@ -3,7 +3,7 @@
   "trash_scores": {
     "default": -10000
   },
-  "trash_description": "Language: German Dual Language and Multi-language releases",
+  "trash_description": "Language: German Dual and Multi language releases",
   "name": "Language: German + Original",
   "includeCustomFormatWhenRenaming": false,
   "specifications": [


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->

Dual and Multi language is also picked up as original audio, for some users it's a preferred option, others rather don't get those releases because there is no way to determine upfront which audio track is used as main audio track.

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

## Open Questions and Pre-Merge TODOs

- [x] Added a Custom Format  provided by @mynameisbogdan that matches on German + Dual/Multi audio.
- [x] Added a option If you DON'T WANT that your media file has a German audio track included.
- [x] Added a option If you PREFER that your media file has a German audio track included.

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
