### PR TITLE
fix(sonarr): Increase preferred and maximum Sonarr quality definition sizes

### DIFF
--- a/docs/json/sonarr/quality-size/anime.json
+++ b/docs/json/sonarr/quality-size/anime.json
@@ -5,116 +5,116 @@
     {
       "quality": "SDTV",
       "min": 5,
-      "preferred": 395,
-      "max": 400
+      "preferred": 995,
+      "max": 1000
     },
     {
       "quality": "WEBRip-480p",
       "min": 5,
-      "preferred": 395,
-      "max": 400
+      "preferred": 995,
+      "max": 1000
     },
     {
       "quality": "WEBDL-480p",
       "min": 5,
-      "preferred": 395,
-      "max": 400
+      "preferred": 995,
+      "max": 1000
     },
     {
       "quality": "DVD",
       "min": 5,
-      "preferred": 395,
-      "max": 400
+      "preferred": 995,
+      "max": 1000
     },
     {
       "quality": "Bluray-480p",
       "min": 5,
-      "preferred": 395,
-      "max": 400
+      "preferred": 995,
+      "max": 1000
     },
     {
       "quality": "HDTV-720p",
       "min": 5,
-      "preferred": 395,
-      "max": 400
+      "preferred": 995,
+      "max": 1000
     },
     {
       "quality": "HDTV-1080p",
       "min": 5,
-      "preferred": 395,
-      "max": 400
+      "preferred": 995,
+      "max": 1000
     },
     {
       "quality": "WEBRip-720p",
       "min": 5,
-      "preferred": 395,
-      "max": 400
+      "preferred": 995,
+      "max": 1000
     },
     {
       "quality": "WEBDL-720p",
       "min": 5,
-      "preferred": 395,
-      "max": 400
+      "preferred": 995,
+      "max": 1000
     },
     {
       "quality": "Bluray-720p",
       "min": 5,
-      "preferred": 395,
-      "max": 400
+      "preferred": 995,
+      "max": 1000
     },
     {
       "quality": "WEBRip-1080p",
       "min": 5,
-      "preferred": 395,
-      "max": 400
+      "preferred": 995,
+      "max": 1000
     },
     {
       "quality": "WEBDL-1080p",
       "min": 5,
-      "preferred": 395,
-      "max": 400
+      "preferred": 995,
+      "max": 1000
     },
     {
       "quality": "Bluray-1080p",
       "min": 5,
-      "preferred": 395,
-      "max": 400
+      "preferred": 995,
+      "max": 1000
     },
     {
       "quality": "Bluray-1080p Remux",
       "min": 5,
-      "preferred": 395,
-      "max": 400
+      "preferred": 995,
+      "max": 1000
     },
     {
       "quality": "HDTV-2160p",
       "min": 5,
-      "preferred": 395,
-      "max": 400
+      "preferred": 995,
+      "max": 1000
     },
     {
       "quality": "WEBRip-2160p",
       "min": 5,
-      "preferred": 395,
-      "max": 400
+      "preferred": 995,
+      "max": 1000
     },
     {
       "quality": "WEBDL-2160p",
       "min": 5,
-      "preferred": 395,
-      "max": 400
+      "preferred": 995,
+      "max": 1000
     },
     {
       "quality": "Bluray-2160p",
       "min": 5,
-      "preferred": 395,
-      "max": 400
+      "preferred": 995,
+      "max": 1000
     },
     {
       "quality": "Bluray-2160p Remux",
       "min": 5,
-      "preferred": 395,
-      "max": 400
+      "preferred": 995,
+      "max": 1000
     }
   ]
 }

--- a/docs/json/sonarr/quality-size/series.json
+++ b/docs/json/sonarr/quality-size/series.json
@@ -5,86 +5,86 @@
     {
       "quality": "HDTV-720p",
       "min": 10,
-      "preferred": 395,
-      "max": 400
+      "preferred": 995,
+      "max": 1000
     },
     {
       "quality": "HDTV-1080p",
       "min": 15,
-      "preferred": 395,
-      "max": 400
+      "preferred": 995,
+      "max": 1000
     },
     {
       "quality": "WEBRip-720p",
       "min": 10,
-      "preferred": 395,
-      "max": 400
+      "preferred": 995,
+      "max": 1000
     },
     {
       "quality": "WEBDL-720p",
       "min": 10,
-      "preferred": 395,
-      "max": 400
+      "preferred": 995,
+      "max": 1000
     },
     {
       "quality": "Bluray-720p",
       "min": 17.1,
-      "preferred": 395,
-      "max": 400
+      "preferred": 995,
+      "max": 1000
     },
     {
       "quality": "WEBRip-1080p",
       "min": 15,
-      "preferred": 395,
-      "max": 400
+      "preferred": 995,
+      "max": 1000
     },
     {
       "quality": "WEBDL-1080p",
       "min": 15,
-      "preferred": 395,
-      "max": 400
+      "preferred": 995,
+      "max": 1000
     },
     {
       "quality": "Bluray-1080p",
       "min": 50.4,
-      "preferred": 395,
-      "max": 400
+      "preferred": 995,
+      "max": 1000
     },
     {
       "quality": "Bluray-1080p Remux",
       "min": 69.1,
-      "preferred": 395,
-      "max": 400
+      "preferred": 995,
+      "max": 1000
     },
     {
       "quality": "HDTV-2160p",
       "min": 25,
-      "preferred": 395,
-      "max": 400
+      "preferred": 995,
+      "max": 1000
     },
     {
       "quality": "WEBRip-2160p",
       "min": 25,
-      "preferred": 395,
-      "max": 400
+      "preferred": 995,
+      "max": 1000
     },
     {
       "quality": "WEBDL-2160p",
       "min": 25,
-      "preferred": 395,
-      "max": 400
+      "preferred": 995,
+      "max": 1000
     },
     {
       "quality": "Bluray-2160p",
       "min": 94.6,
-      "preferred": 395,
-      "max": 400
+      "preferred": 995,
+      "max": 1000
     },
     {
       "quality": "Bluray-2160p Remux",
       "min": 187.4,
-      "preferred": 395,
-      "max": 400
+      "preferred": 995,
+      "max": 1000
     }
   ]
 }


### PR DESCRIPTION
# Pull Request

## Purpose

To maintain compatibility with Sonarr after it merges an increase to the quality definition ranges - namely that `1000` is now 'Unlimited' where `400` was the previous value.

## Approach

In the Sonarr quality definitions JSON
- Change `395` to `995` for preferred quality
- Change `400` to `1000` for max quality

## Open Questions and Pre-Merge TODOs

None

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
