### PR TITLE
[Anime] make dual audio case insensitive

### DIFF
--- a/docs/json/sonarr/cf/anime-dual-audio.json
+++ b/docs/json/sonarr/cf/anime-dual-audio.json
@@ -9,7 +9,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "dual[ ._-]?audio|[([]dual[])]|(JA|ZH|KO)\\+EN|EN\\+(JA|ZH|KO)"
+        "value": "(?i)dual[ ._-]?audio|[([]dual[])]|(JA|ZH|KO)\\+EN|EN\\+(JA|ZH|KO)"
       }
     },
     {


### PR DESCRIPTION
# Pull Request

## Purpose

Add ability to match case insensitive "Dual Audio"

## Approach

`(?i)` before dual audio is going to add ability to match case insensitive:

```
BLEACH Thousand Year Blood War S01E28 KILL THE KING 1080p DSNP WEB-DL AAC2.0 H 264 DUAL-VARYG (Bleach: Sennen Kessen-hen, Dual-Audio, Multi-Subs)
```
![image](https://github.com/user-attachments/assets/b661d246-8816-445d-8686-7a0740e9cb07)

and fixed version:

![image](https://github.com/user-attachments/assets/61555af5-dab0-44fe-b6cf-a0fb9185d4c8)


## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [X] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [X] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
