### PR TITLE
fix(radarr): Update x265.json with (?i) to let the entire regular expression case-insensitive

### DIFF
--- a/docs/json/radarr/cf/x265.json
+++ b/docs/json/radarr/cf/x265.json
@@ -9,7 +9,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "[xh][ ._-]?265|\\bHEVC(\\b|\\d)"
+        "value": "(?i)[xh][ ._-]?265|\\bHEVC(\\b|\\d)"
       }
     },
     {


### PR DESCRIPTION
sometimes I see H 265 or X 265 so I added this modifier to let the entire regular expression case-insensitive. [xh]: Matches "x" or "h" in either lowercase or uppercase due to the (?i) modifier. it will also match "HEVC" in any combination of upper and lower case letters (e.g., "HEVC", "hevc", "Hevc", "hEVC", etc.).
