### PR TITLE
fix(starr): Upscaled CF not matching on certain naming

### DIFF
--- a/docs/json/radarr/cf/upscaled.json
+++ b/docs/json/radarr/cf/upscaled.json
@@ -13,7 +13,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "^(?=.*\\b(HEVC)\\b)(?=.*\\b(AI)\\b)"
+        "value": "(?<=\\b[12]\\d{3}\\b)(?=.*\\b(HEVC)\\b)(?=.*\\b(AI)\\b)"
       }
     },
     {

--- a/docs/json/radarr/cf/upscaled.json
+++ b/docs/json/radarr/cf/upscaled.json
@@ -3,7 +3,7 @@
   "trash_scores": {
     "default": -10000
   },
-  "trash_regex": "https://regex101.com/r/MDx42o/1",
+  "trash_regex": "https://regex101.com/r/MDx42o/latest",
   "name": "Upscaled",
   "includeCustomFormatWhenRenaming": false,
   "specifications": [
@@ -17,12 +17,21 @@
       }
     },
     {
+      "name": "AIUS",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(AIUS)\\b"
+      }
+    },
+    {
       "name": "Regrade",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,
       "required": false,
       "fields": {
-        "value": "\\b(Re-?grade)\\b"
+        "value": "\\b((Upscale)?Re-?graded?)\\b"
       }
     },
     {

--- a/docs/json/sonarr/cf/upscaled.json
+++ b/docs/json/sonarr/cf/upscaled.json
@@ -13,7 +13,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "^(?=.*\\b(HEVC)\\b)(?=.*\\b(AI)\\b)"
+        "value": "(?<=\\b\\d{3,4}p\\b)(?=.*\\b(HEVC)\\b)(?=.*\\b(AI)\\b)"
       }
     },
     {

--- a/docs/json/sonarr/cf/upscaled.json
+++ b/docs/json/sonarr/cf/upscaled.json
@@ -3,7 +3,7 @@
   "trash_scores": {
     "default": -10000
   },
-  "trash_regex": "https://regex101.com/r/xpT0Md/1",
+  "trash_regex": "https://regex101.com/r/xpT0Md/latest",
   "name": "Upscaled",
   "includeCustomFormatWhenRenaming": false,
   "specifications": [
@@ -17,12 +17,21 @@
       }
     },
     {
+      "name": "AIUS",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(AIUS)\\b"
+      }
+    },
+    {
       "name": "Regrade",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,
       "required": false,
       "fields": {
-        "value": "\\b(Re-?grade)\\b"
+        "value": "\\b((Upscale)?Re-?graded?)\\b"
       }
     },
     {


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->
Fix the `Upscaled` CF not matching on certain release naming.

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->
Adjust regex to match on `Upscaleregrade` and variations of it. Additionally added a condition for `AIUS`. Also adjusted the regex for `AI Upscales` to prevent false positives, regex examples for those here:
- [Radarr](https://regex101.com/r/RinDcg/latest)
- [Sonarr](https://regex101.com/r/mpMFKR/latest)

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
