### PR TITLE
fix(guide): unclear qbit mover script host vs url and added cache only

### DIFF
--- a/docs/Downloaders/qBittorrent/Tips/How-to-run-the-unRaid-mover-for-qBittorrent.md
+++ b/docs/Downloaders/qBittorrent/Tips/How-to-run-the-unRaid-mover-for-qBittorrent.md
@@ -179,7 +179,7 @@ Choose your method (select a tab) and copy/paste the script in the new window th
         #!/bin/bash
         /usr/local/emhttp/plugins/dynamix/scripts/notify -s "qBittorrent Mover" -d "qBittorrent Mover starting @ `date +%H:%M:%S`."
         echo "executing script to pause torrents and run mover."
-        python3 /mnt/user/data/scripts/mover.py --host "ip:port" --user "your_user" --password "your_password" --days_from 0 --days_to 2
+        python3 /mnt/user/data/scripts/mover.py --host "ip:port" --user "your_user" --password "your_password" --cache-mount "/mnt/cache" --days_from 0 --days_to 2
         echo "qbittorrent-mover completed and resumed all paused torrents."
         /usr/local/emhttp/plugins/dynamix/scripts/notify -s "qBittorrent Mover" -d "qBittorrent Mover completed @ `date +%H:%M:%S`."
     ```
@@ -191,7 +191,7 @@ Choose your method (select a tab) and copy/paste the script in the new window th
 
         /usr/local/emhttp/plugins/dynamix/scripts/notify -s "qBittorrent Mover" -d "qBittorrent Mover starting @ `date +%H:%M:%S`."
         echo "executing script to pause torrents and run mover."
-        /mnt/user/data/scripts/.venv/bin/python3 /mnt/user/data/scripts/mover.py --host "ip:port" --user "your_user" --password "your_password" --days_from 0 --days_to 2
+        /mnt/user/data/scripts/.venv/bin/python3 /mnt/user/data/scripts/mover.py --host "ip:port" --user "your_user" --password "your_password" --cache-mount "/mnt/cache" --days_from 0 --days_to 2
         echo "qbittorrent-mover completed and resumed all paused torrents."
         /usr/local/emhttp/plugins/dynamix/scripts/notify -s "qBittorrent Mover" -d "qBittorrent Mover completed @ `date +%H:%M:%S`."
     ```
@@ -200,11 +200,12 @@ Choose your method (select a tab) and copy/paste the script in the new window th
 
     Replace `/mnt/user/data/scripts/` in the script with the path you have chosen for the Python script.
 
-- `days_from` => Set Number of Days to stop torrents **from** for the move.
-- `days_to` => Set Number of Days to stop torrents **to** for the move.
-- `host` => The URL you use to access qBittorrent locally.
-- `user` => Your used qBittorrent `User Name` if you have authentication enabled.
-- `password` => Your used qBittorrent `Password` if you have authentication enabled.
+- `--days_from` => Set Number of Days to stop torrents **from** for the move.
+- `--days_to` => Set Number of Days to stop torrents **to** for the move.
+- `--host` => Replace ip with your unraid server ip, replace port with your webgui port you use to access the webgui.
+- `--user` => Your used qBittorrent `User Name` if you have authentication enabled.
+- `--password` => Your used qBittorrent `Password` if you have authentication enabled.
+- `--cache-mount` => Cache mount point in Unraid. This is used to additionally filter for only torrents that exists on the cache mount. Use this option ONLY if you follow TRaSH Guides folder structure. (For default cache drive set this to `/mnt/cache`)
 
 <!--- ![!Bash script](images/Unraid-settings-user-scripts-qbit-mover.png)-->
 


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->

host => The URL you use to access qBittorrent locally. this says to use a URL which would be http://IP:PORT

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

- [x] replace ip with your unraid server ip, replace port with your webgui port you use to access the webgui
- [x] added switch to only pause torrents that are actually on your cache drive

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
