### PR TITLE
fix(Revert): "chore(starr): Improve streaming service CFs"

### DIFF
--- a/docs/json/radarr/cf/atvp.json
+++ b/docs/json/radarr/cf/atvp.json
@@ -9,7 +9,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\b((atvp|aptv)\\b|Apple[ ._-]TV\\+)[ ._-]web[ ._-]?(dl|rip)?\\b"
+        "value": "\\b(atvp|aptv|Apple TV\\+)\\b"
       }
     },
     {

--- a/docs/json/radarr/cf/crav.json
+++ b/docs/json/radarr/cf/crav.json
@@ -1,6 +1,6 @@
 {
   "trash_id": "f6ff65b3f4b464a79dcc75950fe20382",
-  "trash_regex": "https://regex101.com/r/eymcie/latest",
+  "trash_regex": "https://regex101.com/r/eymcie/1",
   "name": "CRAV",
   "includeCustomFormatWhenRenaming": true,
   "specifications": [

--- a/docs/json/radarr/cf/dsnp.json
+++ b/docs/json/radarr/cf/dsnp.json
@@ -9,7 +9,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\b((dsnp|dsny|disney)\\b|Disney\\+)[ ._-]web[ ._-]?(dl|rip)?\\b"
+        "value": "\\b(dsnp|dsny|disney|Disney\\+)\\b"
       }
     },
     {

--- a/docs/json/radarr/cf/fod.json
+++ b/docs/json/radarr/cf/fod.json
@@ -1,6 +1,6 @@
 {
   "trash_id": "917d1f2c845b2b466036b0cc2d7c72a3",
-  "trash_regex": "https://regex101.com/r/kgngPG/latest",
+  "trash_regex": "https://regex101.com/r/kgngPG/1",
   "name": "FOD",
   "includeCustomFormatWhenRenaming": true,
   "specifications": [

--- a/docs/json/radarr/cf/hbo.json
+++ b/docs/json/radarr/cf/hbo.json
@@ -9,7 +9,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\b(hbo)(?![ ._-]max)\\b[ ._-]web[ ._-]?(dl|rip)?\\b"
+        "value": "\\b(hbo)(?![ ._-]max)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)"
       }
     },
     {

--- a/docs/json/radarr/cf/hmax.json
+++ b/docs/json/radarr/cf/hmax.json
@@ -9,7 +9,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\b(hmax|hbom|hbo[ ._-]?max)\\b[ ._-]web[ ._-]?(dl|rip)?\\b"
+        "value": "\\b(hmax|hbom|hbo[ ._-]?max)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)"
       }
     },
     {

--- a/docs/json/radarr/cf/htsr.json
+++ b/docs/json/radarr/cf/htsr.json
@@ -1,6 +1,6 @@
 {
   "trash_id": "834b2c0ba0a8596029b4479a29e1a032",
-  "trash_regex": "https://regex101.com/r/PNiRKh/latest",
+  "trash_regex": "https://regex101.com/r/PNiRKh/1",
   "name": "HTSR",
   "includeCustomFormatWhenRenaming": true,
   "specifications": [

--- a/docs/json/radarr/cf/ip.json
+++ b/docs/json/radarr/cf/ip.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "6185878161f1e2eef9cd0641a0d09eae",
-  "trash_regex": "https://regex101.com/r/iuUsmT/latest",
   "name": "IP",
   "includeCustomFormatWhenRenaming": true,
   "specifications": [
@@ -10,7 +9,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\b(ip(layer)?)\\b[ ._-]web[ ._-]?(dl|rip)?\\b"
+        "value": "\\b(ip|iplayer)\\b"
       }
     },
     {

--- a/docs/json/radarr/cf/it.json
+++ b/docs/json/radarr/cf/it.json
@@ -9,7 +9,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\b(it(unes)?)\\b[ ._-]web[ ._-]?(dl|rip)?\\b"
+        "value": "\\b(it|itunes)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)"
       }
     },
     {

--- a/docs/json/radarr/cf/itvx.json
+++ b/docs/json/radarr/cf/itvx.json
@@ -1,6 +1,6 @@
 {
   "trash_id": "c3492a26af412e385404eade438ec51c",
-  "trash_regex": "https://regex101.com/r/WzmpCx/latest",
+  "trash_regex": "https://regex101.com/r/WzmpCx/1",
   "name": "ITVX",
   "includeCustomFormatWhenRenaming": true,
   "specifications": [
@@ -10,7 +10,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\b(ITV(X)?)\\b[ ._-]web[ ._-]?(dl|rip)?\\b"
+        "value": "\\bITV(X)?\\b[ ._-]web[ ._-]?(dl|rip)?\\b"
       }
     },
     {

--- a/docs/json/radarr/cf/max.json
+++ b/docs/json/radarr/cf/max.json
@@ -1,6 +1,6 @@
 {
   "trash_id": "6a061313d22e51e0f25b7cd4dc065233",
-  "trash_regex": "https://regex101.com/r/fa649l/latest",
+  "trash_regex": "https://regex101.com/r/fa649l/1",
   "name": "MAX",
   "includeCustomFormatWhenRenaming": true,
   "specifications": [
@@ -10,7 +10,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\b((?<!hbo[ ._-])max)\\b[ ._-]web[ ._-]?(dl|rip)?\\b"
+        "value": "\\b((?<!hbo[ ._-])max)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)"
       }
     },
     {

--- a/docs/json/radarr/cf/ovid.json
+++ b/docs/json/radarr/cf/ovid.json
@@ -1,6 +1,6 @@
 {
   "trash_id": "fbca986396c5e695ef7b2def3c755d01",
-  "trash_regex": "https://regex101.com/r/hWHpjV/latest",
+  "trash_regex": "https://regex101.com/r/hWHpjV/1",
   "name": "OViD",
   "includeCustomFormatWhenRenaming": true,
   "specifications": [

--- a/docs/json/radarr/cf/pcok.json
+++ b/docs/json/radarr/cf/pcok.json
@@ -9,7 +9,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\b(pcok|peacock)\\b[ ._-]web[ ._-]?(dl|rip)?\\b"
+        "value": "\\b(pcok|peacock)\\b"
       }
     },
     {

--- a/docs/json/radarr/cf/pmtp.json
+++ b/docs/json/radarr/cf/pmtp.json
@@ -1,6 +1,5 @@
 {
   "trash_id": "e36a0ba1bc902b26ee40818a1d59b8bd",
-  "trash_regex": "https://regex101.com/r/3EhY8J/latest",
   "name": "PMTP",
   "includeCustomFormatWhenRenaming": true,
   "specifications": [
@@ -10,7 +9,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\b((pmtp|Paramount[ ._-]Plus)\\b|Paramount\\+)[ ._-]web[ ._-]?(dl|rip)\\b"
+        "value": "\\b(pmtp|Paramount Plus)\\b"
       }
     },
     {

--- a/docs/json/radarr/cf/stan.json
+++ b/docs/json/radarr/cf/stan.json
@@ -1,6 +1,6 @@
 {
   "trash_id": "c2863d2a50c9acad1fb50e53ece60817",
-  "trash_regex": "https://regex101.com/r/IMS7Or/latest",
+  "trash_regex": "https://regex101.com/r/IMS7Or/1",
   "name": "STAN",
   "includeCustomFormatWhenRenaming": true,
   "specifications": [

--- a/docs/json/radarr/cf/tver.json
+++ b/docs/json/radarr/cf/tver.json
@@ -1,6 +1,6 @@
 {
   "trash_id": "f1b0bae9bc222dab32c1b38b5a7a1088",
-  "trash_regex": "https://regex101.com/r/ZdWC9D/latest",
+  "trash_regex": "https://regex101.com/r/ZdWC9D/1",
   "name": "TVer",
   "includeCustomFormatWhenRenaming": true,
   "specifications": [

--- a/docs/json/radarr/cf/u-next.json
+++ b/docs/json/radarr/cf/u-next.json
@@ -1,6 +1,6 @@
 {
   "trash_id": "279bda7434fd9075786de274e6c3c202",
-  "trash_regex": "https://regex101.com/r/04ZSLm/latest",
+  "trash_regex": "https://regex101.com/r/04ZSLm/1",
   "name": "U-NEXT",
   "includeCustomFormatWhenRenaming": true,
   "specifications": [

--- a/docs/json/sonarr/cf/4od.json
+++ b/docs/json/sonarr/cf/4od.json
@@ -3,7 +3,7 @@
   "trash_scores": {
     "default": 50
   },
-  "trash_regex": "https://regex101.com/r/pa5TPZ/latest",
+  "trash_regex": "https://regex101.com/r/pa5TPZ/1",
   "name": "4OD",
   "includeCustomFormatWhenRenaming": true,
   "specifications": [

--- a/docs/json/sonarr/cf/all4.json
+++ b/docs/json/sonarr/cf/all4.json
@@ -3,7 +3,7 @@
   "trash_scores": {
     "default": 50
   },
-  "trash_regex": "https://regex101.com/r/pUDbbp/latest",
+  "trash_regex": "https://regex101.com/r/pUDbbp/1",
   "name": "ALL4",
   "includeCustomFormatWhenRenaming": true,
   "specifications": [

--- a/docs/json/sonarr/cf/atvp.json
+++ b/docs/json/sonarr/cf/atvp.json
@@ -12,7 +12,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\b((atvp|aptv)\\b|Apple[ ._-]TV\\+)[ ._-]web[ ._-]?(dl|rip)?\\b"
+        "value": "\\b(atvp|aptv|Apple TV\\+)\\b"
       }
     },
     {

--- a/docs/json/sonarr/cf/bglobal.json
+++ b/docs/json/sonarr/cf/bglobal.json
@@ -4,15 +4,6 @@
   "includeCustomFormatWhenRenaming": true,
   "specifications": [
     {
-      "name": "B-Global",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": false,
-      "required": true,
-      "fields": {
-        "value": "\\b(B[ ._-]?Global)\\b"
-      }
-    },
-    {
       "name": "WEBDL",
       "implementation": "SourceSpecification",
       "negate": false,
@@ -37,6 +28,15 @@
       "required": false,
       "fields": {
         "value": 1
+      }
+    },
+    {
+      "name": "B-Global",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": true,
+      "fields": {
+        "value": "\\b(B[ .-]?Global)\\b"
       }
     }
   ]

--- a/docs/json/sonarr/cf/bilibili.json
+++ b/docs/json/sonarr/cf/bilibili.json
@@ -4,15 +4,6 @@
   "includeCustomFormatWhenRenaming": true,
   "specifications": [
     {
-      "name": "Bilibili",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": false,
-      "required": true,
-      "fields": {
-        "value": "\\b(Bilibili)\\b"
-      }
-    },
-    {
       "name": "WEBDL",
       "implementation": "SourceSpecification",
       "negate": false,
@@ -37,6 +28,15 @@
       "required": false,
       "fields": {
         "value": 1
+      }
+    },
+    {
+      "name": "Bilibili",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": true,
+      "fields": {
+        "value": "\\b(Bilibili)\\b"
       }
     }
   ]

--- a/docs/json/sonarr/cf/cc.json
+++ b/docs/json/sonarr/cf/cc.json
@@ -3,7 +3,7 @@
   "trash_scores": {
     "default": 50
   },
-  "trash_regex": "https://regex101.com/r/A3TRwE/latest",
+  "trash_regex": "https://regex101.com/r/A3TRwE/1",
   "name": "CC",
   "includeCustomFormatWhenRenaming": true,
   "specifications": [

--- a/docs/json/sonarr/cf/cr.json
+++ b/docs/json/sonarr/cf/cr.json
@@ -7,15 +7,6 @@
   "includeCustomFormatWhenRenaming": true,
   "specifications": [
     {
-      "name": "Crunchyroll",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": false,
-      "required": true,
-      "fields": {
-        "value": "\\b(C(runchy)?[ ._-]?R(oll)?)\\b"
-      }
-    },
-    {
       "name": "WEBDL",
       "implementation": "SourceSpecification",
       "negate": false,
@@ -40,6 +31,15 @@
       "required": false,
       "fields": {
         "value": 1
+      }
+    },
+    {
+      "name": "Crunchyroll",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": true,
+      "fields": {
+        "value": "\\b(C(runchy)?[ .-]?R(oll)?)\\b"
       }
     }
   ]

--- a/docs/json/sonarr/cf/crav.json
+++ b/docs/json/sonarr/cf/crav.json
@@ -3,7 +3,7 @@
   "trash_scores": {
     "default": 50
   },
-  "trash_regex": "https://regex101.com/r/eymcie/latest",
+  "trash_regex": "https://regex101.com/r/eymcie/1",
   "name": "CRAV",
   "includeCustomFormatWhenRenaming": true,
   "specifications": [

--- a/docs/json/sonarr/cf/dcu.json
+++ b/docs/json/sonarr/cf/dcu.json
@@ -12,7 +12,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\b(dcu|DC[ ._-]Universe)\\b"
+        "value": "\\b(dcu|DC Universe)\\b"
       }
     },
     {

--- a/docs/json/sonarr/cf/dsnp.json
+++ b/docs/json/sonarr/cf/dsnp.json
@@ -13,7 +13,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\b((dsnp|dsny|disney)\\b|Disney\\+)[ ._-]web[ ._-]?(dl|rip)?\\b"
+        "value": "\\b(dsnp|dsny|disney|Disney\\+)\\b"
       }
     },
     {

--- a/docs/json/sonarr/cf/fod.json
+++ b/docs/json/sonarr/cf/fod.json
@@ -3,7 +3,7 @@
   "trash_scores": {
     "default": 50
   },
-  "trash_regex": "https://regex101.com/r/CbFoaJ/latest",
+  "trash_regex": "https://regex101.com/r/CbFoaJ/1",
   "name": "FOD",
   "includeCustomFormatWhenRenaming": true,
   "specifications": [

--- a/docs/json/sonarr/cf/french-adn.json
+++ b/docs/json/sonarr/cf/french-adn.json
@@ -8,15 +8,6 @@
   "includeCustomFormatWhenRenaming": true,
   "specifications": [
     {
-      "name": "ADN",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": false,
-      "required": true,
-      "fields": {
-        "value": "\\b(ADN)\\b"
-      }
-    },
-    {
       "name": "WEBDL",
       "implementation": "SourceSpecification",
       "negate": false,
@@ -41,6 +32,15 @@
       "required": false,
       "fields": {
         "value": 1
+      }
+    },
+    {
+      "name": "ADN",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": true,
+      "fields": {
+        "value": "\\b(ADN)\\b"
       }
     }
   ]

--- a/docs/json/sonarr/cf/french-canalplus.json
+++ b/docs/json/sonarr/cf/french-canalplus.json
@@ -1,27 +1,9 @@
 {
   "trash_id": "f27d46a831e6b16fa3fee2c4e5d10984",
-  "trash_regex": "https://regex101.com/r/UYB7E7/latest",
+  "trash_regex": "https://regex101.com/r/UYB7E7/1",
   "name": "CANAL+",
   "includeCustomFormatWhenRenaming": true,
   "specifications": [
-    {
-      "name": "CANAL+",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "\\b(C(?:anal)?[ ._-]?(Plus|\\+))[ ._-]"
-      }
-    },
-    {
-      "name": "MyCANAL",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "\\b(MyCANAL)\\b"
-      }
-    },
     {
       "name": "WEBDL",
       "implementation": "SourceSpecification",
@@ -38,6 +20,24 @@
       "required": false,
       "fields": {
         "value": 4
+      }
+    },
+    {
+      "name": "CANAL+",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(C(?:anal)?[ .-]?(Plus|\\+))[ .]"
+      }
+    },
+    {
+      "name": "MyCANAL",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(MyCANAL)\\b"
       }
     },
     {

--- a/docs/json/sonarr/cf/french-rtbf.json
+++ b/docs/json/sonarr/cf/french-rtbf.json
@@ -4,15 +4,6 @@
   "includeCustomFormatWhenRenaming": true,
   "specifications": [
     {
-      "name": "Radio Télévision Belge Francophone",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": false,
-      "required": true,
-      "fields": {
-        "value": "\\b(RTBF|AUVIO)\\b"
-      }
-    },
-    {
       "name": "WEBDL",
       "implementation": "SourceSpecification",
       "negate": false,
@@ -28,6 +19,15 @@
       "required": false,
       "fields": {
         "value": 4
+      }
+    },
+    {
+      "name": "Radio Télévision Belge Francophone",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": true,
+      "fields": {
+        "value": "\\b(RTBF|AUVIO)\\b"
       }
     }
   ]

--- a/docs/json/sonarr/cf/french-salto.json
+++ b/docs/json/sonarr/cf/french-salto.json
@@ -4,15 +4,6 @@
   "includeCustomFormatWhenRenaming": true,
   "specifications": [
     {
-      "name": "SALTO",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": false,
-      "required": true,
-      "fields": {
-        "value": "\\b(SALTO)\\b"
-      }
-    },
-    {
       "name": "WEBDL",
       "implementation": "SourceSpecification",
       "negate": false,
@@ -28,6 +19,15 @@
       "required": false,
       "fields": {
         "value": 4
+      }
+    },
+    {
+      "name": "SALTO",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": true,
+      "fields": {
+        "value": "\\b(SALTO)\\b"
       }
     }
   ]

--- a/docs/json/sonarr/cf/french-wkn.json
+++ b/docs/json/sonarr/cf/french-wkn.json
@@ -4,15 +4,6 @@
   "includeCustomFormatWhenRenaming": true,
   "specifications": [
     {
-      "name": "WKN",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": false,
-      "required": true,
-      "fields": {
-        "value": "\\b(WKN|Waka(nim)?)\\b"
-      }
-    },
-    {
       "name": "WEBDL",
       "implementation": "SourceSpecification",
       "negate": false,
@@ -37,6 +28,15 @@
       "required": false,
       "fields": {
         "value": 1
+      }
+    },
+    {
+      "name": "WKN",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": true,
+      "fields": {
+        "value": "\\b(WKN|Waka(nim)?)\\b"
       }
     }
   ]

--- a/docs/json/sonarr/cf/funi.json
+++ b/docs/json/sonarr/cf/funi.json
@@ -7,15 +7,6 @@
   "includeCustomFormatWhenRenaming": true,
   "specifications": [
     {
-      "name": "Funimation",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": false,
-      "required": true,
-      "fields": {
-        "value": "\\b(FUNi(mation)?)\\b"
-      }
-    },
-    {
       "name": "WEBDL",
       "implementation": "SourceSpecification",
       "negate": false,
@@ -40,6 +31,15 @@
       "required": false,
       "fields": {
         "value": 1
+      }
+    },
+    {
+      "name": "Funimation",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": true,
+      "fields": {
+        "value": "\\b(FUNi(mation)?)\\b"
       }
     }
   ]

--- a/docs/json/sonarr/cf/hbo.json
+++ b/docs/json/sonarr/cf/hbo.json
@@ -12,7 +12,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\b(hbo)(?![ ._-]max)\\b(?=[ ._-]web[ ._-]?(dl|rip)?\\b)"
+        "value": "\\b(hbo)(?![ ._-]max)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)"
       }
     },
     {

--- a/docs/json/sonarr/cf/hidive.json
+++ b/docs/json/sonarr/cf/hidive.json
@@ -4,15 +4,6 @@
   "includeCustomFormatWhenRenaming": true,
   "specifications": [
     {
-      "name": "HIDIVE",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": false,
-      "required": true,
-      "fields": {
-        "value": "\\b(HIDI(VE)?)\\b"
-      }
-    },
-    {
       "name": "WEBDL",
       "implementation": "SourceSpecification",
       "negate": false,
@@ -37,6 +28,15 @@
       "required": false,
       "fields": {
         "value": 1
+      }
+    },
+    {
+      "name": "HIDIVE",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": true,
+      "fields": {
+        "value": "\\b(HIDI(VE)?)\\b"
       }
     }
   ]

--- a/docs/json/sonarr/cf/hmax.json
+++ b/docs/json/sonarr/cf/hmax.json
@@ -12,7 +12,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\b(hmax|hbom|hbo[ ._-]?max)\\b[ ._-]web[ ._-]?(dl|rip)?\\b"
+        "value": "\\b(hmax|hbom|hbo[ ._-]?max)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)"
       }
     },
     {

--- a/docs/json/sonarr/cf/htsr.json
+++ b/docs/json/sonarr/cf/htsr.json
@@ -1,6 +1,6 @@
 {
   "trash_id": "4404ad44d87ccbb82746e180713112fb",
-  "trash_regex": "https://regex101.com/r/PNiRKh/latest",
+  "trash_regex": "https://regex101.com/r/PNiRKh/1",
   "trash_scores": {
     "default": 50
   },

--- a/docs/json/sonarr/cf/ip.json
+++ b/docs/json/sonarr/cf/ip.json
@@ -3,7 +3,6 @@
   "trash_scores": {
     "default": 50
   },
-  "trash_regex": "https://regex101.com/r/iuUsmT/latest",
   "name": "IP",
   "includeCustomFormatWhenRenaming": true,
   "specifications": [
@@ -13,7 +12,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\b(ip(layer)?)\\b[ ._-]web[ ._-]?(dl|rip)?\\b"
+        "value": "\\b(ip|iplayer)\\b"
       }
     },
     {

--- a/docs/json/sonarr/cf/it.json
+++ b/docs/json/sonarr/cf/it.json
@@ -12,25 +12,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\b(it(unes)?)\\b[ ._-]web[ ._-]?(dl|rip)?\\b"
-      }
-    },
-    {
-      "name": "WEBDL",
-      "implementation": "SourceSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": 3
-      }
-    },
-    {
-      "name": "WEBRIP",
-      "implementation": "SourceSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": 4
+        "value": "\\b(it|itunes)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)"
       }
     }
   ]

--- a/docs/json/sonarr/cf/itvx.json
+++ b/docs/json/sonarr/cf/itvx.json
@@ -3,7 +3,7 @@
   "trash_scores": {
     "default": 50
   },
-  "trash_regex": "https://regex101.com/r/Nw3FiP/latest",
+  "trash_regex": "https://regex101.com/r/Nw3FiP/1",
   "name": "ITVX",
   "includeCustomFormatWhenRenaming": true,
   "specifications": [
@@ -13,7 +13,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\b(ITV(X)?)\\b[ ._-]web[ ._-]?(dl|rip)?\\b"
+        "value": "\\bITV(X)?\\b[ ._-]web[ ._-]?(dl|rip)?\\b"
       }
     },
     {

--- a/docs/json/sonarr/cf/max.json
+++ b/docs/json/sonarr/cf/max.json
@@ -3,7 +3,7 @@
   "trash_scores": {
     "default": 90
   },
-  "trash_regex": "https://regex101.com/r/fa649l/latest",
+  "trash_regex": "https://regex101.com/r/fa649l/1",
   "name": "MAX",
   "includeCustomFormatWhenRenaming": true,
   "specifications": [
@@ -13,7 +13,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\b((?<!hbo[ ._-])max)\\b[ ._-]web[ ._-]?(dl|rip)?\\b"
+        "value": "\\b((?<!hbo[ ._-])max)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)"
       }
     },
     {

--- a/docs/json/sonarr/cf/nlz.json
+++ b/docs/json/sonarr/cf/nlz.json
@@ -12,7 +12,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\b(nlz(iet)?)\\b"
+        "value": "\\b(nlz|NLZiet)\\b"
       }
     },
     {

--- a/docs/json/sonarr/cf/ovid.json
+++ b/docs/json/sonarr/cf/ovid.json
@@ -3,7 +3,7 @@
   "trash_scores": {
     "default": 50
   },
-  "trash_regex": "https://regex101.com/r/hWHpjV/latest",
+  "trash_regex": "https://regex101.com/r/hWHpjV/1",
   "name": "OViD",
   "includeCustomFormatWhenRenaming": true,
   "specifications": [

--- a/docs/json/sonarr/cf/pcok.json
+++ b/docs/json/sonarr/cf/pcok.json
@@ -12,7 +12,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\b(pcok|Peacock[ ._-]TV)\\b[ ._-]web[ ._-]?(dl|rip)?\\b"
+        "value": "\\b(pcok|Peacock TV)\\b"
       }
     },
     {

--- a/docs/json/sonarr/cf/pmtp.json
+++ b/docs/json/sonarr/cf/pmtp.json
@@ -12,7 +12,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\b((pmtp|Paramount[ ._-]Plus)\\b|Paramount\\+)[ ._-]web[ ._-]?(dl|rip)\\b"
+        "value": "\\b(pmtp|Paramount\\+)\\b"
       }
     },
     {

--- a/docs/json/sonarr/cf/red.json
+++ b/docs/json/sonarr/cf/red.json
@@ -3,7 +3,7 @@
   "trash_scores": {
     "default": 50
   },
-  "trash_regex": "https://regex101.com/r/GfOSFe/latest",
+  "trash_regex": "https://regex101.com/r/GfOSFe/1",
   "name": "RED",
   "includeCustomFormatWhenRenaming": true,
   "specifications": [
@@ -13,7 +13,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\b(red|youtube[ ._-]red)\\b[ ._-]web[ ._-]?(dl|rip)?\\b"
+        "value": "\\b(red|youtube red)\\b[ ._-]web[ ._-]?(dl|rip)?\\b"
       }
     },
     {

--- a/docs/json/sonarr/cf/sho.json
+++ b/docs/json/sonarr/cf/sho.json
@@ -3,7 +3,7 @@
   "trash_scores": {
     "default": 50
   },
-  "trash_regex": "https://regex101.com/r/kjPPbG/latest",
+  "trash_regex": "https://regex101.com/r/kjPPbG/1",
   "name": "SHO",
   "includeCustomFormatWhenRenaming": true,
   "specifications": [

--- a/docs/json/sonarr/cf/stan.json
+++ b/docs/json/sonarr/cf/stan.json
@@ -3,7 +3,7 @@
   "trash_scores": {
     "default": 60
   },
-  "trash_regex": "https://regex101.com/r/IMS7Or/latest",
+  "trash_regex": "https://regex101.com/r/IMS7Or/1",
   "name": "STAN",
   "includeCustomFormatWhenRenaming": true,
   "specifications": [

--- a/docs/json/sonarr/cf/tver.json
+++ b/docs/json/sonarr/cf/tver.json
@@ -3,7 +3,7 @@
   "trash_scores": {
     "default": 50
   },
-  "trash_regex": "https://regex101.com/r/o9YVOG/latest",
+  "trash_regex": "https://regex101.com/r/o9YVOG/1",
   "name": "TVer",
   "includeCustomFormatWhenRenaming": true,
   "specifications": [

--- a/docs/json/sonarr/cf/u-next.json
+++ b/docs/json/sonarr/cf/u-next.json
@@ -3,7 +3,7 @@
   "trash_scores": {
     "default": 50
   },
-  "trash_regex": "https://regex101.com/r/eQuNMO/latest",
+  "trash_regex": "https://regex101.com/r/eQuNMO/1",
   "name": "U-NEXT",
   "includeCustomFormatWhenRenaming": true,
   "specifications": [


### PR DESCRIPTION
Reverts TRaSH-Guides/Guides#1992

Major breaking change. Prevents future Streaming Services renames. This was not tested in Sonarr prior to merging and breaks renaming.

Poor assumptions and logic was leveraged from https://github.com/TRaSH-Guides/Guides/commit/13780d733da0d3d3ad1abe74503c277c2029c048 / #1950