### PR TITLE
fix(guides): Add missing HDR10+ Boost and DV HDR10+ Boost custom formats to profile JSONs

### DIFF
--- a/docs/json/radarr/cf-groups/misc-uhd-optional.json
+++ b/docs/json/radarr/cf-groups/misc-uhd-optional.json
@@ -38,6 +38,16 @@
       "required": false
     },
     {
+      "name": "HDR10+ Boost",
+      "trash_id": "b17886cb4158d9fea189859409975758",
+      "required": false
+    },
+    {
+      "name": "DV HDR10+ Boost",
+      "trash_id": "55a5b50cb416dea5a50c4955896217ab",
+      "required": false
+    },
+    {
       "name": "SDR",
       "trash_id": "9c38ebb7384dada637be8899efa68e6f",
       "required": false

--- a/docs/json/radarr/cf-groups/sqp-2-3-4-5-misc-optional.json
+++ b/docs/json/radarr/cf-groups/sqp-2-3-4-5-misc-optional.json
@@ -56,6 +56,11 @@
       "name": "HDR10+ Boost",
       "trash_id": "b17886cb4158d9fea189859409975758",
       "required": false
+    },
+    {
+      "name": "DV HDR10+ Boost",
+      "trash_id": "55a5b50cb416dea5a50c4955896217ab",
+      "required": false
     }
   ],
   "quality_profiles": {


### PR DESCRIPTION
# Pull Request

## Purpose

Add missing HDR10+ Boost and DV HDR10+ Boost custom formats to profile JSONs.

## Approach

Add missing HDR10+ Boost and DV HDR10+ Boost custom formats to profile JSONs.

## Open Questions and Pre-Merge TODOs

None

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
