### PR TITLE
fix(sonarr): Anime Dual Audio CF should match DUAL- in that title

### DIFF
--- a/docs/json/sonarr/cf/anime-dual-audio.json
+++ b/docs/json/sonarr/cf/anime-dual-audio.json
@@ -9,7 +9,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "dual[ ._-]?audio|[([]dual[])]|(JA|ZH|KO)\\+EN|EN\\+(JA|ZH|KO)"
+        "value": "dual[ ._-]?audio|[([]dual[])]|(JA|ZH|KO)\\+EN|EN\\+(JA|ZH|KO)|(?i)dual[ ._-]"
       }
     },
     {


### PR DESCRIPTION
# Pull Request
it's the first time I'm making a pull request, so I hope I've understood and followed the Contributing Guidelines.
## Purpose

I have made this pull request because there are some anime with DUAL audio that are not caught

## Approach

Add "(?i)dual[ ._-]" to "Dual Audio" so it supports anime with DUAL- in that title.
it will now catch titles like "Wistoria.Wand.and.Sword.S01E12.Wand.and.Sword.1080p.CR.WEB-DL.AAC2.0.H.264.DUAL-VARYG" which is dual audio

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
