### PR TITLE
fix(starr): match `AC-3` as `DD`

### DIFF
--- a/docs/json/radarr/cf/aac.json
+++ b/docs/json/radarr/cf/aac.json
@@ -31,7 +31,7 @@
           "negate": true,
           "required": true,
           "fields": {
-              "value": "\\bDD[P+]|\\b(e[-_. ]?ac3)\\b"
+              "value": "\\bDD[P+]|\\b(e[-_. ]?ac-?3)\\b"
           }
       },
       {
@@ -40,7 +40,7 @@
           "negate": true,
           "required": true,
           "fields": {
-              "value": "\\bDD[^a-z+]|(?<!e)ac3"
+              "value": "\\bDD[^a-z+]|(?<!e-)\\b(ac-?3)\\b"
           }
       },
       {

--- a/docs/json/radarr/cf/anime-bd-tier-03-seadex-muxers.json
+++ b/docs/json/radarr/cf/anime-bd-tier-03-seadex-muxers.json
@@ -30,7 +30,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "\\[AC\\]|-AC\\b"
+        "value": "\\[AC\\]|-AC$"
       }
     },
     {

--- a/docs/json/radarr/cf/atmos-undefined.json
+++ b/docs/json/radarr/cf/atmos-undefined.json
@@ -32,7 +32,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "\\bDD[^a-z+]|(?<!e)ac3"
+        "value": "\\bDD[^a-z+]|(?<!e-)\\b(ac-?3)\\b"
       }
     },
     {
@@ -41,7 +41,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "\\bDD[P+]|\\b(e[-_. ]?ac3)\\b"
+        "value": "\\bDD[P+]|\\b(e[-_. ]?ac-?3)\\b"
       }
     },
     {

--- a/docs/json/radarr/cf/dd.json
+++ b/docs/json/radarr/cf/dd.json
@@ -13,7 +13,7 @@
           "negate": false,
           "required": true,
           "fields": {
-              "value": "\\bDD[^a-z+]|(?<!e)ac3"
+              "value": "\\bDD[^a-z+]|(?<!e-)\\b(ac-?3)\\b"
           }
       },
       {
@@ -22,7 +22,7 @@
           "negate": true,
           "required": true,
           "fields": {
-              "value": "\\bDD[P+]|\\b(e[-_. ]?ac3)\\b"
+              "value": "\\bDD[P+]|\\b(e[-_. ]?ac-?3)\\b"
           }
       },
       {

--- a/docs/json/radarr/cf/ddplus-atmos.json
+++ b/docs/json/radarr/cf/ddplus-atmos.json
@@ -14,7 +14,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\bDD[P+]|\\b(e[-_. ]?ac3)\\b"
+        "value": "\\bDD[P+]|\\b(e[-_. ]?ac-?3)\\b"
       }
     },
     {
@@ -50,7 +50,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "\\bDD[^a-z+]|(?<!e)ac3"
+        "value": "\\bDD[^a-z+]|(?<!e-)\\b(ac-?3)\\b"
       }
     },
     {

--- a/docs/json/radarr/cf/ddplus.json
+++ b/docs/json/radarr/cf/ddplus.json
@@ -13,7 +13,7 @@
           "negate": false,
           "required": true,
           "fields": {
-              "value": "\\bDD[P+](?!A)|\\b(e[-_. ]?ac3)\\b"
+              "value": "\\bDD[P+](?!A)|\\b(e[-_. ]?ac-?3)\\b"
           }
       },
       {

--- a/docs/json/radarr/cf/dts-es.json
+++ b/docs/json/radarr/cf/dts-es.json
@@ -31,7 +31,7 @@
           "negate": true,
           "required": true,
           "fields": {
-              "value": "\\bDD[P+]|\\b(e[-_. ]?ac3)\\b"
+              "value": "\\bDD[P+]|\\b(e[-_. ]?ac-?3)\\b"
           }
       },
       {
@@ -49,7 +49,7 @@
           "negate": true,
           "required": true,
           "fields": {
-              "value": "\\bDD[^a-z+]|(?<!e)ac3"
+              "value": "\\bDD[^a-z+]|(?<!e-)\\b(ac-?3)\\b"
           }
       },
       {

--- a/docs/json/radarr/cf/dts-hd-hra.json
+++ b/docs/json/radarr/cf/dts-hd-hra.json
@@ -32,7 +32,7 @@
           "negate": true,
           "required": true,
           "fields": {
-              "value": "\\bDD[P+]|\\b(e[-_. ]?ac3)\\b"
+              "value": "\\bDD[P+]|\\b(e[-_. ]?ac-?3)\\b"
           }
       },
       {
@@ -50,7 +50,7 @@
           "negate": true,
           "required": true,
           "fields": {
-              "value": "\\bDD[^a-z+]|(?<!e)ac3"
+              "value": "\\bDD[^a-z+]|(?<!e-)\\b(ac-?3)\\b"
           }
       },
       {

--- a/docs/json/radarr/cf/dts-hd-ma.json
+++ b/docs/json/radarr/cf/dts-hd-ma.json
@@ -33,7 +33,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "\\bDD[P+]|\\b(e[-_. ]?ac3)\\b"
+        "value": "\\bDD[P+]|\\b(e[-_. ]?ac-?3)\\b"
       }
     },
     {
@@ -42,7 +42,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "\\bDD[^a-z+]|(?<!e)ac3"
+        "value": "\\bDD[^a-z+]|(?<!e-)\\b(ac-?3)\\b"
       }
     },
     {

--- a/docs/json/radarr/cf/dts-x.json
+++ b/docs/json/radarr/cf/dts-x.json
@@ -32,7 +32,7 @@
           "negate": true,
           "required": true,
           "fields": {
-              "value": "\\bDD[^a-z+]|(?<!e)ac3"
+              "value": "\\bDD[^a-z+]|(?<!e-)\\b(ac-?3)\\b"
           }
       },
       {
@@ -41,7 +41,7 @@
           "negate": true,
           "required": true,
           "fields": {
-              "value": "\\bDD[P+]|\\b(e[-_. ]?ac3)\\b"
+              "value": "\\bDD[P+]|\\b(e[-_. ]?ac-?3)\\b"
           }
       },
       {

--- a/docs/json/radarr/cf/dts.json
+++ b/docs/json/radarr/cf/dts.json
@@ -41,7 +41,7 @@
           "negate": true,
           "required": true,
           "fields": {
-              "value": "\\bDD[P+]|\\b(e[-_. ]?ac3)\\b"
+              "value": "\\bDD[P+]|\\b(e[-_. ]?ac-?3)\\b"
           }
       },
       {
@@ -59,7 +59,7 @@
           "negate": true,
           "required": true,
           "fields": {
-              "value": "\\bDD[^a-z+]|(?<!e)ac3"
+              "value": "\\bDD[^a-z+]|(?<!e-)\\b(ac-?3)\\b"
           }
       },
       {

--- a/docs/json/radarr/cf/flac.json
+++ b/docs/json/radarr/cf/flac.json
@@ -58,7 +58,7 @@
           "negate": true,
           "required": true,
           "fields": {
-              "value": "\\bDD[^a-z+]|(?<!e)ac3"
+              "value": "\\bDD[^a-z+]|(?<!e-)\\b(ac-?3)\\b"
           }
       },
       {
@@ -67,7 +67,7 @@
           "negate": true,
           "required": true,
           "fields": {
-              "value": "\\bDD[P+]|\\b(e[-_. ]?ac3)\\b"
+              "value": "\\bDD[P+]|\\b(e[-_. ]?ac-?3)\\b"
           }
       }
   ]

--- a/docs/json/radarr/cf/pcm.json
+++ b/docs/json/radarr/cf/pcm.json
@@ -58,7 +58,7 @@
           "negate": true,
           "required": true,
           "fields": {
-              "value": "\\bDD[^a-z+]|(?<!e)ac3"
+              "value": "\\bDD[^a-z+]|(?<!e-)\\b(ac-?3)\\b"
           }
       },
       {
@@ -67,7 +67,7 @@
           "negate": true,
           "required": true,
           "fields": {
-              "value": "\\bDD[P+]|\\b(e[-_. ]?ac3)\\b"
+              "value": "\\bDD[P+]|\\b(e[-_. ]?ac-?3)\\b"
           }
       }
   ]

--- a/docs/json/radarr/cf/truehd-atmos.json
+++ b/docs/json/radarr/cf/truehd-atmos.json
@@ -32,7 +32,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "\\bDD[^a-z+]|(?<!e)ac3"
+        "value": "\\bDD[^a-z+]|(?<!e-)\\b(ac-?3)\\b"
       }
     },
     {
@@ -41,7 +41,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "\\bDD[P+]|\\b(e[-_. ]?ac3)\\b"
+        "value": "\\bDD[P+]|\\b(e[-_. ]?ac-?3)\\b"
       }
     },
     {

--- a/docs/json/radarr/cf/truehd.json
+++ b/docs/json/radarr/cf/truehd.json
@@ -32,7 +32,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "\\bDD[P+]|\\b(e[-_. ]?ac3)\\b"
+        "value": "\\bDD[P+]|\\b(e[-_. ]?ac-?3)\\b"
       }
     },
     {
@@ -59,7 +59,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "\\bDD[^a-z+]|(?<!e)ac3"
+        "value": "\\bDD[^a-z+]|(?<!e-)\\b(ac-?3)\\b"
       }
     },
     {

--- a/docs/json/sonarr/cf/aac.json
+++ b/docs/json/sonarr/cf/aac.json
@@ -29,7 +29,7 @@
           "negate": true,
           "required": true,
           "fields": {
-              "value": "\\bDD[P+]|\\b(e[-_. ]?ac3)\\b"
+              "value": "\\bDD[P+]|\\b(e[-_. ]?ac-?3)\\b"
           }
       },
       {
@@ -38,7 +38,7 @@
           "negate": true,
           "required": true,
           "fields": {
-              "value": "\\bDD[^a-z+]|(?<!e)ac3"
+              "value": "\\bDD[^a-z+]|(?<!e-)\\b(ac-?3)\\b"
           }
       },
       {

--- a/docs/json/sonarr/cf/anime-bd-tier-03-seadex-muxers.json
+++ b/docs/json/sonarr/cf/anime-bd-tier-03-seadex-muxers.json
@@ -39,7 +39,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "\\[AC\\]|-AC\\b"
+        "value": "\\[AC\\]|-AC$"
       }
     },
     {

--- a/docs/json/sonarr/cf/atmos-undefined.json
+++ b/docs/json/sonarr/cf/atmos-undefined.json
@@ -30,7 +30,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "\\bDD[^a-z+]|(?<!e)ac3"
+        "value": "\\bDD[^a-z+]|(?<!e-)\\b(ac-?3)\\b"
       }
     },
     {
@@ -39,7 +39,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "\\bDD[P+]|\\b(e[-_. ]?ac3)\\b"
+        "value": "\\bDD[P+]|\\b(e[-_. ]?ac-?3)\\b"
       }
     },
     {

--- a/docs/json/sonarr/cf/dd.json
+++ b/docs/json/sonarr/cf/dd.json
@@ -11,7 +11,7 @@
           "negate": false,
           "required": true,
           "fields": {
-              "value": "\\bDD[^a-z+]|(?<!e)ac3"
+              "value": "\\bDD[^a-z+]|(?<!e-)\\b(ac-?3)\\b"
           }
       },
       {
@@ -20,7 +20,7 @@
           "negate": true,
           "required": true,
           "fields": {
-              "value": "\\bDD[P+]|\\b(e[-_. ]?ac3)\\b"
+              "value": "\\bDD[P+]|\\b(e[-_. ]?ac-?3)\\b"
           }
       },
       {

--- a/docs/json/sonarr/cf/ddplus-atmos.json
+++ b/docs/json/sonarr/cf/ddplus-atmos.json
@@ -12,7 +12,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\bDD[P+]|\\b(e[-_. ]?ac3)\\b"
+        "value": "\\bDD[P+]|\\b(e[-_. ]?ac-?3)\\b"
       }
     },
     {
@@ -48,7 +48,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "\\bDD[^a-z+]|(?<!e)ac3"
+        "value": "\\bDD[^a-z+]|(?<!e-)\\b(ac-?3)\\b"
       }
     },
     {

--- a/docs/json/sonarr/cf/ddplus.json
+++ b/docs/json/sonarr/cf/ddplus.json
@@ -11,7 +11,7 @@
           "negate": false,
           "required": true,
           "fields": {
-              "value": "\\bDD[P+](?!A)|\\b(e[-_. ]?ac3)\\b"
+              "value": "\\bDD[P+](?!A)|\\b(e[-_. ]?ac-?3)\\b"
           }
       },
       {

--- a/docs/json/sonarr/cf/dts-es.json
+++ b/docs/json/sonarr/cf/dts-es.json
@@ -29,7 +29,7 @@
           "negate": true,
           "required": true,
           "fields": {
-              "value": "\\bDD[P+]|\\b(e[-_. ]?ac3)\\b"
+              "value": "\\bDD[P+]|\\b(e[-_. ]?ac-?3)\\b"
           }
       },
       {
@@ -47,7 +47,7 @@
           "negate": true,
           "required": true,
           "fields": {
-              "value": "\\bDD[^a-z+]|(?<!e)ac3"
+              "value": "\\bDD[^a-z+]|(?<!e-)\\b(ac-?3)\\b"
           }
       },
       {

--- a/docs/json/sonarr/cf/dts-hd-hra.json
+++ b/docs/json/sonarr/cf/dts-hd-hra.json
@@ -30,7 +30,7 @@
           "negate": true,
           "required": true,
           "fields": {
-              "value": "\\bDD[P+]|\\b(e[-_. ]?ac3)\\b"
+              "value": "\\bDD[P+]|\\b(e[-_. ]?ac-?3)\\b"
           }
       },
       {
@@ -48,7 +48,7 @@
           "negate": true,
           "required": true,
           "fields": {
-              "value": "\\bDD[^a-z+]|(?<!e)ac3"
+              "value": "\\bDD[^a-z+]|(?<!e-)\\b(ac-?3)\\b"
           }
       },
       {

--- a/docs/json/sonarr/cf/dts-hd-ma.json
+++ b/docs/json/sonarr/cf/dts-hd-ma.json
@@ -31,7 +31,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "\\bDD[P+]|\\b(e[-_. ]?ac3)\\b"
+        "value": "\\bDD[P+]|\\b(e[-_. ]?ac-?3)\\b"
       }
     },
     {
@@ -40,7 +40,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "\\bDD[^a-z+]|(?<!e)ac3"
+        "value": "\\bDD[^a-z+]|(?<!e-)\\b(ac-?3)\\b"
       }
     },
     {

--- a/docs/json/sonarr/cf/dts-x.json
+++ b/docs/json/sonarr/cf/dts-x.json
@@ -30,7 +30,7 @@
           "negate": true,
           "required": true,
           "fields": {
-              "value": "\\bDD[^a-z+]|(?<!e)ac3"
+              "value": "\\bDD[^a-z+]|(?<!e-)\\b(ac-?3)\\b"
           }
       },
       {
@@ -39,7 +39,7 @@
           "negate": true,
           "required": true,
           "fields": {
-              "value": "\\bDD[P+]|\\b(e[-_. ]?ac3)\\b"
+              "value": "\\bDD[P+]|\\b(e[-_. ]?ac-?3)\\b"
           }
       },
       {

--- a/docs/json/sonarr/cf/dts.json
+++ b/docs/json/sonarr/cf/dts.json
@@ -39,7 +39,7 @@
           "negate": true,
           "required": true,
           "fields": {
-              "value": "\\bDD[P+]|\\b(e[-_. ]?ac3)\\b"
+              "value": "\\bDD[P+]|\\b(e[-_. ]?ac-?3)\\b"
           }
       },
       {
@@ -57,7 +57,7 @@
           "negate": true,
           "required": true,
           "fields": {
-              "value": "\\bDD[^a-z+]|(?<!e)ac3"
+              "value": "\\bDD[^a-z+]|(?<!e-)\\b(ac-?3)\\b"
           }
       },
       {

--- a/docs/json/sonarr/cf/flac.json
+++ b/docs/json/sonarr/cf/flac.json
@@ -56,7 +56,7 @@
           "negate": true,
           "required": true,
           "fields": {
-              "value": "\\bDD[^a-z+]|(?<!e)ac3"
+              "value": "\\bDD[^a-z+]|(?<!e-)\\b(ac-?3)\\b"
           }
       },
       {
@@ -65,7 +65,7 @@
           "negate": true,
           "required": true,
           "fields": {
-              "value": "\\bDD[P+]|\\b(e[-_. ]?ac3)\\b"
+              "value": "\\bDD[P+]|\\b(e[-_. ]?ac-?3)\\b"
           }
       }
   ]

--- a/docs/json/sonarr/cf/pcm.json
+++ b/docs/json/sonarr/cf/pcm.json
@@ -56,7 +56,7 @@
           "negate": true,
           "required": true,
           "fields": {
-              "value": "\\bDD[^a-z+]|(?<!e)ac3"
+              "value": "\\bDD[^a-z+]|(?<!e-)\\b(ac-?3)\\b"
           }
       },
       {
@@ -65,7 +65,7 @@
           "negate": true,
           "required": true,
           "fields": {
-              "value": "\\bDD[P+]|\\b(e[-_. ]?ac3)\\b"
+              "value": "\\bDD[P+]|\\b(e[-_. ]?ac-?3)\\b"
           }
       }
   ]

--- a/docs/json/sonarr/cf/truehd-atmos.json
+++ b/docs/json/sonarr/cf/truehd-atmos.json
@@ -30,7 +30,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "\\bDD[^a-z+]|(?<!e)ac3"
+        "value": "\\bDD[^a-z+]|(?<!e-)\\b(ac-?3)\\b"
       }
     },
     {
@@ -39,7 +39,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "\\bDD[P+]|\\b(e[-_. ]?ac3)\\b"
+        "value": "\\bDD[P+]|\\b(e[-_. ]?ac-?3)\\b"
       }
     },
     {

--- a/docs/json/sonarr/cf/truehd.json
+++ b/docs/json/sonarr/cf/truehd.json
@@ -30,7 +30,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "\\bDD[P+]|\\b(e[-_. ]?ac3)\\b"
+        "value": "\\bDD[P+]|\\b(e[-_. ]?ac-?3)\\b"
       }
     },
     {
@@ -57,7 +57,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "\\bDD[^a-z+]|(?<!e)ac3"
+        "value": "\\bDD[^a-z+]|(?<!e-)\\b(ac-?3)\\b"
       }
     }
   ]


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->
Fix the `DD` CF not matching on `AC-3`. Fixes #1888 

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->
Adjust `DD`, `DD+` & `DD+ ATMOS` regex for all audio CFs.

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
