### PR TITLE
fix(radarr): Increase preferred and maximum Radarr quality definition sizes

### DIFF
--- a/docs/json/radarr/quality-size/movie.json
+++ b/docs/json/radarr/quality-size/movie.json
@@ -5,86 +5,86 @@
     {
       "quality": "HDTV-720p",
       "min": 17.1,
-      "preferred": 399,
-      "max": 400
+      "preferred": 1999,
+      "max": 2000
     },
     {
       "quality": "WEBDL-720p",
       "min": 12.5,
-      "preferred": 399,
-      "max": 400
+      "preferred": 1999,
+      "max": 2000
     },
     {
       "quality": "WEBRip-720p",
       "min": 12.5,
-      "preferred": 399,
-      "max": 400
+      "preferred": 1999,
+      "max": 2000
     },
     {
       "quality": "Bluray-720p",
       "min": 25.7,
-      "preferred": 399,
-      "max": 400
+      "preferred": 1999,
+      "max": 2000
     },
     {
       "quality": "HDTV-1080p",
       "min": 33.8,
-      "preferred": 399,
-      "max": 400
+      "preferred": 1999,
+      "max": 2000
     },
     {
       "quality": "WEBDL-1080p",
       "min": 12.5,
-      "preferred": 399,
-      "max": 400
+      "preferred": 1999,
+      "max": 2000
     },
     {
       "quality": "WEBRip-1080p",
       "min": 12.5,
-      "preferred": 399,
-      "max": 400
+      "preferred": 1999,
+      "max": 2000
     },
     {
       "quality": "Bluray-1080p",
       "min": 50.8,
-      "preferred": 399,
-      "max": 400
+      "preferred": 1999,
+      "max": 2000
     },
     {
       "quality": "Remux-1080p",
       "min": 102,
-      "preferred": 399,
-      "max": 400
+      "preferred": 1999,
+      "max": 2000
     },
     {
       "quality": "HDTV-2160p",
       "min": 85,
-      "preferred": 399,
-      "max": 400
+      "preferred": 1999,
+      "max": 2000
     },
     {
       "quality": "WEBDL-2160p",
       "min": 34.5,
-      "preferred": 399,
-      "max": 400
+      "preferred": 1999,
+      "max": 2000
     },
     {
       "quality": "WEBRip-2160p",
       "min": 34.5,
-      "preferred": 399,
-      "max": 400
+      "preferred": 1999,
+      "max": 2000
     },
     {
       "quality": "Bluray-2160p",
       "min": 102,
-      "preferred": 399,
-      "max": 400
+      "preferred": 1999,
+      "max": 2000
     },
     {
       "quality": "Remux-2160p",
       "min": 187.4,
-      "preferred": 399,
-      "max": 400
+      "preferred": 1999,
+      "max": 2000
     }
   ]
 }

--- a/docs/json/radarr/quality-size/sqp-uhd.json
+++ b/docs/json/radarr/quality-size/sqp-uhd.json
@@ -5,50 +5,50 @@
     {
       "quality": "WEBDL-1080p",
       "min": 12.5,
-      "preferred": 399,
-      "max": 400
+      "preferred": 1999,
+      "max": 2000
     },
     {
       "quality": "WEBRip-1080p",
       "min": 12.5,
-      "preferred": 399,
-      "max": 400
+      "preferred": 1999,
+      "max": 2000
     },
     {
       "quality": "Remux-1080p",
       "min": 136.8,
-      "preferred": 399,
-      "max": 400
+      "preferred": 1999,
+      "max": 2000
     },
     {
       "quality": "HDTV-2160p",
       "min": 85,
-      "preferred": 399,
-      "max": 400
+      "preferred": 1999,
+      "max": 2000
     },
     {
       "quality": "WEBDL-2160p",
       "min": 34.5,
-      "preferred": 399,
-      "max": 400
+      "preferred": 1999,
+      "max": 2000
     },
     {
       "quality": "WEBRip-2160p",
       "min": 34.5,
-      "preferred": 399,
-      "max": 400
+      "preferred": 1999,
+      "max": 2000
     },
     {
       "quality": "Bluray-2160p",
       "min": 102,
-      "preferred": 399,
-      "max": 400
+      "preferred": 1999,
+      "max": 2000
     },
     {
       "quality": "Remux-2160p",
       "min": 187.4,
-      "preferred": 399,
-      "max": 400
+      "preferred": 1999,
+      "max": 2000
     }
   ]
 }

--- a/docs/json/sonarr/quality-size/anime.json
+++ b/docs/json/sonarr/quality-size/anime.json
@@ -5,116 +5,116 @@
     {
       "quality": "SDTV",
       "min": 5,
-      "preferred": 395,
-      "max": 400
+      "preferred": 995,
+      "max": 1000
     },
     {
       "quality": "WEBRip-480p",
       "min": 5,
-      "preferred": 395,
-      "max": 400
+      "preferred": 995,
+      "max": 1000
     },
     {
       "quality": "WEBDL-480p",
       "min": 5,
-      "preferred": 395,
-      "max": 400
+      "preferred": 995,
+      "max": 1000
     },
     {
       "quality": "DVD",
       "min": 5,
-      "preferred": 395,
-      "max": 400
+      "preferred": 995,
+      "max": 1000
     },
     {
       "quality": "Bluray-480p",
       "min": 5,
-      "preferred": 395,
-      "max": 400
+      "preferred": 995,
+      "max": 1000
     },
     {
       "quality": "HDTV-720p",
       "min": 5,
-      "preferred": 395,
-      "max": 400
+      "preferred": 995,
+      "max": 1000
     },
     {
       "quality": "HDTV-1080p",
       "min": 5,
-      "preferred": 395,
-      "max": 400
+      "preferred": 995,
+      "max": 1000
     },
     {
       "quality": "WEBRip-720p",
       "min": 5,
-      "preferred": 395,
-      "max": 400
+      "preferred": 995,
+      "max": 1000
     },
     {
       "quality": "WEBDL-720p",
       "min": 5,
-      "preferred": 395,
-      "max": 400
+      "preferred": 995,
+      "max": 1000
     },
     {
       "quality": "Bluray-720p",
       "min": 5,
-      "preferred": 395,
-      "max": 400
+      "preferred": 995,
+      "max": 1000
     },
     {
       "quality": "WEBRip-1080p",
       "min": 5,
-      "preferred": 395,
-      "max": 400
+      "preferred": 995,
+      "max": 1000
     },
     {
       "quality": "WEBDL-1080p",
       "min": 5,
-      "preferred": 395,
-      "max": 400
+      "preferred": 995,
+      "max": 1000
     },
     {
       "quality": "Bluray-1080p",
       "min": 5,
-      "preferred": 395,
-      "max": 400
+      "preferred": 995,
+      "max": 1000
     },
     {
       "quality": "Bluray-1080p Remux",
       "min": 5,
-      "preferred": 395,
-      "max": 400
+      "preferred": 995,
+      "max": 1000
     },
     {
       "quality": "HDTV-2160p",
       "min": 5,
-      "preferred": 395,
-      "max": 400
+      "preferred": 995,
+      "max": 1000
     },
     {
       "quality": "WEBRip-2160p",
       "min": 5,
-      "preferred": 395,
-      "max": 400
+      "preferred": 995,
+      "max": 1000
     },
     {
       "quality": "WEBDL-2160p",
       "min": 5,
-      "preferred": 395,
-      "max": 400
+      "preferred": 995,
+      "max": 1000
     },
     {
       "quality": "Bluray-2160p",
       "min": 5,
-      "preferred": 395,
-      "max": 400
+      "preferred": 995,
+      "max": 1000
     },
     {
       "quality": "Bluray-2160p Remux",
       "min": 5,
-      "preferred": 395,
-      "max": 400
+      "preferred": 995,
+      "max": 1000
     }
   ]
 }

--- a/docs/json/sonarr/quality-size/series.json
+++ b/docs/json/sonarr/quality-size/series.json
@@ -5,86 +5,86 @@
     {
       "quality": "HDTV-720p",
       "min": 10,
-      "preferred": 395,
-      "max": 400
+      "preferred": 995,
+      "max": 1000
     },
     {
       "quality": "HDTV-1080p",
       "min": 15,
-      "preferred": 395,
-      "max": 400
+      "preferred": 995,
+      "max": 1000
     },
     {
       "quality": "WEBRip-720p",
       "min": 10,
-      "preferred": 395,
-      "max": 400
+      "preferred": 995,
+      "max": 1000
     },
     {
       "quality": "WEBDL-720p",
       "min": 10,
-      "preferred": 395,
-      "max": 400
+      "preferred": 995,
+      "max": 1000
     },
     {
       "quality": "Bluray-720p",
       "min": 17.1,
-      "preferred": 395,
-      "max": 400
+      "preferred": 995,
+      "max": 1000
     },
     {
       "quality": "WEBRip-1080p",
       "min": 15,
-      "preferred": 395,
-      "max": 400
+      "preferred": 995,
+      "max": 1000
     },
     {
       "quality": "WEBDL-1080p",
       "min": 15,
-      "preferred": 395,
-      "max": 400
+      "preferred": 995,
+      "max": 1000
     },
     {
       "quality": "Bluray-1080p",
       "min": 50.4,
-      "preferred": 395,
-      "max": 400
+      "preferred": 995,
+      "max": 1000
     },
     {
       "quality": "Bluray-1080p Remux",
       "min": 69.1,
-      "preferred": 395,
-      "max": 400
+      "preferred": 995,
+      "max": 1000
     },
     {
       "quality": "HDTV-2160p",
       "min": 25,
-      "preferred": 395,
-      "max": 400
+      "preferred": 995,
+      "max": 1000
     },
     {
       "quality": "WEBRip-2160p",
       "min": 25,
-      "preferred": 395,
-      "max": 400
+      "preferred": 995,
+      "max": 1000
     },
     {
       "quality": "WEBDL-2160p",
       "min": 25,
-      "preferred": 395,
-      "max": 400
+      "preferred": 995,
+      "max": 1000
     },
     {
       "quality": "Bluray-2160p",
       "min": 94.6,
-      "preferred": 395,
-      "max": 400
+      "preferred": 995,
+      "max": 1000
     },
     {
       "quality": "Bluray-2160p Remux",
       "min": 187.4,
-      "preferred": 395,
-      "max": 400
+      "preferred": 995,
+      "max": 1000
     }
   ]
 }


### PR DESCRIPTION
# Pull Request

## Purpose

To maintain compatibility with Radarr after it merges an increase to the quality definition ranges - namely that `2000` is now 'Unlimited' where `400` was the previous value.

## Approach

In the Radarr quality definitions JSON
- Change `399` to `1999` for preferred quality
- Change `400` to `2000` for max quality

## Open Questions and Pre-Merge TODOs

None

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
