### PR TITLE
fix(starr): Prevent double scoring `DD+` and `DD+ Atmos`

### DIFF
--- a/docs/json/radarr/cf/ddplus.json
+++ b/docs/json/radarr/cf/ddplus.json
@@ -22,7 +22,7 @@
           "negate": true,
           "required": true,
           "fields": {
-              "value": "True[ .-]?HD|\\bATMOS(\\b|\\d)"
+              "value": "True[ .-]?HD|\\bATMOS|DDPA(\\b|\\d)"
           }
       },
       {

--- a/docs/json/sonarr/cf/ddplus.json
+++ b/docs/json/sonarr/cf/ddplus.json
@@ -20,7 +20,7 @@
           "negate": true,
           "required": true,
           "fields": {
-              "value": "True[ .-]?HD|\\bATMOS(\\b|\\d)"
+              "value": "True[ .-]?HD|\\bATMOS|DDPA(\\b|\\d)"
           }
       },
       {


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->

Prevent double scoring `DD+` and `DD+ Atmos`

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

Add ` DDPA`  to `Not TrueHD/ATMOS` condition in the `DD+` Custom Format

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

- [x] [Radarr] Add ` DDPA`  to `Not TrueHD/ATMOS` condition in the `DD+` Custom Format
- [x] [Sonarr] Add ` DDPA`  to `Not TrueHD/ATMOS` condition in the `DD+` Custom Format

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
