### PR TITLE
feat(guides): Improve bottom Question & Suggestion banner

### DIFF
--- a/includes/support.md
+++ b/includes/support.md
@@ -2,6 +2,8 @@
 
 !!! question "Questions or Suggestions?"
 
-    If you have questions or suggestions click the chat badge to join the Discord Support Channel where you can ask your questions directly and get live support.
+    <center>If you have questions or suggestions, click the button below to join our Discord server.</center>
 
-    [![Discord chat](https://img.shields.io/discord/492590071455940612?style=for-the-badge&color=4051B5&logo=discord){ .off-glb }](https://trash-guides.info/discord){:target="_blank" rel="noopener noreferrer"}
+    <center>[ Click For Support ](https://trash-guides.info/discord){ .md-button .md-button--primary }</center>
+
+    <center>[![Discord](https://img.shields.io/discord/492590071455940612?style=for-the-badge&color=4051B5&logo=discord){ .off-glb }](https://trash-guides.info/discord){:target="_blank" rel="noopener noreferrer"}</center>


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->

Seems that some people don't see the bottom Question & Suggestion banner that they should join the discord channel for help etc

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

Created a huge CLICK HERE button (both buttons are clickable)

[Dark Mode]
![image](https://github.com/TRaSH-Guides/Guides/assets/6155095/4b509230-4391-4a7b-bfe7-b26b9d89dbcc)
[Light Mode]
![image](https://github.com/TRaSH-Guides/Guides/assets/6155095/63314418-8a68-4521-a1e8-caae4e69e939)


## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
