### PR TITLE
feat(guides): Move AV1 to unwanted

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ site/
 /docs/Notifiarr/preview.bat
 /docs/Notifiarr/Integrations/_TEMPLATE.md
 /includes/flowcharts/.$radarr-flowchart.drawio.bkp
+.DS_Store

--- a/docs/Radarr/Radarr-collection-of-custom-formats.md
+++ b/docs/Radarr/Radarr-collection-of-custom-formats.md
@@ -899,10 +899,7 @@ We've made 3 guides related to this.
 
 ??? question "AV1 - [Click to show/hide]"
 
-    - This is a new codec and you need modern devices that support it.
-    - We also had reports of playback/transcoding issues.
-    - No main group is actually using it (yet).
-    - It's better to ignore this new codec to prevent compatibility issues.
+    {! include-markdown "../../includes/cf-descriptions/av1.md" !}
 
 ??? example "JSON - [Click to show/hide]"
 

--- a/docs/Radarr/Radarr-collection-of-custom-formats.md
+++ b/docs/Radarr/Radarr-collection-of-custom-formats.md
@@ -52,13 +52,13 @@ We've made 3 guides related to this.
 | Movie Versions                                | Unwanted                                | HQ Release Groups                         |
 | --------------------------------------------- | --------------------------------------- | ----------------------------------------- |
 | [4K Remaster](#4k-remaster)                   | [3D](#3d)                               | [Remux Tier 01](#remux-tier-01)           |
-| [Criterion Collection](#criterion-collection) | [BR-DISK](#br-disk)                     | [Remux Tier 02](#remux-tier-02)           |
-| [Hybrid](#hybrid)                             | [Extras](#extras)                       | [Remux Tier 03](#remux-tier-03)           |
-| [IMAX Enhanced](#imax-enhanced)               | [LQ](#lq)                               | [UHD Bluray Tier 01](#uhd-bluray-tier-01) |
-| [IMAX](#imax)                                 | [LQ (Release Title)](#lq-release-title) | [UHD Bluray Tier 02](#uhd-bluray-tier-02) |
-| [Masters of Cinema](#masters-of-cinema)       | [Upscaled](#upscaled)                   | [UHD Bluray Tier 03](#uhd-bluray-tier-03) |
-| [Open Matte](#open-matte)                     | [x265 (HD)](#x265-hd)                   | [HD Bluray Tier 01](#hd-bluray-tier-01)   |
-| [Remaster](#remaster)                         |                                         | [HD Bluray Tier 02](#hd-bluray-tier-02)   |
+| [Criterion Collection](#criterion-collection) | [AV1](#av1)                             | [Remux Tier 02](#remux-tier-02)           |
+| [Hybrid](#hybrid)                             | [BR-DISK](#br-disk)                     | [Remux Tier 03](#remux-tier-03)           |
+| [IMAX Enhanced](#imax-enhanced)               | [Extras](#extras)                       | [UHD Bluray Tier 01](#uhd-bluray-tier-01) |
+| [IMAX](#imax)                                 | [LQ](#lq)                               | [UHD Bluray Tier 02](#uhd-bluray-tier-02) |
+| [Masters of Cinema](#masters-of-cinema)       | [LQ (Release Title)](#lq-release-title) | [UHD Bluray Tier 03](#uhd-bluray-tier-03) |
+| [Open Matte](#open-matte)                     | [Upscaled](#upscaled)                   | [HD Bluray Tier 01](#hd-bluray-tier-01)   |
+| [Remaster](#remaster)                         | [x265 (HD)](#x265-hd)                   | [HD Bluray Tier 02](#hd-bluray-tier-02)   |
 | [Special Edition](#special-edition)           |                                         | [HD Bluray Tier 03](#hd-bluray-tier-03)   |
 | [Theatrical Cut](#theatrical-cut)             |                                         | [WEB Tier 01](#web-tier-01)               |
 | [Vinegar Syndrome](#vinegar-syndrome)         |                                         | [WEB Tier 02](#web-tier-02)               |
@@ -94,24 +94,24 @@ We've made 3 guides related to this.
 
 | Misc                           | Optional                               | French Audio Version          | French Source Groups                            |
 | ------------------------------ | -------------------------------------- | ----------------------------- | ----------------------------------------------- |
-| [Dutch Groups](#dutch-groups)  | [AV1](#av1)                            | [Multi-French](#multi-french) | [FR Remux Tier 01](#fr-remux-tier-01)           |
-| [FreeLeech](#freeleech)        | [Bad Dual Groups](#bad-dual-groups)    | [Multi-Audio](#multi-audio)   | [FR Remux Tier 02](#fr-remux-tier-02)           |
-| [MPEG2](#mpeg2)                | [DV (Disk)](#dv-disk)                  | [French Audio](#french-audio) | [FR UHD Bluray Tier 01](#fr-uhd-bluray-tier-01) |
-| [Multi](#multi)                | [DV (WEBDL)](#dv-webdl)                | [VFF](#vff)                   | [FR UHD Bluray Tier 02](#fr-uhd-bluray-tier-02) |
-| [Repack/Proper](#repackproper) | [DV HDR10+ Boost](#dv-hdr10plus-boost) | [VOF](#vof)                   | [FR HD Bluray Tier 01](#fr-hd-bluray-tier-01)   |
-| [Repack2](#repack2)            | [EVO (no WEBDL)](#evo-no-webdl)        | [VFI](#vfi)                   | [FR HD Bluray Tier 02](#fr-hd-bluray-tier-02)   |
-| [Repack3](#repack3)            | [HDR10+ Boost](#hdr10plus-boost)       | [VF2](#vf2)                   | [FR WEB Tier 01](#fr-web-tier-01)               |
-| [x264](#x264)                  | [HFR](#hfr)                            | [VFQ](#vfq)                   | [FR WEB Tier 02](#fr-web-tier-02)               |
-| [x265](#x265)                  | [Internal](#internal)                  | [VOQ](#voq)                   | [FR Scene Groups](#fr-scene-groups)             |
-| [x266](#x266)                  | [Line/Mic Dubbed](#linemic-dubbed)     | [VQ](#vq)                     | [FR LQ](#fr-lq)                                 |
-|                                | [No-RlsGroup](#no-rlsgroup)            | [VFB](#vfb)                   |                                                 |
-|                                | [Obfuscated](#obfuscated)              | [VOSTFR](#vostfr)             |                                                 |
-|                                | [Retags](#retags)                      | [FanSUB](#fansub)             |                                                 |
-|                                | [Scene](#scene)                        | [FastSUB](#fastsub)           |                                                 |
-|                                | [SDR (no WEBDL)](#sdr-no-webdl)        |                               |                                                 |
+| [Dutch Groups](#dutch-groups)  | [Bad Dual Groups](#bad-dual-groups)    | [Multi-French](#multi-french) | [FR Remux Tier 01](#fr-remux-tier-01)           |
+| [FreeLeech](#freeleech)        | [DV (Disk)](#dv-disk)                  | [Multi-Audio](#multi-audio)   | [FR Remux Tier 02](#fr-remux-tier-02)           |
+| [MPEG2](#mpeg2)                | [DV (WEBDL)](#dv-webdl)                | [French Audio](#french-audio) | [FR UHD Bluray Tier 01](#fr-uhd-bluray-tier-01) |
+| [Multi](#multi)                | [DV HDR10+ Boost](#dv-hdr10plus-boost) | [VFF](#vff)                   | [FR UHD Bluray Tier 02](#fr-uhd-bluray-tier-02) |
+| [Repack/Proper](#repackproper) | [EVO (no WEBDL)](#evo-no-webdl)        | [VOF](#vof)                   | [FR HD Bluray Tier 01](#fr-hd-bluray-tier-01)   |
+| [Repack2](#repack2)            | [HDR10+ Boost](#hdr10plus-boost)       | [VFI](#vfi)                   | [FR HD Bluray Tier 02](#fr-hd-bluray-tier-02)   |
+| [Repack3](#repack3)            | [HFR](#hfr)                            | [VF2](#vf2)                   | [FR WEB Tier 01](#fr-web-tier-01)               |
+| [x264](#x264)                  | [Internal](#internal)                  | [VFQ](#vfq)                   | [FR WEB Tier 02](#fr-web-tier-02)               |
+| [x265](#x265)                  | [Line/Mic Dubbed](#linemic-dubbed)     | [VOQ](#voq)                   | [FR Scene Groups](#fr-scene-groups)             |
+| [x266](#x266)                  | [No-RlsGroup](#no-rlsgroup)            | [VQ](#vq)                     | [FR LQ](#fr-lq)                                 |
+|                                | [Obfuscated](#obfuscated)              | [VFB](#vfb)                   |                                                 |
+|                                | [Retags](#retags)                      | [VOSTFR](#vostfr)             |                                                 |
+|                                | [Scene](#scene)                        | [FanSUB](#fansub)             |                                                 |
+|                                | [SDR (no WEBDL)](#sdr-no-webdl)        | [FastSUB](#fastsub)           |                                                 |
 |                                | [SDR](#sdr)                            |                               |                                                 |
 |                                | [VP9](#vp9)                            |                               |                                                 |
 |                                | [x265 (no HDR/DV)](#x265-no-hdrdv)     |                               |                                                 |
+|                                |                                        |                               |                                                 |
 
 ---
 
@@ -895,6 +895,25 @@ We've made 3 guides related to this.
 
 ---
 
+### AV1
+
+??? question "AV1 - [Click to show/hide]"
+
+    - This is a new codec and you need modern devices that support it.
+    - We also had reports of playback/transcoding issues.
+    - No main group is actually using it (yet).
+    - It's better to ignore this new codec to prevent compatibility issues.
+
+??? example "JSON - [Click to show/hide]"
+
+    ```json
+    [[% filter indent(width=4) %]][[% include 'json/radarr/cf/av1.json' %]][[% endfilter %]]
+    ```
+
+<sub><sup>[TOP](#index)</sup></sub>
+
+---
+
 ### BR-DISK
 
 ??? question "BR-DISK - [Click to show/hide]"
@@ -1204,25 +1223,6 @@ We've made 3 guides related to this.
 
     ```json
     [[% filter indent(width=4) %]][[% include 'json/radarr/cf/x265-no-hdrdv.json' %]][[% endfilter %]]
-    ```
-
-<sub><sup>[TOP](#index)</sup></sub>
-
----
-
-### AV1
-
-??? question "AV1 - [Click to show/hide]"
-
-    - This is a new codec and you need modern devices that support it.
-    - We also had reports of playback/transcoding issues.
-    - No main group is actually using it (yet).
-    - It's better to ignore this new codec to prevent compatibility issues.
-
-??? example "JSON - [Click to show/hide]"
-
-    ```json
-    [[% filter indent(width=4) %]][[% include 'json/radarr/cf/av1.json' %]][[% endfilter %]]
     ```
 
 <sub><sup>[TOP](#index)</sup></sub>

--- a/docs/Sonarr/sonarr-collection-of-custom-formats.md
+++ b/docs/Sonarr/sonarr-collection-of-custom-formats.md
@@ -730,10 +730,7 @@ We've made 3 guides related to this.
 
 ??? question "AV1 - [Click to show/hide]"
 
-    - This is a new codec and you need modern devices that support it.
-    - We also had reports of playback/transcoding issues.
-    - No main group is actually using it (yet).
-    - It's better to ignore this new codec to prevent compatibility issues.
+    {! include-markdown "../../includes/cf-descriptions/av1.md" !}
 
 ??? example "JSON - [Click to show/hide]"
 

--- a/docs/Sonarr/sonarr-collection-of-custom-formats.md
+++ b/docs/Sonarr/sonarr-collection-of-custom-formats.md
@@ -48,13 +48,13 @@ We've made 3 guides related to this.
 
 | Series Versions       | Unwanted                                | HQ Source Groups                        |
 | --------------------- | --------------------------------------- | --------------------------------------- |
-| [Hybrid](#hybrid)     | [BR-DISK](#br-disk)                     | [Remux Tier 01](#remux-tier-01)         |
-| [Remaster](#remaster) | [Extras](#extras)                       | [Remux Tier 02](#remux-tier-02)         |
-|                       | [LQ](#lq)                               | [HD Bluray Tier 01](#hd-bluray-tier-01) |
-|                       | [LQ (Release Title)](#lq-release-title) | [HD Bluray Tier 02](#hd-bluray-tier-02) |
-|                       | [Upscaled](#upscaled)                   | [WEB Tier 01](#web-tier-01)             |
-|                       | [x265 (HD)](#x265-hd)                   | [WEB Tier 02](#web-tier-02)             |
-|                       |                                         | [WEB Tier 03](#web-tier-03)             |
+| [Hybrid](#hybrid)     | [AV1](#av1)                             | [Remux Tier 01](#remux-tier-01)         |
+| [Remaster](#remaster) | [BR-DISK](#br-disk)                     | [Remux Tier 02](#remux-tier-02)         |
+|                       | [Extras](#extras)                       | [HD Bluray Tier 01](#hd-bluray-tier-01) |
+|                       | [LQ](#lq)                               | [HD Bluray Tier 02](#hd-bluray-tier-02) |
+|                       | [LQ (Release Title)](#lq-release-title) | [WEB Tier 01](#web-tier-01)             |
+|                       | [Upscaled](#upscaled)                   | [WEB Tier 02](#web-tier-02)             |
+|                       | [x265 (HD)](#x265-hd)                   | [WEB Tier 03](#web-tier-03)             |
 |                       |                                         | [WEB Scene](#web-scene)                 |
 
 ---
@@ -93,23 +93,23 @@ We've made 3 guides related to this.
 
 | Misc                           | Optional                               | French Audio Version          | French Source Groups                          |
 | ------------------------------ | -------------------------------------- | ----------------------------- | --------------------------------------------- |
-| [FreeLeech](#freeleech)        | [AV1](#av1)                            | [Multi-French](#multi-french) | [FR Remux Tier 01](#fr-remux-tier-01)         |
-| [MPEG2](#mpeg2)                | [Bad Dual Groups](#bad-dual-groups)    | [Multi-Audio](#multi-audio)   | [FR HD Bluray Tier 01](#fr-hd-bluray-tier-01) |
-| [Multi](#multi)                | [DV (Disk)](#dv-disk)                  | [French Audio](#french-audio) | [FR WEB Tier 01](#fr-web-tier-01)             |
-| [Repack v2](#repack-v2)        | [DV (WEBDL)](#dv-webdl)                | [VFF](#vff)                   | [FR WEB Tier 02](#fr-web-tier-02)             |
-| [Repack v3](#repack-v3)        | [DV HDR10+ Boost](#dv-hdr10plus-boost) | [VOF](#vof)                   | [FR WEB Tier 03](#fr-web-tier-03)             |
-| [Repack/Proper](#repackproper) | [HDR10+ Boost](#hdr10plus-boost)       | [VFI](#vfi)                   | [FR Anime Tier 01](#fr-anime-tier-01)         |
-| [x264](#x264)                  | [HFR](#hfr)                            | [VF2](#vf2)                   | [FR Anime Tier 02](#fr-anime-tier-02)         |
-| [x265](#x265)                  | [Internal](#internal)                  | [VFQ](#vfq)                   | [FR Anime Tier 03](#fr-anime-tier-03)         |
-| [x266](#x266)                  | [No-RlsGroup](#no-rlsgroup)            | [VOQ](#voq)                   | [FR Anime FanSub](#fr-anime-fansub)           |
-|                                | [Obfuscated](#obfuscated)              | [VQ](#vq)                     | [FR Scene Groups](#fr-scene-groups)           |
-|                                | [Retags](#retags)                      | [VFB](#vfb)                   | [FR LQ](#fr-lq)                               |
-|                                | [Scene](#scene)                        | [VOSTFR](#vostfr)             |                                               |
-|                                | [SDR (no WEBDL)](#sdr-no-webdl)        | [FanSUB](#fansub)             |                                               |
-|                                | [SDR](#sdr)                            | [FastSUB](#fastsub)           |                                               |
-|                                | [Season Packs](#season-pack)           |                               |                                               |
+| [FreeLeech](#freeleech)        | [Bad Dual Groups](#bad-dual-groups)    | [Multi-French](#multi-french) | [FR Remux Tier 01](#fr-remux-tier-01)         |
+| [MPEG2](#mpeg2)                | [DV (Disk)](#dv-disk)                  | [Multi-Audio](#multi-audio)   | [FR HD Bluray Tier 01](#fr-hd-bluray-tier-01) |
+| [Multi](#multi)                | [DV (WEBDL)](#dv-webdl)                | [French Audio](#french-audio) | [FR WEB Tier 01](#fr-web-tier-01)             |
+| [Repack v2](#repack-v2)        | [DV HDR10+ Boost](#dv-hdr10plus-boost) | [VFF](#vff)                   | [FR WEB Tier 02](#fr-web-tier-02)             |
+| [Repack v3](#repack-v3)        | [HDR10+ Boost](#hdr10plus-boost)       | [VOF](#vof)                   | [FR WEB Tier 03](#fr-web-tier-03)             |
+| [Repack/Proper](#repackproper) | [HFR](#hfr)                            | [VFI](#vfi)                   | [FR Anime Tier 01](#fr-anime-tier-01)         |
+| [x264](#x264)                  | [Internal](#internal)                  | [VF2](#vf2)                   | [FR Anime Tier 02](#fr-anime-tier-02)         |
+| [x265](#x265)                  | [No-RlsGroup](#no-rlsgroup)            | [VFQ](#vfq)                   | [FR Anime Tier 03](#fr-anime-tier-03)         |
+| [x266](#x266)                  | [Obfuscated](#obfuscated)              | [VOQ](#voq)                   | [FR Anime FanSub](#fr-anime-fansub)           |
+|                                | [Retags](#retags)                      | [VQ](#vq)                     | [FR Scene Groups](#fr-scene-groups)           |
+|                                | [Scene](#scene)                        | [VFB](#vfb)                   | [FR LQ](#fr-lq)                               |
+|                                | [SDR (no WEBDL)](#sdr-no-webdl)        | [VOSTFR](#vostfr)             |                                               |
+|                                | [SDR](#sdr)                            | [FanSUB](#fansub)             |                                               |
+|                                | [Season Packs](#season-pack)           | [FastSUB](#fastsub)           |                                               |
 |                                | [VP9](#vp9)                            |                               |                                               |
 |                                | [x265 (no HDR/DV)](#x265-no-hdrdv)     |                               |                                               |
+|                                |                                        |                               |                                               |
 
 ---
 
@@ -726,6 +726,25 @@ We've made 3 guides related to this.
 
 ---
 
+### AV1
+
+??? question "AV1 - [Click to show/hide]"
+
+    - This is a new codec and you need modern devices that support it.
+    - We also had reports of playback/transcoding issues.
+    - No main group is actually using it (yet).
+    - It's better to ignore this new codec to prevent compatibility issues.
+
+??? example "JSON - [Click to show/hide]"
+
+    ```json
+    [[% filter indent(width=4) %]][[% include 'json/sonarr/cf/av1.json' %]][[% endfilter %]]
+    ```
+
+<sub><sup>[TOP](#index)</sup></sub>
+
+---
+
 ### BR-DISK
 
 ??? question "BR-DISK - [Click to show/hide]"
@@ -1210,25 +1229,6 @@ We've made 3 guides related to this.
 
     ```json
     [[% filter indent(width=4) %]][[% include 'json/sonarr/cf/x265-no-hdrdv.json' %]][[% endfilter %]]
-    ```
-
-<sub><sup>[TOP](#index)</sup></sub>
-
----
-
-### AV1
-
-??? question "AV1 - [Click to show/hide]"
-
-    - This is a new codec and you need modern devices that support it.
-    - We also had reports of playback/transcoding issues.
-    - No main group is actually using it (yet).
-    - It's better to ignore this new codec to prevent compatibility issues.
-
-??? example "JSON - [Click to show/hide]"
-
-    ```json
-    [[% filter indent(width=4) %]][[% include 'json/sonarr/cf/av1.json' %]][[% endfilter %]]
     ```
 
 <sub><sup>[TOP](#index)</sup></sub>

--- a/docs/json/radarr/quality-profiles/hd-bluray-web.json
+++ b/docs/json/radarr/quality-profiles/hd-bluray-web.json
@@ -73,6 +73,7 @@
     "x265 (HD)": "dc98083864ea246d05a42df0d05f81cc",
     "3D": "b8cd450cbfa689c0259a01d9e29ba3d6",
     "Extras": "0a3f082873eb454bde444150b70253cc",
+    "AV1": "cae4ca30163749b891686f95532519bd",
     "AMZN": "b3b3a6ac74ecbd56bcdbefa4799fb9df",
     "ATVP": "40e9380490e748672c2522eaaeb692f7",
     "BCORE": "cc5e51a9e85a6296ceefe097a77f12f4",

--- a/docs/json/radarr/quality-profiles/remux-web-1080p.json
+++ b/docs/json/radarr/quality-profiles/remux-web-1080p.json
@@ -74,6 +74,7 @@
     "x265 (HD)": "dc98083864ea246d05a42df0d05f81cc",
     "3D": "b8cd450cbfa689c0259a01d9e29ba3d6",
     "Extras": "0a3f082873eb454bde444150b70253cc",
+    "AV1": "cae4ca30163749b891686f95532519bd",
     "AMZN": "b3b3a6ac74ecbd56bcdbefa4799fb9df",
     "ATVP": "40e9380490e748672c2522eaaeb692f7",
     "BCORE": "cc5e51a9e85a6296ceefe097a77f12f4",

--- a/docs/json/radarr/quality-profiles/remux-web-2160p.json
+++ b/docs/json/radarr/quality-profiles/remux-web-2160p.json
@@ -86,6 +86,7 @@
     "3D": "b8cd450cbfa689c0259a01d9e29ba3d6",
     "Upscaled": "bfd8eb01832d646a0a89c4deb46f8564",
     "Extras": "0a3f082873eb454bde444150b70253cc",
+    "AV1": "cae4ca30163749b891686f95532519bd",
     "AMZN": "b3b3a6ac74ecbd56bcdbefa4799fb9df",
     "ATVP": "40e9380490e748672c2522eaaeb692f7",
     "BCORE": "cc5e51a9e85a6296ceefe097a77f12f4",

--- a/docs/json/radarr/quality-profiles/sqp-1-1080p.json
+++ b/docs/json/radarr/quality-profiles/sqp-1-1080p.json
@@ -88,6 +88,7 @@
     "3D": "b8cd450cbfa689c0259a01d9e29ba3d6",
     "Extras": "0a3f082873eb454bde444150b70253cc",
     "10 bit": "a5d148168c4506b55cf53984107c396e",
+    "AV1": "cae4ca30163749b891686f95532519bd",
     "1080p": "820b09bb9acbfde9c35c71e0e565dad8",
     "720p": "b2be17d608fc88818940cd1833b0b24c",
     "AMZN": "b3b3a6ac74ecbd56bcdbefa4799fb9df",

--- a/docs/json/radarr/quality-profiles/sqp-1-2160p.json
+++ b/docs/json/radarr/quality-profiles/sqp-1-2160p.json
@@ -104,6 +104,7 @@
     "Upscaled": "bfd8eb01832d646a0a89c4deb46f8564",
     "Extras": "0a3f082873eb454bde444150b70253cc",
     "10 bit": "a5d148168c4506b55cf53984107c396e",
+    "AV1": "cae4ca30163749b891686f95532519bd",
     "1080p": "820b09bb9acbfde9c35c71e0e565dad8",
     "720p": "b2be17d608fc88818940cd1833b0b24c",
     "AMZN": "b3b3a6ac74ecbd56bcdbefa4799fb9df",

--- a/docs/json/radarr/quality-profiles/sqp-2.json
+++ b/docs/json/radarr/quality-profiles/sqp-2.json
@@ -90,6 +90,7 @@
     "3D": "b8cd450cbfa689c0259a01d9e29ba3d6",
     "Upscaled": "bfd8eb01832d646a0a89c4deb46f8564",
     "Extras": "0a3f082873eb454bde444150b70253cc",
+    "AV1": "cae4ca30163749b891686f95532519bd",
     "1080p": "820b09bb9acbfde9c35c71e0e565dad8",
     "2160p": "fb392fb0d61a010ae38e49ceaa24a1ef",
     "AMZN": "b3b3a6ac74ecbd56bcdbefa4799fb9df",

--- a/docs/json/radarr/quality-profiles/sqp-3.json
+++ b/docs/json/radarr/quality-profiles/sqp-3.json
@@ -87,6 +87,7 @@
     "3D": "b8cd450cbfa689c0259a01d9e29ba3d6",
     "Upscaled": "bfd8eb01832d646a0a89c4deb46f8564",
     "Extras": "0a3f082873eb454bde444150b70253cc",
+    "AV1": "cae4ca30163749b891686f95532519bd",
     "1080p": "820b09bb9acbfde9c35c71e0e565dad8",
     "2160p": "fb392fb0d61a010ae38e49ceaa24a1ef",
     "AMZN": "b3b3a6ac74ecbd56bcdbefa4799fb9df",

--- a/docs/json/radarr/quality-profiles/sqp-4.json
+++ b/docs/json/radarr/quality-profiles/sqp-4.json
@@ -82,6 +82,7 @@
     "3D": "b8cd450cbfa689c0259a01d9e29ba3d6",
     "Upscaled": "bfd8eb01832d646a0a89c4deb46f8564",
     "Extras": "0a3f082873eb454bde444150b70253cc",
+    "AV1": "cae4ca30163749b891686f95532519bd",
     "1080p": "820b09bb9acbfde9c35c71e0e565dad8",
     "2160p": "fb392fb0d61a010ae38e49ceaa24a1ef",
     "AMZN": "b3b3a6ac74ecbd56bcdbefa4799fb9df",

--- a/docs/json/radarr/quality-profiles/sqp-5.json
+++ b/docs/json/radarr/quality-profiles/sqp-5.json
@@ -90,6 +90,7 @@
     "3D": "b8cd450cbfa689c0259a01d9e29ba3d6",
     "Upscaled": "bfd8eb01832d646a0a89c4deb46f8564",
     "Extras": "0a3f082873eb454bde444150b70253cc",
+    "AV1": "cae4ca30163749b891686f95532519bd",
     "1080p": "820b09bb9acbfde9c35c71e0e565dad8",
     "2160p": "fb392fb0d61a010ae38e49ceaa24a1ef",
     "AMZN": "b3b3a6ac74ecbd56bcdbefa4799fb9df",

--- a/docs/json/radarr/quality-profiles/uhd-bluray-web.json
+++ b/docs/json/radarr/quality-profiles/uhd-bluray-web.json
@@ -85,6 +85,7 @@
     "3D": "b8cd450cbfa689c0259a01d9e29ba3d6",
     "Upscaled": "bfd8eb01832d646a0a89c4deb46f8564",
     "Extras": "0a3f082873eb454bde444150b70253cc",
+    "AV1": "cae4ca30163749b891686f95532519bd",
     "AMZN": "b3b3a6ac74ecbd56bcdbefa4799fb9df",
     "ATVP": "40e9380490e748672c2522eaaeb692f7",
     "BCORE": "cc5e51a9e85a6296ceefe097a77f12f4",

--- a/docs/json/sonarr/quality-profiles/web-1080p.json
+++ b/docs/json/sonarr/quality-profiles/web-1080p.json
@@ -46,6 +46,7 @@
     "LQ (Release Title)": "e2315f990da2e2cbfc9fa5b7a6fcfe48",
     "x265 (HD)": "47435ece6b99a0b477caf360e79ba0bb",
     "Extras": "fbcb31d8dabd2a319072b84fc0b7249c",
+    "AV1": "15a05bc7c1a36e2b57fd628f8977e2fc",
     "Repack/Proper": "ec8fa7296b64e8cd390a1600981f3923",
     "Repack v2": "eb3d5cc0a2be0db205fb823640db6a3c",
     "Repack v3": "44e7c4de10ae50265753082e5dc76047",

--- a/docs/json/sonarr/quality-profiles/web-2160p.json
+++ b/docs/json/sonarr/quality-profiles/web-2160p.json
@@ -57,6 +57,7 @@
     "LQ (Release Title)": "e2315f990da2e2cbfc9fa5b7a6fcfe48",
     "x265 (no HDR/DV)": "9b64dff695c2115facf1b6ea59c9bd07",
     "Extras": "fbcb31d8dabd2a319072b84fc0b7249c",
+    "AV1": "15a05bc7c1a36e2b57fd628f8977e2fc",
     "Repack/Proper": "ec8fa7296b64e8cd390a1600981f3923",
     "Repack v2": "eb3d5cc0a2be0db205fb823640db6a3c",
     "Repack v3": "44e7c4de10ae50265753082e5dc76047",

--- a/includes/cf-descriptions/av1.md
+++ b/includes/cf-descriptions/av1.md
@@ -1,0 +1,1 @@
+!!! info "Currently, AV1 encodes are aimed towards smaller file sizes to the detriment of visual quality."

--- a/includes/cf-descriptions/av1.md
+++ b/includes/cf-descriptions/av1.md
@@ -1,1 +1,1 @@
-!!! info "Currently, AV1 encodes are aimed towards smaller file sizes to the detriment of visual quality."
+!!! info "AV1 encodes are currently targeting small file sizes, rather than good visual quality."

--- a/includes/cf-descriptions/av1.md
+++ b/includes/cf-descriptions/av1.md
@@ -1,1 +1,6 @@
-!!! info "AV1 encodes are currently targeting small file sizes, rather than good visual quality."
+AV1 encodes are currently targeting small file sizes, rather than good visual quality.
+
+- This is a new codec and you need modern devices that support it.
+- We also had reports of playback/transcoding issues.
+- No main group is actually using it (yet).
+- It's better to ignore this new codec to prevent compatibility issues

--- a/includes/cf/radarr-unwanted-uhd.md
+++ b/includes/cf/radarr-unwanted-uhd.md
@@ -9,6 +9,7 @@
     | [{{ radarr['cf']['3d']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#3d)                             |        {{ radarr['cf']['3d']['trash_scores']['default'] }}        | {{ radarr['cf']['3d']['trash_id'] }}               |
     | [{{ radarr['cf']['upscaled']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#upscaled)                 |     {{ radarr['cf']['upscaled']['trash_scores']['default'] }}     | {{ radarr['cf']['upscaled']['trash_id'] }}         |
     | [{{ radarr['cf']['extras']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#extras)                     |      {{ radarr['cf']['extras']['trash_scores']['default'] }}      | {{ radarr['cf']['extras']['trash_id'] }}           |
+    | [{{ radarr['cf']['av1']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#av1)                           |       {{ radarr['cf']['av1']['trash_scores']['default'] }}        | {{ radarr['cf']['av1']['trash_id'] }}              |
 
     ---
 
@@ -24,3 +25,6 @@
     - **{{ radarr['cf']['3d']['name'] }}:** Is 3D still a thing for home use ?
     - **{{ radarr['cf']['upscaled']['name'] }}:** A custom format to prevent Radarr from grabbing upscaled releases.
     - **{{ radarr['cf']['extras']['name'] }}:** Blocks releases that only contain extras
+    - **{{ radarr['cf']['av1']['name'] }}:** This blocks all releases encoded in AV1.
+
+        {! include-markdown "../../includes/cf-descriptions/av1.md" !}

--- a/includes/cf/radarr-unwanted.md
+++ b/includes/cf/radarr-unwanted.md
@@ -8,6 +8,7 @@
     | [{{ radarr['cf']['x265-hd']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#x265-hd) :warning:         |     {{ radarr['cf']['x265-hd']['trash_scores']['default'] }}      | {{ radarr['cf']['x265-hd']['trash_id'] }}          |
     | [{{ radarr['cf']['3d']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#3d)                             |        {{ radarr['cf']['3d']['trash_scores']['default'] }}        | {{ radarr['cf']['3d']['trash_id'] }}               |
     | [{{ radarr['cf']['extras']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#extras)                     |      {{ radarr['cf']['extras']['trash_scores']['default'] }}      | {{ radarr['cf']['extras']['trash_id'] }}           |
+    | [{{ radarr['cf']['av1']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#av1)                           |       {{ radarr['cf']['av1']['trash_scores']['default'] }}        | {{ radarr['cf']['av1']['trash_id'] }}              |
 
     ---
 
@@ -22,3 +23,6 @@
 
     - **{{ radarr['cf']['3d']['name'] }}:** Is 3D still a thing for home use ?
     - **{{ radarr['cf']['extras']['name'] }}:** Blocks releases that only contain extras
+    - **{{ radarr['cf']['av1']['name'] }}:** This blocks all releases encoded in AV1.
+
+        {! include-markdown "../../includes/cf-descriptions/av1.md" !}

--- a/includes/cf/sonarr-unwanted-uhd.md
+++ b/includes/cf/sonarr-unwanted-uhd.md
@@ -7,6 +7,7 @@
     | [{{ sonarr['cf']['lq-release-title']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#lq-release-title) | {{ sonarr['cf']['lq-release-title']['trash_scores']['default'] }} | {{ sonarr['cf']['lq-release-title']['trash_id'] }} |
     | [{{ sonarr['cf']['upscaled']['name'] }}](/Sonarr/Sonarr-collection-of-custom-formats/#upscaled)                 |     {{ sonarr['cf']['upscaled']['trash_scores']['default'] }}     | {{ sonarr['cf']['upscaled']['trash_id'] }}         |
     | [{{ sonarr['cf']['extras']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#extras)                     |      {{ sonarr['cf']['extras']['trash_scores']['default'] }}      | {{ sonarr['cf']['extras']['trash_id'] }}           |
+    | [{{ sonarr['cf']['av1']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#av1)                           |       {{ sonarr['cf']['av1']['trash_scores']['default'] }}        | {{ sonarr['cf']['av1']['trash_id'] }}              |
 
     ---
 
@@ -17,3 +18,6 @@
     - **{{ sonarr['cf']['lq-release-title']['name'] }}:** A collection of terms seen in the titles of Low Quality releases that are not captured by using a release group name.
     - **{{ sonarr['cf']['upscaled']['name'] }}:** This custom format is used to prevent Sonarr from grabbing upscaled releases.
     - **{{ sonarr['cf']['extras']['name'] }}:** This blocks/ignores extras
+    - **{{ sonarr['cf']['av1']['name'] }}:** This blocks all releases encoded in AV1.
+
+        {! include-markdown "../../includes/cf-descriptions/av1.md" !}

--- a/includes/cf/sonarr-unwanted.md
+++ b/includes/cf/sonarr-unwanted.md
@@ -7,6 +7,7 @@
     | [{{ sonarr['cf']['lq-release-title']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#lq-release-title) | {{ sonarr['cf']['lq-release-title']['trash_scores']['default'] }} | {{ sonarr['cf']['lq-release-title']['trash_id'] }} |
     | [{{ sonarr['cf']['x265-hd']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#x265-hd) :warning:         |     {{ sonarr['cf']['x265-hd']['trash_scores']['default'] }}      | {{ sonarr['cf']['x265-hd']['trash_id'] }}          |
     | [{{ sonarr['cf']['extras']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#extras)                     |      {{ sonarr['cf']['extras']['trash_scores']['default'] }}      | {{ sonarr['cf']['extras']['trash_id'] }}           |
+    | [{{ sonarr['cf']['av1']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#av1)                           |       {{ sonarr['cf']['av1']['trash_scores']['default'] }}        | {{ sonarr['cf']['av1']['trash_id'] }}              |
 
     ---
 
@@ -20,3 +21,6 @@
         {! include-markdown "../../includes/cf-descriptions/x265-hd-sonarr-warning.md" !}
 
     - **{{ sonarr['cf']['extras']['name'] }}:** This blocks/ignores extras
+    - **{{ sonarr['cf']['av1']['name'] }}:** This blocks all releases encoded in AV1.
+
+        {! include-markdown "../../includes/cf-descriptions/av1.md" !}

--- a/includes/sqp/1-4k-cf-scoring-sqp1.md
+++ b/includes/sqp/1-4k-cf-scoring-sqp1.md
@@ -103,15 +103,10 @@
 
 ??? abstract "Optional - [Click to show/hide]"
 
-    !!! tip "I recommend using the following Custom Formats"
-
-        - `AV1` This will prevent grabbing AV1 releases.
-
     !!! danger "Adding any of the `HDR10+ Boosts` could result in less streaming optimized releases :warning:"
 
     | Custom Format                                                                                                       |                                Score                                | Trash ID                                             |
     | ------------------------------------------------------------------------------------------------------------------- | :-----------------------------------------------------------------: | ---------------------------------------------------- |
-    | [{{ radarr['cf']['av1']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#av1)                               |        {{ radarr['cf']['av1']['trash_scores']['default'] }}         | {{ radarr['cf']['av1']['trash_id'] }}                |
     | [{{ radarr['cf']['bad-dual-groups']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#bad-dual-groups)       |  {{ radarr['cf']['bad-dual-groups']['trash_scores']['default'] }}   | {{ radarr['cf']['bad-dual-groups']['trash_id'] }}    |
     | [{{ radarr['cf']['evo-no-webdl']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#evo-no-webdl)             |    {{ radarr['cf']['evo-no-webdl']['trash_scores']['default'] }}    | {{ radarr['cf']['evo-no-webdl']['trash_id'] }}       |
     | [{{ radarr['cf']['no-rlsgroup']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#no-rlsgroup)               |    {{ radarr['cf']['no-rlsgroup']['trash_scores']['default'] }}     | {{ radarr['cf']['no-rlsgroup']['trash_id'] }}        |
@@ -125,7 +120,6 @@
 
     Breakdown and Why
 
-    - **{{ radarr['cf']['av1']['name'] }}**: This will prevent grabbing AV1 releases.
     - **{{ radarr['cf']['bad-dual-groups']['name'] }}:** [*Optional*] These groups take the original release and add their own language track (e.g. AAC 2.0 Portuguese) as the first track. Afterward, FFprobe would determine that the media file is Portuguese. It's a common rule that you only add the best audio as the main track.
     Also they often even rename the release name into Portuguese.
     - **{{ radarr['cf']['evo-no-webdl']['name'] }}:** This group is often banned for low-quality Blu-ray releases, but their WEB-DLs are okay.

--- a/includes/sqp/radarr-unwanted-sqp1.md
+++ b/includes/sqp/radarr-unwanted-sqp1.md
@@ -9,6 +9,7 @@
     | [{{ radarr['cf']['3d']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#3d)                             |        {{ radarr['cf']['3d']['trash_scores']['default'] }}        | {{ radarr['cf']['3d']['trash_id'] }}               |
     | [{{ radarr['cf']['extras']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#extras)                     |      {{ radarr['cf']['extras']['trash_scores']['default'] }}      | {{ radarr['cf']['extras']['trash_id'] }}           |
     | [{{ radarr['cf']['10bit']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#10bit)                       |    {{ radarr['cf']['10bit']['trash_scores']['sqp-1-1080p'] }}     | {{ radarr['cf']['10bit']['trash_id'] }}            |
+    | [{{ radarr['cf']['av1']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#av1)                           |       {{ radarr['cf']['av1']['trash_scores']['default'] }}        | {{ radarr['cf']['av1']['trash_id'] }}              |
 
     ---
 
@@ -24,3 +25,6 @@
     - **{{ radarr['cf']['3d']['name'] }}:** Is 3D still a thing for home use ?
     - **{{ radarr['cf']['extras']['name'] }}:** Blocks releases that only contain extras
     - **{{ radarr['cf']['10bit']['name'] }}:** Blocks releases that use Hi10P
+    - **{{ radarr['cf']['av1']['name'] }}:** This blocks all releases encoded in AV1.
+
+        {! include-markdown "../../includes/cf-descriptions/av1.md" !}

--- a/includes/sqp/radarr-unwanted-uhd-sqp1.md
+++ b/includes/sqp/radarr-unwanted-uhd-sqp1.md
@@ -10,6 +10,7 @@
     | [{{ radarr['cf']['upscaled']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#upscaled)                 |     {{ radarr['cf']['upscaled']['trash_scores']['default'] }}     | {{ radarr['cf']['upscaled']['trash_id'] }}         |
     | [{{ radarr['cf']['extras']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#extras)                     |      {{ radarr['cf']['extras']['trash_scores']['default'] }}      | {{ radarr['cf']['extras']['trash_id'] }}           |
     | [{{ radarr['cf']['10bit']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#10bit)                       |    {{ radarr['cf']['10bit']['trash_scores']['sqp-1-2160p'] }}     | {{ radarr['cf']['10bit']['trash_id'] }}            |
+    | [{{ radarr['cf']['av1']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#av1)                           |       {{ radarr['cf']['av1']['trash_scores']['default'] }}        | {{ radarr['cf']['av1']['trash_id'] }}              |
 
     ---
 
@@ -26,3 +27,6 @@
     - **{{ radarr['cf']['upscaled']['name'] }}:** A custom format to prevent Radarr from grabbing upscaled releases.
     - **{{ radarr['cf']['extras']['name'] }}:** Blocks releases that only contain extras
     - **{{ radarr['cf']['10bit']['name'] }}:** Blocks releases that use Hi10P
+    - **{{ radarr['cf']['av1']['name'] }}:** This blocks all releases encoded in AV1.
+
+        {! include-markdown "../../includes/cf-descriptions/av1.md" !}


### PR DESCRIPTION
# Pull Request

## Purpose

Resolve: #1962 

## Approach

- [x] Remove AV1 from Radarr and Sonarr optional guide sections.
- [x] Add AV1 to Radarr and Sonarr unwanted guide sections.
- [x] Add AV1 to Radarr and Sonarr profile JSON files.
- [x] Built and tested locally.

## Open Questions and Pre-Merge TODOs

None

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
