### PR TITLE
feat(maintenance): update dubs-only cf for KaiDubs dual audio releases

### DIFF
--- a/docs/json/sonarr/cf/dubs-only.json
+++ b/docs/json/sonarr/cf/dubs-only.json
@@ -25,12 +25,12 @@
       }
     },
     {
-      "name": "KaiDubs",
+      "name": "KaiDubs (Not Dual Audio)",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,
       "required": false,
       "fields": {
-        "value": "\\b(KaiDubs)\\b"
+        "value": "^(?!.*(dual[ ._-]?audio|[\\[(]dual[\\]]|(JA|ZH)\\+EN|EN\\+(JA|ZH))).*\\b(KaiDubs)\\b"
       }
     },
     {


### PR DESCRIPTION
# Pull Request

## Purpose

Seeing KaiDubs releases that are dual audio so editing this to avoid negative scores 

## Approach

Used "KS (Not Dual Audio)" as a template, tested on a KaiDubs dual audio release to confirm scores are applied as expected 

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [X ] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [ X] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
