### PR TITLE
update(cf/hbomax): adds capturing hbomax (without separator)

### DIFF
--- a/docs/Sonarr/Sonarr-Release-Profile-RegEx.md
+++ b/docs/Sonarr/Sonarr-Release-Profile-RegEx.md
@@ -152,7 +152,7 @@ Add this to your `Preferred (3)` with a score of [90]
 Add this to your `Preferred (3)` with a score of [80]
 
 ```bash
-/\b(hmax|hbom|hbo[ ._-]max)\b(?=[ ._-]web[ ._-]?(dl|rip)\b)/i
+/\b(hmax|hbom|hbo[ ._-]?max)\b(?=[ ._-]web[ ._-]?(dl|rip)\b)/i
 ```
 
 ```bash

--- a/docs/json/radarr/cf/hmax.json
+++ b/docs/json/radarr/cf/hmax.json
@@ -9,7 +9,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\b(hmax|hbom|hbo[ ._-]max)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)"
+        "value": "\\b(hmax|hbom|hbo[ ._-]?max)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)"
       }
     },
     {

--- a/docs/json/sonarr/cf/hmax.json
+++ b/docs/json/sonarr/cf/hmax.json
@@ -12,7 +12,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\b(hmax|hbom|hbo[ ._-]max)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)"
+        "value": "\\b(hmax|hbom|hbo[ ._-]?max)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)"
       }
     },
     {

--- a/docs/json/sonarr/cf/uhd-streaming-cut.json
+++ b/docs/json/sonarr/cf/uhd-streaming-cut.json
@@ -21,7 +21,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "\\b(hmax|hbom|hbo[ ._-]max)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)"
+        "value": "\\b(hmax|hbom|hbo[ ._-]?max)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)"
       }
     },
     {

--- a/docs/json/sonarr/rp/streaming.json
+++ b/docs/json/sonarr/rp/streaming.json
@@ -20,7 +20,7 @@
     {
       "score": 80,
       "terms": [
-        "/\\b(hmax|hbom|hbo[ ._-]max)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)/i",
+        "/\\b(hmax|hbom|hbo[ ._-]?max)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)/i",
         "/\\b(qibi|quibi)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)/i"
       ]
     },


### PR DESCRIPTION
# Pull Request

## Purpose
closes #1894 - non-standard naming of HBO Max service without separator

https://regex101.com/r/VZsSwC/2

see title

simple change to add optional `?` to existing separators `[ ._-]` of `hbo` and `max`

## Approach

ctrl shift F -> go to each result and insert a `?` -> save files -> push branch -> create PR.... -> profit
