### PR TITLE
fix(Revert): "fix(starr): Moved webdl and webrip into Amazon regex to prevent incorrect matches"

### DIFF
--- a/docs/json/radarr/cf/amzn.json
+++ b/docs/json/radarr/cf/amzn.json
@@ -9,7 +9,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\b(amzn|amazon(hd)?)\\b[ ._-]web[ ._-]?(dl|rip)?\\b"
+        "value": "\\b(amzn|amazon(hd)?)\\b"
       }
     },
     {

--- a/docs/json/sonarr/cf/amzn.json
+++ b/docs/json/sonarr/cf/amzn.json
@@ -13,7 +13,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\b(amzn|amazon(hd)?)\\b[ ._-]web[ ._-]?(dl|rip)?\\b"
+        "value": "\\b(amzn|amazon(hd)?)\\b"
       }
     },
     {


### PR DESCRIPTION
Reverts TRaSH-Guides/Guides#1950

Major breaking change. Prevents future AMZN renames. This was not tested in Sonarr prior to merging and breaks renaming