### PR TITLE
fix(backend): Remove cf schema validation blocking addition of default: 0 scores

### DIFF
--- a/schemas/base-cf.schema.json
+++ b/schemas/base-cf.schema.json
@@ -9,10 +9,7 @@
       "type": "object",
       "properties": {
         "default": {
-          "type": "integer",
-          "not": {
-            "const": 0
-          }
+          "type": "integer"
         }
       },
       "patternProperties": {


### PR DESCRIPTION
# Pull Request

## Purpose

Remove the custom format schema validation which blocks default: 0 scores. This is because we need to add a few default: 0 scores in service of #2143 

## Approach

Remove the part of the schema which blocks these scores

## Open Questions and Pre-Merge TODOs

None

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
