### PR TITLE
feat(guide): Move the third-party tools section out of the qBittorrent section and put it in the downloaders root section

### DIFF
--- a/docs/Downloaders/.pages
+++ b/docs/Downloaders/.pages
@@ -5,3 +5,4 @@ nav:
   - qBittorrent
   - Deluge
   - ruTorrent
+  - 3rd Party tools: 3rd-party-tools.md

--- a/docs/Downloaders/3rd-party-tools.md
+++ b/docs/Downloaders/3rd-party-tools.md
@@ -1,6 +1,6 @@
 # 3rd Party tools
 
-Here you will find a collection of 3rd party tools and other related links for qBittorrent.
+Here you will find a collection of 3rd party tools for several downloaders we cover.
 
 ## qBit Manage
 

--- a/docs/Downloaders/qBittorrent/.pages
+++ b/docs/Downloaders/qBittorrent/.pages
@@ -3,5 +3,4 @@ nav:
   - Paths: Paths.md
   - How to add Categories: How-to-add-categories.md
   - Port forwarding: Port-forwarding.md
-  - 3rd Party tools: 3rd-party-tools.md
   - Tips

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -146,6 +146,8 @@ plugins:
         # Recyclarr redirects
         Recyclarr/recyclarr-configs.md: https://recyclarr.dev/wiki/guide-configs/
         Recyclarr/recyclarr-configs-sqp.md: https://recyclarr.dev/wiki/sqp-configs/
+        # Downloaders redirects
+        Downloaders/qBittorrent/3rd-party-tools.md: Downloaders/3rd-party-tools.md
 
 theme:
   name: material


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->

This way, it’s just third-party tools relevant to downloaders, not just to qBittorrent.

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

Moved the third-party tools section out of the qBittorrent section and put it in the downloaders root section.

![image](https://github.com/user-attachments/assets/137ad0e0-35ed-472a-96dc-3d09ebc48394)

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
