### PR TITLE
feat(guide): Hardlinks FAQ - Always show the limitations

### DIFF
--- a/docs/Hardlinks/Hardlinks-and-Instant-Moves.md
+++ b/docs/Hardlinks/Hardlinks-and-Instant-Moves.md
@@ -12,18 +12,22 @@ This guide consists of 4 sections.
 
 1. This page with a short description.
 1. [How to set up for](/Hardlinks/How-to-setup-for/) your installation method.
-1. [Examples](/Hardlinks/Examples/) what you should use for your path settings in your used applications.
+1. [Examples](/Hardlinks/Examples/) What you should use for your path settings in your used applications.
 1. [Check if hardlinks are working](/Hardlinks/Check-if-hardlinks-are-working/)
 
 So you want one of the following?
 
 - Instant moves (Atomic-Moves) during import of the Starr Apps (useful when using Usenet)?
 - You don't want to use twice the storage when using torrents. (hardlinks)?
-- You want to perma seed?
+- You want to perma-seed?
 
 Then Continue to [How to set up for](/Hardlinks/How-to-setup-for/) your installation method.
 
 ## FAQ
+
+### Hardlinks Limitations
+
+!!! danger "- You <u>CAN'T</u> create hardlinks for directories :bangbang:<br>- You <u>CAN'T</u> hardlink across separate file systems, partitions, volumes or mounts :bangbang:<br>- Some file systems, such as exFAT, are known not to support hardlinks and should be avoided (double-check if you are unsure!)"
 
 ### What are Hardlinks
 
@@ -55,14 +59,6 @@ Then Continue to [How to set up for](/Hardlinks/How-to-setup-for/) your installa
 ??? question "**What are Instant Moves (Atomic Moves)?** - [Click to show/hide]"
 
     A real move and not a copy file from the download folder to the media folder and then deleting the file from the download folder.
-
-### Hardlinks Limitations
-
-??? question "**Hardlinks limitations** - [Click to show/hide]"
-
-    - You **CAN'T** create hardlinks for directories :bangbang:
-    - You **CAN'T** hardlink across separate file systems, partitions, or mounts :bangbang:
-    - Some file systems, such as exFAT, are known not to support hardlinks and should be avoided (double-check if you are unsure!)
 
 ### What are the Starr Apps
 


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->

@mynameisbogdan requested in Radarr discord if the hardlinks limitations could be always seen because some people can't be bothered to `Click to show/hide`  or read the FAQ in general.

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

Make it always visible

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

- [x] Moved the hardlinks limitations to the top of the FAQ
- [x] Made it always seen
- [x] Changed it from a question admonitions (green) to a danger admonitions (red) 

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
