### PR TITLE
Update movie-versions-noremux.json

### DIFF
--- a/docs/json/radarr/cf-groups/movie-versions-noremux.json
+++ b/docs/json/radarr/cf-groups/movie-versions-noremux.json
@@ -5,42 +5,42 @@
     {
       "name": "Remaster",
       "trash_id": "570bc9ebecd92723d2d21500f4be314c",
-      "required": true
+      "required": false
     },
     {
       "name": "4K Remaster",
       "trash_id": "eca37840c13c6ef2dd0262b141a5482f",
-      "required": true
+      "required": false
     },
     {
       "name": "Criterion Collection",
       "trash_id": "e0c07d59beb37348e975a930d5e50319",
-      "required": true
+      "required": false
     },
     {
       "name": "Masters of Cinema",
       "trash_id": "9d27d9d2181838f76dee150882bdc58c",
-      "required": true
+      "required": false
     },
     {
       "name": "Vinegar Syndrome",
       "trash_id": "db9b4c4b53d312a3ca5f1378f6440fc9",
-      "required": true
+      "required": false
     },
     {
       "name": "Special Edition",
       "trash_id": "957d0f44b592285f26449575e8b1167e",
-      "required": true
+      "required": false
     },
     {
       "name": "IMAX",
       "trash_id": "eecf3a857724171f968a66cb5719e152",
-      "required": true
+      "required": false
     },
     {
       "name": "IMAX Enhanced",
       "trash_id": "9f6cbff8cfe4ebbc1bde14c7b7bec0de",
-      "required": true
+      "required": false
     }
   ],
   "quality_profiles": {


### PR DESCRIPTION
make the movies groups not required

# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [ ] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
