### PR TITLE
feat(guides): Add Lidarr redirect to Davo's Community Lidarr Guide

### DIFF
--- a/docs/.pages
+++ b/docs/.pages
@@ -3,6 +3,7 @@ nav:
   - Radarr
   - Sonarr
   - Prowlarr
+  - Lidarr
   - Bazarr
   - Downloaders
   - Plex

--- a/docs/Lidarr/index.md
+++ b/docs/Lidarr/index.md
@@ -6,7 +6,7 @@
 
 !!! info "Lidarr is a music collection manager for Usenet and BitTorrent users. It can monitor multiple RSS feeds for new tracks from your favorite artists and will grab, sort and rename them. It can also be configured to automatically upgrade the quality of files already downloaded when a better quality format becomes available."
 
-For Installation and Quick Start Guide please check the official [WikiArr](https://wiki.servarr.com/en/lidarr){:target="\_blank" rel="noopener noreferrer"}
+For Installation and Quick Start Guide please check the official [WikiArr](https://wiki.servarr.com/lidarr){:target="\_blank" rel="noopener noreferrer"}
 
 ---
 

--- a/docs/Lidarr/index.md
+++ b/docs/Lidarr/index.md
@@ -1,0 +1,41 @@
+# Lidarr
+
+!!! failure "TRaSH Guides do not have any guides related to Lidarr.<br>We suggest that you use [Davo's Community Lidarr Guide](https://wiki.servarr.com/lidarr/community-guide "Like TRaSH Guides, but Davo for Lidarr"){:target="\_blank" rel="noopener noreferrer"}"
+
+---
+
+!!! info "Lidarr is a music collection manager for Usenet and BitTorrent users. It can monitor multiple RSS feeds for new tracks from your favorite artists and will grab, sort and rename them. It can also be configured to automatically upgrade the quality of files already downloaded when a better quality format becomes available."
+
+For Installation and Quick Start Guide please check the official [WikiArr](https://wiki.servarr.com/en/lidarr){:target="\_blank" rel="noopener noreferrer"}
+
+---
+
+## Master
+
+![Current Master/Stable](https://img.shields.io/badge/dynamic/json?color=4051B5&style=for-the-badge&label=Master&query=%24%5B0%5D.version&url=https://lidarr.servarr.com/v1/update/master/changes){ .off-glb }
+
+(Default/Stable): It has been tested by users on the develop and nightly branches and it’s not known to have any major issues. This version will receive updates approximately monthly. On GitHub, this is the `master` branch.
+
+## Develop
+
+![Current Develop/Beta](https://img.shields.io/badge/dynamic/json?color=4051B5&style=for-the-badge&label=Develop&query=%24%5B0%5D.version&url=https://lidarr.servarr.com/v1/update/develop/changes){ .off-glb }
+
+(Beta): This is the testing edge. Released after being tested in the nightly branch to ensure no immediate issues. New features and bug fixes are released here first after nightly. It can be considered semi-stable but is still `beta`. This version will receive updates either weekly or biweekly depending on development.
+
+!!! warning "**Warning: You may not be able to go back to `master` after switching to this branch.** On GitHub, this is a snapshot of the `develop` branch at a specific point in time."
+
+## Nightly
+
+![Current Nightly/Unstable](https://img.shields.io/badge/dynamic/json?color=4051B5&style=for-the-badge&label=Nightly&query=%24%5B0%5D.version&url=https://lidarr.servarr.com/v1/update/nightly/changes){ .off-glb }
+
+(Alpha/Unstable) : This is the bleeding edge. It is released as soon as the code is committed and passes all automated tests. This build may have not been used by us or other users yet. There is no guarantee that it will even run in some cases. This branch is only recommended for advanced users. Issues and self-investigation are expected in this branch.
+
+**_Use this branch only if you know what you are doing and are willing to get your hands dirty to recover a failed update._**
+
+This version is updated immediately.
+
+!!! danger "**Warning: You may not be able to go back to `master` after switching to this branch.** On GitHub, this is the `develop` branch."
+
+### How do I update Lidarr
+
+External link to the official [WikiArr](https://wiki.servarr.com/en/lidarr/faq#how-do-i-update-lidarr){:target="\_blank" rel="noopener noreferrer"}.


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->

Many people asked if TRaSH Guides has a guide for Lidarr, so someone suggested adding a redirect to [Davo's Community Lidarr Guide](https://wiki.servarr.com/lidarr/community-guide "Like TRaSH Guides, but Davo for Lidarr")

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

## Open Questions and Pre-Merge TODOs

Added Lidarr redirect to Davo's Community Lidarr Guide

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
