### PR TITLE
chore(sonarr): add 720p CF

### DIFF
--- a/docs/json/sonarr/cf/720p.json
+++ b/docs/json/sonarr/cf/720p.json
@@ -1,0 +1,19 @@
+{
+  "trash_id": "c99279ee27a154c2f20d1d505cc99e25",
+  "trash_scores": {
+    "default": 5
+  },
+  "name": "720p",
+  "includeCustomFormatWhenRenaming": false,
+  "specifications": [
+    {
+      "name": "720p",
+      "implementation": "ResolutionSpecification",
+      "negate": false,
+      "required": true,
+      "fields": {
+        "value": 720
+      }
+    }
+  ]
+}


### PR DESCRIPTION
# Pull Request

## Purpose

Adding a 720p CF to sonarr.

## Approach

This is following the 2160p and 1080p formats already available for Sonarr, plus the 2160p, 1080p and 720p formats for Radarr, to complete the set.

Hash created via https://md5.gromweb.com/?string=Sonarr+720p

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
