### PR TITLE
chore(guide): update inconsistent naming in downloaders pages

### DIFF
--- a/docs/Downloaders/NZBGet/Basic-Setup.md
+++ b/docs/Downloaders/NZBGet/Basic-Setup.md
@@ -1,6 +1,6 @@
 # NZBGet - Basic Setup
 
-!!! danger "NZBGet development has been officially abandoned by the developer :bangbang:"
+!!! note "NZBGet development has been picked up again by new developers over at [github](https://github.com/nzbgetcom/nzbget){:target="\_blank" rel="noopener noreferrer"}!"
 
 {! include-markdown "../../../includes/downloaders/basic-setup.md" !}
 

--- a/docs/Downloaders/NZBGet/Paths-and-Categories.md
+++ b/docs/Downloaders/NZBGet/Paths-and-Categories.md
@@ -1,6 +1,6 @@
 # NZBGet - Paths and Categories
 
-!!! danger "NZBGet development has been officially abandoned by the developer :bangbang:"
+!!! note "NZBGet development has been picked up again by new developers over at [github](https://github.com/nzbgetcom/nzbget){:target="\_blank" rel="noopener noreferrer"}!"
 
 {! include-markdown "../../../includes/downloaders/path.md" !}
 

--- a/docs/Downloaders/NZBGet/index.md
+++ b/docs/Downloaders/NZBGet/index.md
@@ -1,5 +1,5 @@
 # NZBGet
 
-!!! danger "NZBGet development has been officially abandoned by the developer :bangbang:"
+!!! note "NZBGet development has been picked up again by new developers over at [github](https://github.com/nzbgetcom/nzbget){:target="\_blank" rel="noopener noreferrer"}!"
 
 ![version](https://img.shields.io/badge/dynamic/json?query=%24.version&url=https%3A%2F%2Fraw.githubusercontent.com%2Fhotio%2Fnzbget%2Frelease%2FVERSION.json&label=Latest%20Version&style=for-the-badge&color=4051B5){ .off-glb }

--- a/docs/Downloaders/NZBGet/scripts/index.md
+++ b/docs/Downloaders/NZBGet/scripts/index.md
@@ -1,6 +1,6 @@
-# NzbGet Scripts
+# NZBGet Scripts
 
-!!! danger "NZBGet development has been officially abandoned by the developer :bangbang:"
+!!! note "NZBGet development has been picked up again by new developers over at [github](https://github.com/nzbgetcom/nzbget){:target="\_blank" rel="noopener noreferrer"}!"
 
 ## Clean
 

--- a/docs/Downloaders/SABnzbd/Basic-Setup.md
+++ b/docs/Downloaders/SABnzbd/Basic-Setup.md
@@ -12,7 +12,7 @@
 
 ## General
 
-[Sabnzbd Documentation](https://sabnzbd.org/wiki/configuration/4.3/general){:target="\_blank" rel="noopener noreferrer"}
+[SABnzbd Documentation](https://sabnzbd.org/wiki/configuration/4.3/general){:target="\_blank" rel="noopener noreferrer"}
 
 ### Tuning
 
@@ -25,7 +25,7 @@ I recommend setting a sane maximum speed and then limiting below that, to keep y
 
 ## Folders
 
-[Sabnzbd Documentation](https://sabnzbd.org/wiki/configuration/4.3/folders){:target="\_blank" rel="noopener noreferrer"}
+[SABnzbd Documentation](https://sabnzbd.org/wiki/configuration/4.3/folders){:target="\_blank" rel="noopener noreferrer"}
 
 ### User Folders
 
@@ -50,7 +50,7 @@ The default is empty, I picked history because it is easy. It'll end up in the `
 
 ## Servers
 
-[Sabnzbd Documentation](https://sabnzbd.org/wiki/configuration/4.3/servers){:target="\_blank" rel="noopener noreferrer"}
+[SABnzbd Documentation](https://sabnzbd.org/wiki/configuration/4.3/servers){:target="\_blank" rel="noopener noreferrer"}
 
 `Settings` => `Servers` => `Add Server`
 ![!Servers](images/sabnzbd-servers.png)
@@ -73,7 +73,7 @@ The default is empty, I picked history because it is easy. It'll end up in the `
 
 ## Categories
 
-[Sabnzbd Documentation](https://sabnzbd.org/wiki/configuration/4.3/categories){:target="\_blank" rel="noopener noreferrer"}
+[SABnzbd Documentation](https://sabnzbd.org/wiki/configuration/4.3/categories){:target="\_blank" rel="noopener noreferrer"}
 
 `Settings`=> `Categories`
 
@@ -83,7 +83,7 @@ Covered and fully explained in [SABnzbd - Paths and Categories](/Downloaders/SAB
 
 ## Switches
 
-[Sabnzbd Documentation](https://sabnzbd.org/wiki/configuration/4.3/switches){:target="\_blank" rel="noopener noreferrer"}
+[SABnzbd Documentation](https://sabnzbd.org/wiki/configuration/4.3/switches){:target="\_blank" rel="noopener noreferrer"}
 
 ### Queue
 
@@ -160,7 +160,7 @@ Being that Sonarr/Radarr only looks at the last xx amount in the queue/history.
 
     Make sure you check both boxes under `Completed Download Handling` at step 3.
 
-    Select Sabnzbd at step 4 and scroll down to the bottom of the new window where it says `Completed Download Handling` and check both boxes.
+    Select SABnzbd at step 4 and scroll down to the bottom of the new window where it says `Completed Download Handling` and check both boxes.
 
     ![!Sonarr: Download Clients - SABnzbd](images/sonarr-download-clients-sabnzbd.png)
 
@@ -176,7 +176,7 @@ Being that Sonarr/Radarr only looks at the last xx amount in the queue/history.
 
     and both boxes under `Failed Download Handling` at step 4.
 
-    Select Sabnzbd at step 5 and scroll down to the bottom of the new window where it says `Completed Download Handling` and check both boxes.
+    Select SABnzbd at step 5 and scroll down to the bottom of the new window where it says `Completed Download Handling` and check both boxes.
 
     ![!Radarr: Download Clients - SABnzbd](images/radarr-download-clients-sabnzbd.png)
 

--- a/docs/Downloaders/SABnzbd/scripts/Clean/Clean.py
+++ b/docs/Downloaders/SABnzbd/scripts/Clean/Clean.py
@@ -11,7 +11,7 @@
 ## NOTE: This script requires Python 3                          ##
 ##                                                              ##
 ## Install:                                                     ##
-## 1. Copy script to sabnzbd's script folder                    ##
+## 1. Copy script to SABnzbd's script folder                    ##
 ## 2. run: sudo chmod +x Clean.py                               ##
 ## 3. in SABnzbd go to Config > Switches                        ##
 ## 4. Change Pre-queue user script and select: Clean.py         ##

--- a/docs/Downloaders/SABnzbd/scripts/index.md
+++ b/docs/Downloaders/SABnzbd/scripts/index.md
@@ -14,7 +14,7 @@
 
     Install Instructions:
 
-        1. Copy script to sabnzbd's script folder
+        1. Copy script to SABnzbd's script folder
         1. run: `sudo chmod +x Clean.py`
         1. in SABnzbd go to `Settings` => `Switches`
         1. Change Pre-queue user script and select: `Clean.py`
@@ -38,7 +38,7 @@
 
     Install Instructions:
 
-        1. Copy script to sabnzbd's script folder
+        1. Copy script to SABnzbd's script folder
         1. run: `sudo chmod +x replace_for.py`
         1. in SABnzbd go to `Settings` => `Categories`
         1. Change script for required categories and select: `replace_for.py`

--- a/docs/Downloaders/SABnzbd/scripts/replace_for/replace_for.py
+++ b/docs/Downloaders/SABnzbd/scripts/replace_for/replace_for.py
@@ -9,7 +9,7 @@
 ## Author: miker                                                ##
 ##                                                              ##
 ## Install:                                                     ##
-## 1. Copy script to sabnzbd's script folder                    ##
+## 1. Copy script to SABnzbd's script folder                    ##
 ## 2. run: sudo chmod +x replace_for.py                         ##
 ## 3. in SABnzbd go to Config > Categories                      ##
 ## 4. Assign replace_for.py to the required category            ##

--- a/docs/Downloaders/index.md
+++ b/docs/Downloaders/index.md
@@ -6,7 +6,7 @@ Here you will find Guides for several Download Clients.
 
 [NZBGet](/Downloaders/NZBGet/)
 
-!!! danger "NZBGet development has been officially abandoned by the developer :bangbang:"
+!!! note "NZBGet development has been picked up again by new developers over at [github](https://github.com/nzbgetcom/nzbget){:target="\_blank" rel="noopener noreferrer"}!"
 
 ![version](https://img.shields.io/badge/dynamic/json?query=%24.version&url=https%3A%2F%2Fraw.githubusercontent.com%2Fhotio%2Fnzbget%2Frelease%2FVERSION.json&label=Latest%20Version&style=for-the-badge&color=4051B5){ .off-glb }
 


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->
Fix inconsistencies in the `Downloaders` pages.

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->
Fix capitalization for the downloaders pages in several cases and remove the deprecation warning for NZBGet.

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
