### PR TITLE
feat(Radarr): Add Custom Format for iTunes streaming services

### DIFF
--- a/docs/Radarr/Radarr-collection-of-custom-formats.md
+++ b/docs/Radarr/Radarr-collection-of-custom-formats.md
@@ -76,6 +76,7 @@ We've made 3 guides related to this.
 | [HBO](#hbo)                | [VIU](#viu)              |                          |
 | [HBO Max](#hmax)           |                          |                          |
 | [Hulu](#hulu)              |                          |                          |
+| [iTunes](#it)              |                          |                          |
 | [Max](#max)                |                          |                          |
 | [Movies Anywhere](#ma)     |                          |                          |
 | [Netflix](#nf)             |                          |                          |
@@ -1902,6 +1903,24 @@ We've made 3 guides related to this.
 
     ```json
     [[% filter indent(width=4) %]][[% include 'json/radarr/cf/hulu.json' %]][[% endfilter %]]
+    ```
+
+<sub><sup>[TOP](#index)</sup></sub>
+
+---
+
+#### IT
+
+<sub>iT = iTunes</sub>
+
+??? question "iTunes - [Click to show/hide]"
+
+    {! include-markdown "../../includes/cf-descriptions/it.md" !}
+
+??? example "JSON - [Click to show/hide]"
+
+    ```json
+    [[% filter indent(width=4) %]][[% include 'json/radarr/cf/it.json' %]][[% endfilter %]]
     ```
 
 <sub><sup>[TOP](#index)</sup></sub>

--- a/docs/json/radarr/cf/it.json
+++ b/docs/json/radarr/cf/it.json
@@ -1,0 +1,34 @@
+{
+  "trash_id": "e0ec9672be6cac914ffad34a6b077209",
+  "name": "iT",
+  "includeCustomFormatWhenRenaming": true,
+  "specifications": [
+    {
+      "name": "iTunes",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": true,
+      "fields": {
+        "value": "\\b(it|itunes)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)"
+      }
+    },
+    {
+      "name": "WEBDL",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 7
+      }
+    },
+    {
+      "name": "WEBRIP",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 8
+      }
+    }
+  ]
+}

--- a/docs/json/radarr/quality-profiles/hd-bluray-web.json
+++ b/docs/json/radarr/quality-profiles/hd-bluray-web.json
@@ -80,6 +80,7 @@
     "HBO": "509e5f41146e278f9eab1ddaceb34515",
     "HMAX": "5763d1b0ce84aff3b21038eea8e9b8ad",
     "Hulu": "526d445d4c16214309f0fd2b3be18a89",
+    "iT": "e0ec9672be6cac914ffad34a6b077209",
     "MA": "2a6039655313bf5dab1e43523b62c374",
     "MAX": "6a061313d22e51e0f25b7cd4dc065233",
     "NF": "170b1d363bd8516fbf3a3eb05d4faff6",

--- a/docs/json/radarr/quality-profiles/remux-web-1080p.json
+++ b/docs/json/radarr/quality-profiles/remux-web-1080p.json
@@ -81,6 +81,7 @@
     "HBO": "509e5f41146e278f9eab1ddaceb34515",
     "HMAX": "5763d1b0ce84aff3b21038eea8e9b8ad",
     "Hulu": "526d445d4c16214309f0fd2b3be18a89",
+    "iT": "e0ec9672be6cac914ffad34a6b077209",
     "MA": "2a6039655313bf5dab1e43523b62c374",
     "MAX": "6a061313d22e51e0f25b7cd4dc065233",
     "NF": "170b1d363bd8516fbf3a3eb05d4faff6",

--- a/docs/json/radarr/quality-profiles/remux-web-2160p.json
+++ b/docs/json/radarr/quality-profiles/remux-web-2160p.json
@@ -93,6 +93,7 @@
     "HBO": "509e5f41146e278f9eab1ddaceb34515",
     "HMAX": "5763d1b0ce84aff3b21038eea8e9b8ad",
     "Hulu": "526d445d4c16214309f0fd2b3be18a89",
+    "iT": "e0ec9672be6cac914ffad34a6b077209",
     "MA": "2a6039655313bf5dab1e43523b62c374",
     "MAX": "6a061313d22e51e0f25b7cd4dc065233",
     "NF": "170b1d363bd8516fbf3a3eb05d4faff6",

--- a/docs/json/radarr/quality-profiles/sqp-1-1080p.json
+++ b/docs/json/radarr/quality-profiles/sqp-1-1080p.json
@@ -97,6 +97,7 @@
     "HBO": "509e5f41146e278f9eab1ddaceb34515",
     "HMAX": "5763d1b0ce84aff3b21038eea8e9b8ad",
     "Hulu": "526d445d4c16214309f0fd2b3be18a89",
+    "iT": "e0ec9672be6cac914ffad34a6b077209",
     "MA": "2a6039655313bf5dab1e43523b62c374",
     "MAX": "6a061313d22e51e0f25b7cd4dc065233",
     "NF": "170b1d363bd8516fbf3a3eb05d4faff6",

--- a/docs/json/radarr/quality-profiles/sqp-1-2160p.json
+++ b/docs/json/radarr/quality-profiles/sqp-1-2160p.json
@@ -113,6 +113,7 @@
     "HBO": "509e5f41146e278f9eab1ddaceb34515",
     "HMAX": "5763d1b0ce84aff3b21038eea8e9b8ad",
     "Hulu": "526d445d4c16214309f0fd2b3be18a89",
+    "iT": "e0ec9672be6cac914ffad34a6b077209",
     "MA": "2a6039655313bf5dab1e43523b62c374",
     "MAX": "6a061313d22e51e0f25b7cd4dc065233",
     "NF": "170b1d363bd8516fbf3a3eb05d4faff6",

--- a/docs/json/radarr/quality-profiles/sqp-2.json
+++ b/docs/json/radarr/quality-profiles/sqp-2.json
@@ -99,6 +99,7 @@
     "HBO": "509e5f41146e278f9eab1ddaceb34515",
     "HMAX": "5763d1b0ce84aff3b21038eea8e9b8ad",
     "Hulu": "526d445d4c16214309f0fd2b3be18a89",
+    "iT": "e0ec9672be6cac914ffad34a6b077209",
     "MA": "2a6039655313bf5dab1e43523b62c374",
     "MAX": "6a061313d22e51e0f25b7cd4dc065233",
     "NF": "170b1d363bd8516fbf3a3eb05d4faff6",

--- a/docs/json/radarr/quality-profiles/sqp-3.json
+++ b/docs/json/radarr/quality-profiles/sqp-3.json
@@ -96,6 +96,7 @@
     "HBO": "509e5f41146e278f9eab1ddaceb34515",
     "HMAX": "5763d1b0ce84aff3b21038eea8e9b8ad",
     "Hulu": "526d445d4c16214309f0fd2b3be18a89",
+    "iT": "e0ec9672be6cac914ffad34a6b077209",
     "MA": "2a6039655313bf5dab1e43523b62c374",
     "MAX": "6a061313d22e51e0f25b7cd4dc065233",
     "NF": "170b1d363bd8516fbf3a3eb05d4faff6",

--- a/docs/json/radarr/quality-profiles/sqp-4.json
+++ b/docs/json/radarr/quality-profiles/sqp-4.json
@@ -91,6 +91,7 @@
     "HBO": "509e5f41146e278f9eab1ddaceb34515",
     "HMAX": "5763d1b0ce84aff3b21038eea8e9b8ad",
     "Hulu": "526d445d4c16214309f0fd2b3be18a89",
+    "iT": "e0ec9672be6cac914ffad34a6b077209",
     "MA": "2a6039655313bf5dab1e43523b62c374",
     "MAX": "6a061313d22e51e0f25b7cd4dc065233",
     "NF": "170b1d363bd8516fbf3a3eb05d4faff6",

--- a/docs/json/radarr/quality-profiles/sqp-5.json
+++ b/docs/json/radarr/quality-profiles/sqp-5.json
@@ -99,6 +99,7 @@
     "HBO": "509e5f41146e278f9eab1ddaceb34515",
     "HMAX": "5763d1b0ce84aff3b21038eea8e9b8ad",
     "Hulu": "526d445d4c16214309f0fd2b3be18a89",
+    "iT": "e0ec9672be6cac914ffad34a6b077209",
     "MA": "2a6039655313bf5dab1e43523b62c374",
     "MAX": "6a061313d22e51e0f25b7cd4dc065233",
     "NF": "170b1d363bd8516fbf3a3eb05d4faff6",

--- a/docs/json/radarr/quality-profiles/uhd-bluray-web.json
+++ b/docs/json/radarr/quality-profiles/uhd-bluray-web.json
@@ -92,6 +92,7 @@
     "HBO": "509e5f41146e278f9eab1ddaceb34515",
     "HMAX": "5763d1b0ce84aff3b21038eea8e9b8ad",
     "Hulu": "526d445d4c16214309f0fd2b3be18a89",
+    "iT": "e0ec9672be6cac914ffad34a6b077209",
     "MA": "2a6039655313bf5dab1e43523b62c374",
     "MAX": "6a061313d22e51e0f25b7cd4dc065233",
     "NF": "170b1d363bd8516fbf3a3eb05d4faff6",

--- a/includes/cf/radarr-streaming-services.md
+++ b/includes/cf/radarr-streaming-services.md
@@ -1,21 +1,22 @@
 ??? abstract "General Streaming Services - [Click to show/hide]"
 
-    | Custom Format                                                                               |                         Score                          | Trash ID                                 |
-    | ------------------------------------------------------------------------------------------- | :----------------------------------------------------: | ---------------------------------------- |
-    | [{{ radarr['cf']['amzn']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#amzn)     |                           0                            | {{ radarr['cf']['amzn']['trash_id'] }}   |
-    | [{{ radarr['cf']['atvp']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#atvp)     |                           0                            | {{ radarr['cf']['atvp']['trash_id'] }}   |
-    | [{{ radarr['cf']['bcore']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#bcore)   | {{ radarr['cf']['bcore']['trash_scores']['default'] }} | {{ radarr['cf']['bcore']['trash_id'] }}  |
-    | [{{ radarr['cf']['crit']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#crit)     | {{ radarr['cf']['crit']['trash_scores']['default'] }}  | {{ radarr['cf']['crit']['trash_id'] }}   |
-    | [{{ radarr['cf']['dsnp']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#dsnp)     |                           0                            | {{ radarr['cf']['dsnp']['trash_id'] }}   |
-    | [{{ radarr['cf']['hbo']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#hbo)       |                           0                            | {{ radarr['cf']['hbo']['trash_id'] }}    |
-    | [{{ radarr['cf']['hmax']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#hmax)     |                           0                            | {{ radarr['cf']['hmax']['trash_id'] }}   |
-    | [{{ radarr['cf']['hulu']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#hulu)     |                           0                            | {{ radarr['cf']['hulu']['trash_id'] }}   |
-    | [{{ radarr['cf']['max']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#max)       |                           0                            | {{ radarr['cf']['max']['trash_id'] }}    |
-    | [{{ radarr['cf']['ma']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#ma)         |  {{ radarr['cf']['ma']['trash_scores']['default'] }}   | {{ radarr['cf']['ma']['trash_id'] }}     |
-    | [{{ radarr['cf']['nf']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#nf)         |                           0                            | {{ radarr['cf']['nf']['trash_id'] }}     |
-    | [{{ radarr['cf']['pmtp']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#pmtp)     |                           0                            | {{ radarr['cf']['pmtp']['trash_id'] }}   |
-    | [{{ radarr['cf']['pcok']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#pcok)     |                           0                            | {{ radarr['cf']['pcok']['trash_id'] }}   |
-    | [{{ radarr['cf']['stan']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#stan)     |                           0                            | {{ radarr['cf']['stan']['trash_id'] }}   |
+    | Custom Format                                                                             |                         Score                          | Trash ID                                |
+    | ----------------------------------------------------------------------------------------- | :----------------------------------------------------: | --------------------------------------- |
+    | [{{ radarr['cf']['amzn']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#amzn)   |                           0                            | {{ radarr['cf']['amzn']['trash_id'] }}  |
+    | [{{ radarr['cf']['atvp']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#atvp)   |                           0                            | {{ radarr['cf']['atvp']['trash_id'] }}  |
+    | [{{ radarr['cf']['bcore']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#bcore) | {{ radarr['cf']['bcore']['trash_scores']['default'] }} | {{ radarr['cf']['bcore']['trash_id'] }} |
+    | [{{ radarr['cf']['crit']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#crit)   | {{ radarr['cf']['crit']['trash_scores']['default'] }}  | {{ radarr['cf']['crit']['trash_id'] }}  |
+    | [{{ radarr['cf']['dsnp']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#dsnp)   |                           0                            | {{ radarr['cf']['dsnp']['trash_id'] }}  |
+    | [{{ radarr['cf']['hbo']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#hbo)     |                           0                            | {{ radarr['cf']['hbo']['trash_id'] }}   |
+    | [{{ radarr['cf']['hmax']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#hmax)   |                           0                            | {{ radarr['cf']['hmax']['trash_id'] }}  |
+    | [{{ radarr['cf']['hulu']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#hulu)   |                           0                            | {{ radarr['cf']['hulu']['trash_id'] }}  |
+    | [{{ radarr['cf']['it']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#it)       |                           0                            | {{ radarr['cf']['it']['trash_id'] }}    |
+    | [{{ radarr['cf']['max']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#max)     |                           0                            | {{ radarr['cf']['max']['trash_id'] }}   |
+    | [{{ radarr['cf']['ma']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#ma)       |  {{ radarr['cf']['ma']['trash_scores']['default'] }}   | {{ radarr['cf']['ma']['trash_id'] }}    |
+    | [{{ radarr['cf']['nf']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#nf)       |                           0                            | {{ radarr['cf']['nf']['trash_id'] }}    |
+    | [{{ radarr['cf']['pmtp']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#pmtp)   |                           0                            | {{ radarr['cf']['pmtp']['trash_id'] }}  |
+    | [{{ radarr['cf']['pcok']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#pcok)   |                           0                            | {{ radarr['cf']['pcok']['trash_id'] }}  |
+    | [{{ radarr['cf']['stan']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#stan)   |                           0                            | {{ radarr['cf']['stan']['trash_id'] }}  |
 
     ---
 

--- a/includes/sqp/1-4k-streaming-services.md
+++ b/includes/sqp/1-4k-streaming-services.md
@@ -10,6 +10,7 @@
     | [{{ radarr['cf']['hbo']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#hbo)     |                                       0                                        | {{ radarr['cf']['hbo']['trash_id'] }}   |
     | [{{ radarr['cf']['hmax']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#hmax)   |                                       0                                        | {{ radarr['cf']['hmax']['trash_id'] }}  |
     | [{{ radarr['cf']['hulu']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#hulu)   |                                       0                                        | {{ radarr['cf']['hulu']['trash_id'] }}  |
+    | [{{ radarr['cf']['it']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#it)       |                                       0                                        | {{ radarr['cf']['it']['trash_id'] }}    |
     | [{{ radarr['cf']['max']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#max)     |                                       0                                        | {{ radarr['cf']['max']['trash_id'] }}   |
     | [{{ radarr['cf']['ma']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#ma)       |              {{ radarr['cf']['ma']['trash_scores']['default'] }}               | {{ radarr['cf']['ma']['trash_id'] }}    |
     | [{{ radarr['cf']['nf']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#nf)       |                                       0                                        | {{ radarr['cf']['nf']['trash_id'] }}    |

--- a/includes/sqp/1-streaming-services.md
+++ b/includes/sqp/1-streaming-services.md
@@ -10,6 +10,7 @@
     | [{{ radarr['cf']['hbo']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#hbo)     |                                       0                                        | {{ radarr['cf']['hbo']['trash_id'] }}   |
     | [{{ radarr['cf']['hmax']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#hmax)   |                                       0                                        | {{ radarr['cf']['hmax']['trash_id'] }}  |
     | [{{ radarr['cf']['hulu']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#hulu)   |                                       0                                        | {{ radarr['cf']['hulu']['trash_id'] }}  |
+    | [{{ radarr['cf']['it']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#it)       |                                       0                                        | {{ radarr['cf']['it']['trash_id'] }}    |
     | [{{ radarr['cf']['max']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#max)     |                                       0                                        | {{ radarr['cf']['max']['trash_id'] }}   |
     | [{{ radarr['cf']['ma']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#ma)       |              {{ radarr['cf']['ma']['trash_scores']['default'] }}               | {{ radarr['cf']['ma']['trash_id'] }}    |
     | [{{ radarr['cf']['nf']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#nf)       |                                       0                                        | {{ radarr['cf']['nf']['trash_id'] }}    |


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->

Add Custom Format for iTunes streaming services

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

Created NEW Custom Format for iTunes streaming services

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

- [x] Tested locacally
- [x] Created iT JSON for CF
- [x] Added MD5 Hash
- [x] Added to Collection of Custom Formats - General Streaming Services Table
- [x] Updated public guides that use General Streaming Services 
- [x] Updated both SQP-1 that use General Streaming Services because they use a custom scoring. 

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
