### PR TITLE
feat(guide): Move RlsGrp `Kitsune` from `WEB Tier 02` to `WEB Tier 01`

### DIFF
--- a/docs/json/radarr/cf/web-tier-01.json
+++ b/docs/json/radarr/cf/web-tier-01.json
@@ -125,6 +125,15 @@
       }
     },
     {
+      "name": "Kitsune",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(Kitsune)$"
+      }
+    },
+    {
       "name": "NOSiViD",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,

--- a/docs/json/radarr/cf/web-tier-02.json
+++ b/docs/json/radarr/cf/web-tier-02.json
@@ -44,15 +44,6 @@
       }
     },
     {
-      "name": "Kitsune",
-      "implementation": "ReleaseGroupSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "^(Kitsune)$"
-      }
-    },
-    {
       "name": "MiU",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,

--- a/docs/json/sonarr/cf/web-tier-01.json
+++ b/docs/json/sonarr/cf/web-tier-01.json
@@ -89,6 +89,15 @@
       }
     },
     {
+      "name": "Kitsune",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(Kitsune)$"
+      }
+    },
+    {
       "name": "monkee",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,

--- a/docs/json/sonarr/cf/web-tier-02.json
+++ b/docs/json/sonarr/cf/web-tier-02.json
@@ -197,15 +197,6 @@
       }
     },
     {
-      "name": "Kitsune",
-      "implementation": "ReleaseGroupSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "^(Kitsune)$"
-      }
-    },
-    {
       "name": "LAZY",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->

After receiving several pieces of information and having a discussion with the team, we have decided to move RlsGrp `Kitsune` from `WEB Tier 02` to `WEB Tier 01`

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

Moved RlsGrp `Kitsune` from `WEB Tier 02` to `WEB Tier 01`

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
