### PR TITLE
chore(anime): Move Nandesuka to LQ

### DIFF
--- a/docs/json/radarr/cf/anime-web-tier-04-official-subs.json
+++ b/docs/json/radarr/cf/anime-web-tier-04-official-subs.json
@@ -97,15 +97,6 @@
       }
     },
     {
-      "name": "NanDesuKa",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "\\b(NanDesuKa)\\b"
-      }
-    },
-    {
       "name": "URANIME",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,

--- a/docs/json/sonarr/cf/anime-lq-groups.json
+++ b/docs/json/sonarr/cf/anime-lq-groups.json
@@ -673,6 +673,15 @@
       }
     },
     {
+      "name": "NanDesuKa",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(NanDesuKa)\\b"
+      }
+    },
+    {
       "name": "NemDiggers",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,

--- a/docs/json/sonarr/cf/anime-web-tier-04-official-subs.json
+++ b/docs/json/sonarr/cf/anime-web-tier-04-official-subs.json
@@ -106,15 +106,6 @@
       }
     },
     {
-      "name": "NanDesuKa",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "\\b(NanDesuKa)\\b"
-      }
-    },
-    {
       "name": "URANIME",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,


### PR DESCRIPTION
# Pull Request

## Purpose

I've regularly seen Nandesuka mislabel and episode numbers. Not positive if that should be cause for moving to LQ, but I find myself regularly blacklisting their releases.

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
