### PR TITLE
feat(starr-anime): Add SoM and Cunnysseur to Anime BD Tiers

### DIFF
--- a/docs/json/radarr/cf/anime-bd-tier-01-top-seadex-muxers.json
+++ b/docs/json/radarr/cf/anime-bd-tier-01-top-seadex-muxers.json
@@ -97,6 +97,15 @@
       }
     },
     {
+      "name": "SoM",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[SoM\\]|-SoM\\b"
+      }
+    },
+    {
       "name": "Vanilla",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,

--- a/docs/json/radarr/cf/anime-bd-tier-02-seadex-muxers.json
+++ b/docs/json/radarr/cf/anime-bd-tier-02-seadex-muxers.json
@@ -115,6 +115,15 @@
       }
     },
     {
+      "name": "CsS",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(CsS)\\b"
+      }
+    },
+    {
       "name": "CUNNY",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,
@@ -124,12 +133,12 @@
       }
     },
     {
-      "name": "CsS",
+      "name": "Cunnysseur",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,
       "required": false,
       "fields": {
-        "value": "\\b(CsS)\\b"
+        "value": "\\b(Cunnysseur)\\b"
       }
     },
     {

--- a/docs/json/sonarr/cf/anime-bd-tier-01-top-seadex-muxers.json
+++ b/docs/json/sonarr/cf/anime-bd-tier-01-top-seadex-muxers.json
@@ -106,6 +106,15 @@
       }
     },
     {
+      "name": "SoM",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[SoM\\]|-SoM\\b"
+      }
+    },
+    {
       "name": "Vanilla",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,

--- a/docs/json/sonarr/cf/anime-bd-tier-02-seadex-muxers.json
+++ b/docs/json/sonarr/cf/anime-bd-tier-02-seadex-muxers.json
@@ -142,6 +142,15 @@
       }
     },
     {
+      "name": "Cunnysseur",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Cunnysseur)\\b"
+      }
+    },
+    {
       "name": "D-Z0N3",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->

Add SoM to Anime BD Tier 1 and Cunnysseur to Anime BD Tier 2

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

Edit the CF JSON files

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
