### PR TITLE
ci: prevent mkdocs macro issue

### DIFF
--- a/.github/workflows/mkdocs_bug_prevent.yml
+++ b/.github/workflows/mkdocs_bug_prevent.yml
@@ -1,0 +1,39 @@
+name: Check for Mkdocs Issues
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+
+      - name: Find JSON Files Changed in Commit
+        id: find_json_files
+        run: |
+          # Get the list of JSON files changed in the commit
+          JSON_FILES=$(git diff --name-only ${{ github.event.before }} ${{ github.sha }} | grep '\.json$' || true)
+          echo "json_files=$JSON_FILES" >> $GITHUB_ENV
+
+      - name: Check JSON Files for MkDocs Macro Issues
+        run: |
+          # Check if any JSON files contain the [[ pattern
+          if [[ -n "$JSON_FILES" ]]; then
+            if grep -r '\[\[' $JSON_FILES; then
+              echo "::error::Found '[[', which breaks MkDocs macros in JSON files:"
+              grep -r -n '\[\[' $JSON_FILES
+              exit 1
+            else
+              echo "No '[[', patterns found in JSON files."
+            fi
+          else
+            echo "No JSON files changed in this commit."
+          fi

--- a/.github/workflows/mkdocs_bug_prevent.yml
+++ b/.github/workflows/mkdocs_bug_prevent.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Find JSON Files Changed in Commit
         id: find_json_files


### PR DESCRIPTION
# Pull Request

## Purpose

Regex for `[[` in changed json and fail.
This is due to `[[` breaking the macro in mkdocs

Ref
- https://github.com/TRaSH-Guides/Guides/commit/38dac49f48ce12638742b0ea206c13c0602cc9c8