### PR TITLE
feat(guide): Add Groups to LQ

### DIFF
--- a/docs/json/radarr/cf/lq-release-title.json
+++ b/docs/json/radarr/cf/lq-release-title.json
@@ -34,6 +34,15 @@
       }
     },
     {
+      "name": "GalaxyRG",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(GalaxyRG)\\b"
+      }
+    },
+    {
       "name": "jennaortega",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,

--- a/docs/json/radarr/cf/lq.json
+++ b/docs/json/radarr/cf/lq.json
@@ -358,6 +358,15 @@
       }
     },
     {
+      "name": "KC",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(KC)$"
+      }
+    },
+    {
       "name": "KiNGDOM",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,
@@ -646,6 +655,15 @@
       }
     },
     {
+      "name": "SHD",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(SHD)$"
+      }
+    },
+    {
       "name": "ShieldBearer",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,
@@ -706,6 +724,15 @@
       "required": false,
       "fields": {
         "value": "^(TIKO)$"
+      }
+    },
+    {
+      "name": "VECTOR",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(VECTOR)$"
       }
     },
     {

--- a/docs/json/sonarr/cf/lq.json
+++ b/docs/json/sonarr/cf/lq.json
@@ -43,6 +43,15 @@
       }
     },
     {
+      "name": "DepraveD",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(DepraveD)$"
+      }
+    },
+    {
       "name": "EVO",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,
@@ -106,6 +115,15 @@
       }
     },
     {
+      "name": "KC",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(KC)$"
+      }
+    },
+    {
       "name": "MeGusta",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,
@@ -157,6 +175,15 @@
       "required": false,
       "fields": {
         "value": "^(SasukeducK)$"
+      }
+    },
+    {
+      "name": "SHD",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(SHD)$"
       }
     },
     {


### PR DESCRIPTION
- KC: Uses "Ai" ambiguously in release titles
- SHD: Incorrect DV profile usage and incompatible file containers (.ts)
- VECTOR: Uses user-generated dynamic HDR metadata with DaVinci Resolve
- GalaxyRG: Also added to LQ (Release Title) as some releases are badly formatted
- DepraveD: Also added to Sonarr LQ as some TV releases identified

# Pull Request

## Purpose

Resolve:
- #2002
- #2020
- #2021 
- #2022 

## Approach

Add the following groups to LQ as follows:
- KC: Uses "Ai" ambiguously in release titles
- SHD: Incorrect DV profile usage and incompatible file containers (.ts)
- VECTOR: Uses user-generated dynamic HDR metadata with DaVinci Resolve
- GalaxyRG: Also added to LQ (Release Title) as some releases are badly formatted
- DepraveD: Also added to Sonarr LQ as some TV releases identified

## Open Questions and Pre-Merge TODOs

None

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
