### PR TITLE
feat(guides): Move KRaLiMaRKo to Radarr Remux Tier 03 and expand Hybrid CF matching to include Bluray qualities

### DIFF
--- a/docs/json/radarr/cf/hybrid.json
+++ b/docs/json/radarr/cf/hybrid.json
@@ -25,12 +25,12 @@
       }
     },
     {
-      "name": "Remux",
-      "implementation": "QualityModifierSpecification",
+      "name": "Bluray",
+      "implementation": "SourceSpecification",
       "negate": false,
-      "required": true,
+      "required": false,
       "fields": {
-        "value": 5
+        "value": 9
       }
     }
   ]

--- a/docs/json/radarr/cf/remux-tier-02.json
+++ b/docs/json/radarr/cf/remux-tier-02.json
@@ -26,15 +26,6 @@
       }
     },
     {
-      "name": "KRaLiMaRKo",
-      "implementation": "ReleaseGroupSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "^(KRaLiMaRKo)$"
-      }
-    },
-    {
       "name": "NCmt",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,

--- a/docs/json/radarr/cf/remux-tier-03.json
+++ b/docs/json/radarr/cf/remux-tier-03.json
@@ -53,6 +53,15 @@
       }
     },
     {
+      "name": "KRaLiMaRKo",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(KRaLiMaRKo)$"
+      }
+    },
+    {
       "name": "NTb",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,

--- a/docs/json/sonarr/cf/hybrid.json
+++ b/docs/json/sonarr/cf/hybrid.json
@@ -28,9 +28,18 @@
       "name": "Remux",
       "implementation": "SourceSpecification",
       "negate": false,
-      "required": true,
+      "required": false,
       "fields": {
         "value": 7
+      }
+    },
+    {
+      "name": "Bluray",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 6
       }
     }
   ]


### PR DESCRIPTION
# Pull Request

## Purpose

Resolve: #1996 and #1997 

## Approach

- Move KRaLiMaRKo from Radarr Remux Tier 02 to Radarr Remux Tier 03 custom format
- Amend Hybrid custom formats for Sonarr and Radarr to also match Bluray qualities
- Tested in Sonarr and Radarr test instances

## Open Questions and Pre-Merge TODOs

None

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
