### PR TITLE
feat(starr-anime): add several RlsGrps to LQ

### DIFF
--- a/docs/json/radarr/cf/anime-lq-groups.json
+++ b/docs/json/radarr/cf/anime-lq-groups.json
@@ -520,12 +520,12 @@
       }
     },
     {
-      "name": "KazeTV",
+      "name": "KAZETV",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,
       "required": false,
       "fields": {
-        "value": "\\b(KazeTV)\\b"
+        "value": "\\b(KAZETV)\\b"
       }
     },
     {

--- a/docs/json/radarr/cf/anime-lq-groups.json
+++ b/docs/json/radarr/cf/anime-lq-groups.json
@@ -691,12 +691,12 @@
       }
     },
     {
-      "name": "Mozzi2",
+      "name": "Moozzi2",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,
       "required": false,
       "fields": {
-        "value": "\\b(Mozzi2)\\b"
+        "value": "\\b(Moozzi2)\\b"
       }
     },
     {

--- a/docs/json/radarr/cf/anime-lq-groups.json
+++ b/docs/json/radarr/cf/anime-lq-groups.json
@@ -520,15 +520,6 @@
       }
     },
     {
-      "name": "KAZETV",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "\\b(KAZETV)\\b"
-      }
-    },
-    {
       "name": "KEKMASTERS",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,

--- a/docs/json/radarr/cf/anime-lq-groups.json
+++ b/docs/json/radarr/cf/anime-lq-groups.json
@@ -340,6 +340,15 @@
       }
     },
     {
+      "name": "Emmid",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Emmid\\]|-Emmid\\b"
+      }
+    },
+    {
       "name": "ExREN",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,
@@ -493,12 +502,30 @@
       }
     },
     {
+      "name": "Kallango",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Kallango\\]|-Kallango\\b"
+      }
+    },
+    {
       "name": "Kanjouteki",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,
       "required": false,
       "fields": {
         "value": "\\b(Kanjouteki)\\b"
+      }
+    },
+    {
+      "name": "KazeTV",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(KazeTV)\\b"
       }
     },
     {
@@ -670,6 +697,15 @@
       "required": false,
       "fields": {
         "value": "\\b(Modders[ .-]?Bay)\\b"
+      }
+    },
+    {
+      "name": "Mozzi2",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Mozzi2)\\b"
       }
     },
     {
@@ -988,6 +1024,15 @@
       }
     },
     {
+      "name": "Sokudo",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Sokudo\\]|-Sokudo\\b"
+      }
+    },
+    {
       "name": "SRW",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,
@@ -1084,6 +1129,15 @@
       "required": false,
       "fields": {
         "value": "\\[UNBIASED\\]|-UNBIASED\\b"
+      }
+    },
+    {
+      "name": "uP",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[uP\\]"
       }
     },
     {

--- a/docs/json/sonarr/cf/anime-lq-groups.json
+++ b/docs/json/sonarr/cf/anime-lq-groups.json
@@ -520,12 +520,12 @@
       }
     },
     {
-      "name": "KazeTV",
+      "name": "KAZETV",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,
       "required": false,
       "fields": {
-        "value": "\\b(KazeTV)\\b"
+        "value": "\\b(KAZETV)\\b"
       }
     },
     {

--- a/docs/json/sonarr/cf/anime-lq-groups.json
+++ b/docs/json/sonarr/cf/anime-lq-groups.json
@@ -691,12 +691,12 @@
       }
     },
     {
-      "name": "Mozzi2",
+      "name": "Moozzi2",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,
       "required": false,
       "fields": {
-        "value": "\\b(Mozzi2)\\b"
+        "value": "\\b(Moozzi2)\\b"
       }
     },
     {

--- a/docs/json/sonarr/cf/anime-lq-groups.json
+++ b/docs/json/sonarr/cf/anime-lq-groups.json
@@ -520,15 +520,6 @@
       }
     },
     {
-      "name": "KAZETV",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "\\b(KAZETV)\\b"
-      }
-    },
-    {
       "name": "KEKMASTERS",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,

--- a/docs/json/sonarr/cf/anime-lq-groups.json
+++ b/docs/json/sonarr/cf/anime-lq-groups.json
@@ -340,6 +340,15 @@
       }
     },
     {
+      "name": "Emmid",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Emmid\\]|-Emmid\\b"
+      }
+    },
+    {
       "name": "ExREN",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,
@@ -493,12 +502,30 @@
       }
     },
     {
+      "name": "Kallango",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Kallango\\]|-Kallango\\b"
+      }
+    },
+    {
       "name": "Kanjouteki",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,
       "required": false,
       "fields": {
         "value": "\\b(Kanjouteki)\\b"
+      }
+    },
+    {
+      "name": "KazeTV",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(KazeTV)\\b"
       }
     },
     {
@@ -670,6 +697,15 @@
       "required": false,
       "fields": {
         "value": "\\b(Modders[ .-]?Bay)\\b"
+      }
+    },
+    {
+      "name": "Mozzi2",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Mozzi2)\\b"
       }
     },
     {
@@ -988,6 +1024,15 @@
       }
     },
     {
+      "name": "Sokudo",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Sokudo\\]|-Sokudo\\b"
+      }
+    },
+    {
       "name": "SRW",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,
@@ -1084,6 +1129,15 @@
       "required": false,
       "fields": {
         "value": "\\[UNBIASED\\]|-UNBIASED\\b"
+      }
+    },
+    {
+      "name": "uP",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[uP\\]"
       }
     },
     {


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->
Resolve #1995 

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->
Add `Mozzi2`, `uP`, `Kallango`, `Emmid` and `Sokudo` to the `Anime LQ Groups` CF.

- Sokudo - AV1
- Emmid - some releases missing subtitles, only have dubtitles, includes many unnecessary language tracks, not consistent with track labelling and order
- Kallango/uP - Not on Nyaa and I cannot figure out why I initially banned them. My guess though is that both do upscales which replace older shows. Kallango seems to be exclusively on one of the unnameables, but they have some non-anime releases on others where it is just pt-BR releases.
- Moozzi2 - As it was getting uploaded to usenet, was replacing a bunch of people's releases with low quality raws.

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
