### PR TITLE
feat(starr-anime): add Shiniori-Raws to Anime Raws CF

### DIFF
--- a/docs/json/radarr/cf/anime-raws.json
+++ b/docs/json/radarr/cf/anime-raws.json
@@ -167,6 +167,15 @@
       "fields": {
         "value": "Seicher[ ._-]?(Raws)"
       }
+    },
+    {
+      "name": "Shiniori-Raws",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "Shiniori[ ._-]?(Raws)"
+      }
     }
   ]
 }

--- a/docs/json/sonarr/cf/anime-raws.json
+++ b/docs/json/sonarr/cf/anime-raws.json
@@ -167,6 +167,15 @@
       "fields": {
         "value": "Seicher[ ._-]?(Raws)"
       }
+    },
+    {
+      "name": "Shiniori-Raws",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "Shiniori[ ._-]?(Raws)"
+      }
     }
   ]
 }


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->
Resolve #2008 

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->
Add `Shiniori-Raws` to the `Anime Raws` CF for both Sonarr and Radarr.

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
