### PR TITLE
ci(pr-name-check): integrates pr naming convention into workflow

### DIFF
--- a/.github/workflows/pr-naming-check.yml
+++ b/.github/workflows/pr-naming-check.yml
@@ -2,7 +2,7 @@ name: Pull Request Title Validation
 
 on:
   pull_request:
-    types: [opened, reopened, edited]
+    types: [opened, reopened, edited, synchronize]
 
 jobs:
   pull-request-title-validation:

--- a/.github/workflows/pr-naming-check.yml
+++ b/.github/workflows/pr-naming-check.yml
@@ -26,7 +26,7 @@ jobs:
               if ((context.payload.action === 'opened') || (context.payload.action === 'reopened')) {
                 const prNumber = context.payload.pull_request.number;
                 const author = context.payload.pull_request.user.login;
-                const message = `@${author} your pull request title "${context.payload.pull_request.title}" does not conform to our naming conventions (https://www.conventionalcommits.org/en/v1.0.0/).\n\nPlease update the title to match the pattern: "feat|build|chore|style|fix|update|ci(<area>): <description>"`;
+                const message = `@${author} your pull request title "${context.payload.pull_request.title}" does not conform to our [naming conventions](https://www.conventionalcommits.org/en/v1.0.0/).\n\nPlease update the title to match the pattern: "feat|build|chore|style|fix|update|ci(\\<area\\>): \\<description\\>"`;
                 github.rest.issues.createComment({
                   owner: context.repo.owner,
                   repo: context.repo.repo,

--- a/.github/workflows/pr-naming-check.yml
+++ b/.github/workflows/pr-naming-check.yml
@@ -26,7 +26,7 @@ jobs:
               if ((context.payload.action === 'opened') || (context.payload.action === 'reopened')) {
                 const prNumber = context.payload.pull_request.number;
                 const author = context.payload.pull_request.user.login;
-                const message = `@${author} your pull request title "${context.payload.pull_request.title}" does not conform to our [naming conventions](https://www.conventionalcommits.org/en/v1.0.0/).\n\nPlease update the title to match the pattern: "feat|build|chore|style|fix|update|ci(\\<area\\>): \\<description\\>"`;
+                const message = `@${author} your pull request title "${context.payload.pull_request.title}" does not conform to our [naming conventions](https://www.conventionalcommits.org/en/v1.0.0/).\n\nPlease update the title to match the pattern: "feat|build|chore|style|fix|update|ci(\\<area\\>): \\<description\\>\n\nYou can check your title at this [regex101 link](https://regex101.com/r/jOZ6kU/1)."`;
                 github.rest.issues.createComment({
                   owner: context.repo.owner,
                   repo: context.repo.repo,

--- a/.github/workflows/pr-naming-check.yml
+++ b/.github/workflows/pr-naming-check.yml
@@ -1,0 +1,40 @@
+name: Pull Request Title Validation
+
+on:
+  pull_request:
+    types: [opened, reopened, edited]
+
+jobs:
+  pull-request-title-validation:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check PR title format
+        id: check_title
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const titleRegex = /^(Revert \")?(feat|build|chore|style|fix|update|ci)\((\w|\/|-)+\)\:.+/g;
+            const title = context.payload.pull_request.title;
+            const isValid = titleRegex.test(title);
+            if (!isValid) {
+              console.error(`PR title "${title}" doesn't match the required format.`);
+            }
+            return isValid;
+
+      - name: Leave comment for OP
+        if: steps.check_title.outputs.result == 'false'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const prNumber = context.payload.pull_request.number;
+            const author = context.payload.pull_request.user.login;
+            const message = `@${author} your pull request title "${context.payload.pull_request.title}" does not conform to our naming conventions (https://www.conventionalcommits.org/en/v1.0.0/).\n\nPlease update the title to match the pattern: "feat|build|chore|style|fix|update|ci(<area>): <description>"`;
+            github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              body: message
+            });

--- a/.github/workflows/pr-naming-check.yml
+++ b/.github/workflows/pr-naming-check.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [opened, reopened, edited, synchronize]
 
+permissions:
+  issues: write
+  pull-requests: write
+
 jobs:
   pull-request-title-validation:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-naming-check.yml
+++ b/.github/workflows/pr-naming-check.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Check PR title format
+      - name: Validate Pull Request Title
         id: check_title
         uses: actions/github-script@v7
         with:
@@ -19,22 +19,16 @@ jobs:
             const title = context.payload.pull_request.title;
             const isValid = titleRegex.test(title);
             if (!isValid) {
-              console.error(`PR title "${title}" doesn't match the required format.`);
+              if ((context.payload.action === 'opened') || (context.payload.action === 'reopened')) {
+                const prNumber = context.payload.pull_request.number;
+                const author = context.payload.pull_request.user.login;
+                const message = `@${author} your pull request title "${context.payload.pull_request.title}" does not conform to our naming conventions (https://www.conventionalcommits.org/en/v1.0.0/).\n\nPlease update the title to match the pattern: "feat|build|chore|style|fix|update|ci(<area>): <description>"`;
+                github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: prNumber,
+                  body: message
+                });
+              }
+              core.setFailed(`PR title "${title}" doesn't match the required format.`)
             }
-            return isValid;
-
-      - name: Leave comment for OP
-        if: steps.check_title.outputs.result == 'false'
-        uses: actions/github-script@v7
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const prNumber = context.payload.pull_request.number;
-            const author = context.payload.pull_request.user.login;
-            const message = `@${author} your pull request title "${context.payload.pull_request.title}" does not conform to our naming conventions (https://www.conventionalcommits.org/en/v1.0.0/).\n\nPlease update the title to match the pattern: "feat|build|chore|style|fix|update|ci(<area>): <description>"`;
-            github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: prNumber,
-              body: message
-            });

--- a/.github/workflows/pr-naming-check.yml
+++ b/.github/workflows/pr-naming-check.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const titleRegex = /^(Revert \")?(feat|build|chore|style|fix|update|ci)\((\w|\/|-)+\)\:.+/g;
+            const titleRegex = /^(Revert \")?(feat|fix|docs|style|refactor|perf|test|update|build|ci|chore)(\([\w\/-]+\))?:\s.+$/g;
             const title = context.payload.pull_request.title;
             const isValid = titleRegex.test(title);
             if (!isValid) {


### PR DESCRIPTION
# Pull Request

## Purpose

verifies that the naming conventions we use are followed for PR open/reopen/edit

## TODO

- [x] verify that commenting works when pr title is bad
- [x] verify that commenting does not happen when title is good
- [x] verify regex edge cases?