### PR TITLE
feat(guides): SABnzbd - Updated description for utilizing the scripts folder

### DIFF
--- a/docs/Downloaders/SABnzbd/scripts/index.md
+++ b/docs/Downloaders/SABnzbd/scripts/index.md
@@ -7,8 +7,9 @@ If you have a script you want to share, don't hesitate to create a [PR](https://
 !!! warning "Because these scripts are community-provided and maintained we can't assure that they are still 100% working"
 
 ## Prerequisites
-- You've created folder called `"scripts"` in the root directory of SABnzbd 
-- You've set the `scripts` folder inside the SABnzbd settings under `"Folder" > "User Folders" > "Scripts Folder"`. ([More Infos](https://sabnzbd.org/wiki/configuration/4.3/folders))
+
+- You've created folder called `scripts` in the root directory of SABnzbd 
+- You've set the `scripts` folder inside the SABnzbd settings under `Folder > User Folders > Scripts Folder`. ([More Infos](https://sabnzbd.org/wiki/configuration/4.3/folders))
 - Your script got sufficient rights to execute. ([More Infos](https://sabnzbd.org/wiki/configuration/4.3/scripts/post-processing-scripts))
 
 ## Clean
@@ -26,10 +27,10 @@ If you have a script you want to share, don't hesitate to create a [PR](https://
     Install Instructions:
 
         1. Copy script to SABnzbd's `scripts` folder
-        1. Use your prefered shell and navigate to the `scripts` folder with the command `cd` (example `cd /mnt/user/appdata/sabnzdb/scripts`).
-        1. run: `sudo chmod +x Clean.py`
-        1. in SABnzbd go to `Settings` => `Switches`
-        1. Change Pre-queue user script and select: `Clean.py`
+        2. Use your prefered shell and navigate to the `scripts` folder with the command `cd` (example `cd /mnt/user/appdata/sabnzdb/scripts`).
+        3. run: `sudo chmod +x Clean.py`
+        4. in SABnzbd go to `Settings` => `Switches`
+        5. Change Pre-queue user script and select: `Clean.py`
 
     ![!Enable Clean.py](/Downloaders/SABnzbd/images/sabnzbd-switches-queue-clean.png)
 

--- a/docs/Downloaders/SABnzbd/scripts/index.md
+++ b/docs/Downloaders/SABnzbd/scripts/index.md
@@ -8,7 +8,7 @@ If you have a script you want to share, don't hesitate to create a [PR](https://
 
 ## Prerequisites
 
-- You've created folder called `scripts` in the root directory of SABnzbd 
+- You've created folder called `scripts` in the root directory of SABnzbd
 - You've set the `scripts` folder inside the SABnzbd settings under `Folder > User Folders > Scripts Folder`. ([More Infos](https://sabnzbd.org/wiki/configuration/4.3/folders))
 - Your script got sufficient rights to execute. ([More Infos](https://sabnzbd.org/wiki/configuration/4.3/scripts/post-processing-scripts))
 

--- a/docs/Downloaders/SABnzbd/scripts/index.md
+++ b/docs/Downloaders/SABnzbd/scripts/index.md
@@ -6,6 +6,11 @@ If you have a script you want to share, don't hesitate to create a [PR](https://
 
 !!! warning "Because these scripts are community-provided and maintained we can't assure that they are still 100% working"
 
+## Prerequisites
+- You've created folder called `"scripts"` in the root directory of SABnzbd 
+- You've set the `scripts` folder inside the SABnzbd settings under `"Folder" > "User Folders" > "Scripts Folder"`. ([More Infos](https://sabnzbd.org/wiki/configuration/4.3/folders))
+- Your script got sufficient rights to execute. ([More Infos](https://sabnzbd.org/wiki/configuration/4.3/scripts/post-processing-scripts))
+
 ## Clean
 
 ??? info "Clean NZB name"
@@ -20,7 +25,8 @@ If you have a script you want to share, don't hesitate to create a [PR](https://
 
     Install Instructions:
 
-        1. Copy script to SABnzbd's script folder
+        1. Copy script to SABnzbd's `scripts` folder
+        1. Use your prefered shell and navigate to the `scripts` folder with the command `cd` (example `cd /mnt/user/appdata/sabnzdb/scripts`).
         1. run: `sudo chmod +x Clean.py`
         1. in SABnzbd go to `Settings` => `Switches`
         1. Change Pre-queue user script and select: `Clean.py`


### PR DESCRIPTION
Added prerequisites for better understanding the following steps. It should be clearer now that the user needs to create a scripts folder and has to select it inside the settings.

# Pull Request

## Purpose

Improved information  base for lesser-techie users.

## Approach

From the user perspective, I had the issue to understand where to put the scripts. I tried to solve this by adding helpful informations and links to the official SABnzbd  KB.

## Open Questions and Pre-Merge TODOs

Nothing to do here

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
