### PR TITLE
style(discord-shields): restore discord shields

### DIFF
--- a/docs/Radarr/radarr-setup-quality-profiles.md
+++ b/docs/Radarr/radarr-setup-quality-profiles.md
@@ -80,6 +80,7 @@ At the bottom, in your chosen profile, you will see the added Custom Formats whe
     <center>If you're unsure or have questions do not hesitate to ask for help on Discord</center>
 
     <center>[ Click For Support ](https://trash-guides.info/discord){ .md-button .md-button--primary }</center>
+    <center>[![Discord chat](https://img.shields.io/discord/492590071455940612?style=for-the-badge&color=4051B5&logo=discord){ .off-glb }](https://trash-guides.info/discord){:target="\_blank" rel="noopener noreferrer"}</center>
 
 ---
 

--- a/docs/Sonarr/sonarr-setup-quality-profiles.md
+++ b/docs/Sonarr/sonarr-setup-quality-profiles.md
@@ -75,6 +75,7 @@ At the bottom, in your chosen profile, you will see the added Custom Formats whe
     <center>If you're unsure or have questions do not hesitate to ask for help on Discord</center>
 
     <center>[ Click For Support ](https://trash-guides.info/discord){ .md-button .md-button--primary }</center>
+    <center>[![Discord chat](https://img.shields.io/discord/492590071455940612?style=for-the-badge&color=4051B5&logo=discord){ .off-glb }](https://trash-guides.info/discord){:target="\_blank" rel="noopener noreferrer"}</center>
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@
 
 # TRaSH-Guides
 
-[![Discord chat](https://trash-guides.info/assets/discord.png){ .off-glb }](https://trash-guides.info/discord){:target="\_blank" rel="noopener noreferrer"}
+[![Discord chat](https://img.shields.io/discord/492590071455940612?style=for-the-badge&color=4051B5&logo=discord){ .off-glb }](https://trash-guides.info/discord){:target="\_blank" rel="noopener noreferrer"}
 [![GitHub last commit](https://img.shields.io/github/last-commit/TRaSH-Guides/Guides?color=4051B5&label=Last%20Update&style=flat-square){ .off-glb }](https://github.com/TRaSH-Guides/Guides/commits/master){:target="\_blank" rel="noopener noreferrer"}
 [![GitHub contributors](https://img.shields.io/github/contributors/TRaSH-Guides/Guides?color=4051B5&style=flat-square){ .off-glb }](https://github.com/TRaSH-Guides/Guides/graphs/contributors){:target="\_blank" rel="noopener noreferrer"}
 [![GitHub pull requests](https://img.shields.io/github/issues-pr/TRaSH-Guides/Guides?color=4051B5&style=flat-square){ .off-glb }](https://github.com/TRaSH-Guides/Guides/pulls){:target="\_blank" rel="noopener noreferrer"}
@@ -29,7 +29,8 @@ I try to make my guides as easy as possible for everyone to understand and, in m
 - If you want to contribute, feel free to create a PR (Pull Request).
 - If you found a actual issue related to the guide you can open a Github [issue](https://github.com/TRaSH-Guides/Guides/issues){:target="\_blank" rel="noopener noreferrer"}.
 
-<center>[ Click For Support ](https://trash-guides.info/discord){ .md-button .md-button--primary }</center>
+<center>[ Click For Support ](https://trash-guides.info/discord){ .md-button .md-button--primary .custom_width }</center>
+<center>[![Discord chat](https://img.shields.io/discord/492590071455940612?style=for-the-badge&color=4051B5&logo=discord){ .off-glb }](https://trash-guides.info/discord){:target="\_blank" rel="noopener noreferrer"}</center>
 
 ---
 

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -72,3 +72,11 @@ td {
   fill: var(--md-accent-fg-color);
   transform:rotate(45deg);
 }
+.md-typeset .md-button.custom_width {
+  border-radius:0rem;
+  padding:.625em .91em;
+}
+.md-typeset .md-button {
+  border-radius:0rem;
+  padding:.625em 2.2em;
+}

--- a/includes/cf/score-attention.md
+++ b/includes/cf/score-attention.md
@@ -8,4 +8,5 @@
     If you're unsure or have questions do not hesitate to ask for help on Discord
 
     <center>[ Click For Support ](https://trash-guides.info/discord){ .md-button .md-button--primary }</center>
+    <center>[![Discord chat](https://img.shields.io/discord/492590071455940612?style=for-the-badge&color=4051B5&logo=discord){ .off-glb }](https://trash-guides.info/discord){:target="\_blank" rel="noopener noreferrer"}</center>
 <!-- markdownlint-enable MD041-->

--- a/includes/support.md
+++ b/includes/support.md
@@ -6,4 +6,5 @@
     <center>If you have questions or suggestions, click the button below to join our Discord server.</center>
 
     <center>[ Click For Support ](https://trash-guides.info/discord){ .md-button .md-button--primary }</center>
+    <center>[![Discord chat](https://img.shields.io/discord/492590071455940612?style=for-the-badge&color=4051B5&logo=discord){ .off-glb }](https://trash-guides.info/discord){:target="\_blank" rel="noopener noreferrer"}</center>
 <!-- markdownlint-enable MD041-->


### PR DESCRIPTION
started by switching to worker-based discord shields that fetch from discords public API

now shields.io seems to work again, so restored those

- [x] restore shields to other pages if necessary
