### PR TITLE
feat(Radarr): Add RlsGrp `W4NK3R` to `HD Bluray Tier 03`

### DIFF
--- a/docs/json/radarr/cf/hd-bluray-tier-03.json
+++ b/docs/json/radarr/cf/hd-bluray-tier-03.json
@@ -79,6 +79,15 @@
       "fields": {
         "value": "^(SPHD)$"
       }
+    },
+    {
+      "name": "W4NK3R",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(W4NK3R)$"
+      }
     }
   ]
 }


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->

Add RlsGrp `W4NK3R` to `HD Bluray Tier 03`

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

Added RlsGrp `W4NK3R` to `HD Bluray Tier 03`

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

- [x] Tested locally
- [x] Sorted Json A-Z
- [x] Imported the JSON in locall Radarr to test for import errors 

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
