### PR TITLE
feat(starr-anime): Add Korean to Anime Dual Audio

### DIFF
--- a/docs/json/radarr/cf/anime-dual-audio.json
+++ b/docs/json/radarr/cf/anime-dual-audio.json
@@ -9,7 +9,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "dual[ ._-]?audio|[\\[(]dual[\\])]|(JA|ZH)\\+EN|EN\\+(JA|ZH)"
+        "value": "dual[ ._-]?audio|[[(]dual[])]|(JA|ZH|KO)\\+EN|EN\\+(JA|ZH|KO)"
       }
     },
     {
@@ -18,7 +18,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "\\[(JA|ZH)\\]"
+        "value": "\\[(JA|ZH|KO)\\]"
       }
     },
     {
@@ -27,7 +27,8 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": 8
+        "value": 8,
+        "exceptLanguage": false
       }
     },
     {
@@ -36,7 +37,18 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": 10
+        "value": 10,
+        "exceptLanguage": false
+      }
+    },
+    {
+      "name": "Korean Language",
+      "implementation": "LanguageSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 21,
+        "exceptLanguage": false
       }
     }
   ]

--- a/docs/json/radarr/cf/anime-dual-audio.json
+++ b/docs/json/radarr/cf/anime-dual-audio.json
@@ -27,8 +27,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": 8,
-        "exceptLanguage": false
+        "value": 8
       }
     },
     {
@@ -37,8 +36,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": 10,
-        "exceptLanguage": false
+        "value": 10
       }
     },
     {
@@ -47,8 +45,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": 21,
-        "exceptLanguage": false
+        "value": 21
       }
     }
   ]

--- a/docs/json/radarr/cf/anime-dual-audio.json
+++ b/docs/json/radarr/cf/anime-dual-audio.json
@@ -9,7 +9,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "dual[ ._-]?audio|[\\[(]dual[\\])]|(JA|ZH|KO)\\+EN|EN\\+(JA|ZH|KO)"
+        "value": "dual[ ._-]?audio|[([]dual[])]|(JA|ZH|KO)\\+EN|EN\\+(JA|ZH|KO)"
       }
     },
     {

--- a/docs/json/radarr/cf/anime-dual-audio.json
+++ b/docs/json/radarr/cf/anime-dual-audio.json
@@ -9,7 +9,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "dual[ ._-]?audio|[[(]dual[])]|(JA|ZH|KO)\\+EN|EN\\+(JA|ZH|KO)"
+        "value": "dual[ ._-]?audio|[\\[(]dual[\\])]|(JA|ZH|KO)\\+EN|EN\\+(JA|ZH|KO)"
       }
     },
     {

--- a/docs/json/sonarr/cf/anime-dual-audio.json
+++ b/docs/json/sonarr/cf/anime-dual-audio.json
@@ -9,7 +9,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "dual[ ._-]?audio|[\\[(]dual[\\])]|(JA|ZH)\\+EN|EN\\+(JA|ZH)"
+        "value": "dual[ ._-]?audio|[[(]dual[])]|(JA|ZH|KO)\\+EN|EN\\+(JA|ZH|KO)"
       }
     },
     {
@@ -18,7 +18,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "\\[(JA|ZH)\\]"
+        "value": "\\[(JA|ZH|KO)\\]"
       }
     },
     {
@@ -27,7 +27,8 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": 8
+        "value": 8,
+        "exceptLanguage": false
       }
     },
     {
@@ -36,7 +37,18 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": 10
+        "value": 10,
+        "exceptLanguage": false
+      }
+    },
+    {
+      "name": "Korean Language",
+      "implementation": "LanguageSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 21,
+        "exceptLanguage": false
       }
     }
   ]

--- a/docs/json/sonarr/cf/anime-dual-audio.json
+++ b/docs/json/sonarr/cf/anime-dual-audio.json
@@ -27,8 +27,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": 8,
-        "exceptLanguage": false
+        "value": 8
       }
     },
     {
@@ -37,8 +36,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": 10,
-        "exceptLanguage": false
+        "value": 10
       }
     },
     {
@@ -47,8 +45,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": 21,
-        "exceptLanguage": false
+        "value": 21
       }
     }
   ]

--- a/docs/json/sonarr/cf/anime-dual-audio.json
+++ b/docs/json/sonarr/cf/anime-dual-audio.json
@@ -9,7 +9,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "dual[ ._-]?audio|[\\[(]dual[\\])]|(JA|ZH|KO)\\+EN|EN\\+(JA|ZH|KO)"
+        "value": "dual[ ._-]?audio|[([]dual[])]|(JA|ZH|KO)\\+EN|EN\\+(JA|ZH|KO)"
       }
     },
     {

--- a/docs/json/sonarr/cf/anime-dual-audio.json
+++ b/docs/json/sonarr/cf/anime-dual-audio.json
@@ -9,7 +9,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "dual[ ._-]?audio|[[(]dual[])]|(JA|ZH|KO)\\+EN|EN\\+(JA|ZH|KO)"
+        "value": "dual[ ._-]?audio|[\\[(]dual[\\])]|(JA|ZH|KO)\\+EN|EN\\+(JA|ZH|KO)"
       }
     },
     {


### PR DESCRIPTION
# Pull Request

## Purpose

Adding Korean language to anime dual audio to handle a few cases like Tower of God. Keeping unnecessary slashes because everything breaks without them

## Approach

Adding Korean to the Sonarr and Radarr CF, readding slashes that were removed earlier

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
