### PR TITLE
feat(starr-anime): Add Moxie to anime bd tier 2

### DIFF
--- a/docs/json/radarr/cf/anime-bd-tier-02-seadex-muxers.json
+++ b/docs/json/radarr/cf/anime-bd-tier-02-seadex-muxers.json
@@ -250,6 +250,15 @@
       }
     },
     {
+      "name": "Moxie",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Moxie\\]|-Moxie\\b"
+      }
+    },
+    {
       "name": "MTBB",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,

--- a/docs/json/sonarr/cf/anime-bd-tier-02-seadex-muxers.json
+++ b/docs/json/sonarr/cf/anime-bd-tier-02-seadex-muxers.json
@@ -259,6 +259,15 @@
       }
     },
     {
+      "name": "Moxie",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Moxie\\]|-Moxie\\b"
+      }
+    },
+    {
       "name": "MTBB",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->

Add Moxie to the anime tiers due to high quality BD remuxes

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->
Added to the json files

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [ ] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
