### PR TITLE
feat(Radarr): Add PTer to Radarr UHD Bluray Tier 03

### DIFF
--- a/docs/json/radarr/cf/uhd-bluray-tier-03.json
+++ b/docs/json/radarr/cf/uhd-bluray-tier-03.json
@@ -73,6 +73,15 @@
       }
     },
     {
+      "name": "PTer",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(PTer)$"
+      }
+    },
+    {
       "name": "SPHD",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,


### PR DESCRIPTION
# Pull Request

## Purpose

To add PTer to Radarr UHD Bluray Tier 03, resolving #1612 

## Approach

Modify the Radarr UHD Bluray Tier 03 custom format to add an optional Release Group match for `PTer`

## Open Questions and Pre-Merge TODOs

None

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
