### PR TITLE
feat(starr): Remove LoliHouse from Anime LQ groups

### DIFF
--- a/docs/json/radarr/cf/anime-lq-groups.json
+++ b/docs/json/radarr/cf/anime-lq-groups.json
@@ -538,15 +538,6 @@
       }
     },
     {
-      "name": "LoliHouse",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "\\b(LoliHouse)\\b"
-      }
-    },
-    {
       "name": "M@nI",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,

--- a/docs/json/sonarr/cf/anime-lq-groups.json
+++ b/docs/json/sonarr/cf/anime-lq-groups.json
@@ -538,15 +538,6 @@
       }
     },
     {
-      "name": "LoliHouse",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "\\b(LoliHouse)\\b"
-      }
-    },
-    {
       "name": "M@nI",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,


### PR DESCRIPTION
# Pull Request

## Purpose
LoliHouse has a good reputation and the quality of WEBRip is also relatively high. Should not be classified into Anime LQ Groups.
<!-- Please provide a detailed description of why you created this pull request. -->

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [X] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [X] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
