### PR TITLE
feat(guides): Add hallowed to (U)HD Bluray Tier 03 and create new `hallowed` Radarr custom format

### DIFF
--- a/docs/json/radarr/cf/hallowed.json
+++ b/docs/json/radarr/cf/hallowed.json
@@ -1,0 +1,19 @@
+{
+  "trash_id": "7a0d1ad358fee9f5b074af3ef3f9d9ef",
+  "trash_scores": {
+    "default": 600
+  },
+  "name": "hallowed",
+  "includeCustomFormatWhenRenaming": false,
+  "specifications": [
+    {
+      "name": "hallowed",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": true,
+      "fields": {
+        "value": "^(hallowed)$"
+      }
+    }
+  ]
+}

--- a/docs/json/radarr/cf/hd-bluray-tier-03.json
+++ b/docs/json/radarr/cf/hd-bluray-tier-03.json
@@ -45,6 +45,15 @@
       }
     },
     {
+      "name": "hallowed",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(hallowed)$"
+      }
+    },
+    {
       "name": "HONE",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,

--- a/docs/json/radarr/cf/uhd-bluray-tier-03.json
+++ b/docs/json/radarr/cf/uhd-bluray-tier-03.json
@@ -55,6 +55,15 @@
       }
     },
     {
+      "name": "hallowed",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(hallowed)$"
+      }
+    },
+    {
       "name": "HONE",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,

--- a/docs/updates.txt
+++ b/docs/updates.txt
@@ -1,3 +1,6 @@
+# 2024-06-15 22:00
+- [feat(guides): Add hallowed to (U)HD Bluray Tier 03 and create new hallowed Radarr custom format (#1978)](https://github.com/TRaSH-Guides/Guides/pull/1978)
+
 # 2024-06-14 04:00
 - Synology: [feat(jellyseerr): add jellyseerr (#209)](https://github.com/TRaSH-Guides/Synology-Templates/pull/209)
 - Synology: [fix(env): add missing details and clarify for plex (#207)](https://github.com/TRaSH-Guides/Synology-Templates/pull/207)


### PR DESCRIPTION
# Pull Request

## Purpose

- Add the 'hallowed' rlsgrp to Radarr (U)HD Bluray Tier 03
- Create new `hallowed` Radarr custom format for use with SQP-1 variants
- Give default score of `600` to new `hallowed` Radarr custom format

## Approach

- [x] Add the 'hallowed' rlsgrp to Radarr (U)HD Bluray Tier 03 custom formats
- [x] Create new `hallowed` Radarr custom format, using new unique `trash_id`
- [x] Add default score of `600` to new `hallowed` Radarr custom format (current test score is 1600, so setting to 600 + HD Bluray Tier 03 SQP-1 score of 1000 keeps score parity)

## Open Questions and Pre-Merge TODOs

None

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
