### PR TITLE
fix(sonarr): Add Bluray-576p quality filesize settings for Anime

### DIFF
--- a/docs/Sonarr/Sonarr-Quality-Settings-File-Size.md
+++ b/docs/Sonarr/Sonarr-Quality-Settings-File-Size.md
@@ -52,5 +52,6 @@
     | {{ sonarr['quality-size']['anime']['qualities'][16]['quality'] }} | {{ sonarr['quality-size']['anime']['qualities'][16]['min'] }} | {{ sonarr['quality-size']['anime']['qualities'][16]['preferred'] }} | {{ sonarr['quality-size']['anime']['qualities'][16]['max'] }} |
     | {{ sonarr['quality-size']['anime']['qualities'][17]['quality'] }} | {{ sonarr['quality-size']['anime']['qualities'][17]['min'] }} | {{ sonarr['quality-size']['anime']['qualities'][17]['preferred'] }} | {{ sonarr['quality-size']['anime']['qualities'][17]['max'] }} |
     | {{ sonarr['quality-size']['anime']['qualities'][18]['quality'] }} | {{ sonarr['quality-size']['anime']['qualities'][18]['min'] }} | {{ sonarr['quality-size']['anime']['qualities'][18]['preferred'] }} | {{ sonarr['quality-size']['anime']['qualities'][18]['max'] }} |
+    | {{ sonarr['quality-size']['anime']['qualities'][19]['quality'] }} | {{ sonarr['quality-size']['anime']['qualities'][19]['min'] }} | {{ sonarr['quality-size']['anime']['qualities'][19]['preferred'] }} | {{ sonarr['quality-size']['anime']['qualities'][19]['max'] }} |
 
 --8<-- "includes/support.md"

--- a/docs/json/sonarr/quality-size/anime.json
+++ b/docs/json/sonarr/quality-size/anime.json
@@ -33,6 +33,12 @@
       "max": 1000
     },
     {
+      "quality": "Bluray-576p",
+      "min": 5,
+      "preferred": 995,
+      "max": 1000
+    },
+    {
       "quality": "HDTV-720p",
       "min": 5,
       "preferred": 995,


### PR DESCRIPTION
# Pull Request

## Purpose

Add missing Bluray-576p quality to quality settings JSON and guide

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

## Open Questions and Pre-Merge Added to `anime` quality definition set only as `series`/Standard does not have qualities below 720p.

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
