### PR TITLE
fix(backend): Movie Versions custom form group jsons have non-unique names and trash_ids

### DIFF
--- a/docs/json/radarr/cf-groups/movie-versions-noremux.json
+++ b/docs/json/radarr/cf-groups/movie-versions-noremux.json
@@ -1,6 +1,6 @@
 {
-  "name": "Movie Versions",
-  "trash_id": "f4f1474b963b24cf983455743aa9906c",
+  "name": "Movie Versions (Non-Remux Profiles) (Optional)",
+  "trash_id": "bf033fe44d9b84aa6eceba6d0e27a88e",
   "custom_formats": [
     {
       "name": "Remaster",

--- a/docs/json/radarr/cf-groups/movie-versions.json
+++ b/docs/json/radarr/cf-groups/movie-versions.json
@@ -1,5 +1,5 @@
 {
-  "name": "Movie Versions",
+  "name": "Movie Versions (Optional)",
   "trash_id": "f4f1474b963b24cf983455743aa9906c",
   "custom_formats": [
     {


### PR DESCRIPTION
# Pull Request

## Purpose

To give the Movie Versions custom format group json files unique names and trash_ids, as this is required for syncing to external sync tools

## Approach

- Generate a new hash for a trash_id for `movie-versions-noremux.json`
- Create a new name for `movie-versions-noremux.json`
- Add 'Optional' to both json names to be explicit that these are now optional

## Open Questions and Pre-Merge TODOs

None

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
