### PR TITLE
fix(sonarr): add DSCV to Discovery+ CF matching

### DIFF
--- a/docs/json/sonarr/cf/dscp.json
+++ b/docs/json/sonarr/cf/dscp.json
@@ -3,6 +3,7 @@
   "trash_scores": {
     "default": 50
   },
+  "trash_regex": "https://regex101.com/r/i0x6OX/latest",
   "name": "DSCP",
   "includeCustomFormatWhenRenaming": true,
   "specifications": [
@@ -12,7 +13,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\b(dscp|dcp|disc)\\b[ ._-]web[ ._-]?(dl|rip)?\\b"
+        "value": "\\b((dscp|dcp|disc)\\b|dscv\\+?)[ ._-]web[ ._-]?(dl|rip)?\\b"
       }
     },
     {


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->
Match DSCV as `Discovery+`.

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->
Adjust `Discovery+` CF regex to also match `DSCV` and `DSCV+`.

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
