### PR TITLE
feat(starr-anime): add Moozzi2 and Reinforce to Anime Raws CF

### DIFF
--- a/docs/json/radarr/cf/anime-lq-groups.json
+++ b/docs/json/radarr/cf/anime-lq-groups.json
@@ -691,15 +691,6 @@
       }
     },
     {
-      "name": "Moozzi2",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "\\b(Moozzi2)\\b"
-      }
-    },
-    {
       "name": "Mr. Deadpool",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,

--- a/docs/json/radarr/cf/anime-raws.json
+++ b/docs/json/radarr/cf/anime-raws.json
@@ -88,6 +88,15 @@
       }
     },
     {
+      "name": "Moozzi2",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Moozzi2)\\b"
+      }
+    },
+    {
       "name": "NanakoRaws",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,
@@ -148,6 +157,15 @@
       "required": false,
       "fields": {
         "value": "\\b(Raws-Maji)\\b"
+      }
+    },
+    {
+      "name": "ReinForce",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(ReinForce)\\b"
       }
     },
     {

--- a/docs/json/sonarr/cf/anime-lq-groups.json
+++ b/docs/json/sonarr/cf/anime-lq-groups.json
@@ -691,15 +691,6 @@
       }
     },
     {
-      "name": "Moozzi2",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "\\b(Moozzi2)\\b"
-      }
-    },
-    {
       "name": "Mr. Deadpool",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,

--- a/docs/json/sonarr/cf/anime-raws.json
+++ b/docs/json/sonarr/cf/anime-raws.json
@@ -88,6 +88,15 @@
       }
     },
     {
+      "name": "Moozzi2",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Moozzi2)\\b"
+      }
+    },
+    {
       "name": "NanakoRaws",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,
@@ -148,6 +157,15 @@
       "required": false,
       "fields": {
         "value": "\\b(Raws-Maji)\\b"
+      }
+    },
+    {
+      "name": "ReinForce",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(ReinForce)\\b"
       }
     },
     {


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->

Adding raw groups like Moozzi2 and ReinForce to the Anime Raws CF

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

Add the above to the CFs and remove Moozzi2 from the Anime LQ CF for better classification

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
