### PR TITLE
fix(guide): Add SQP-1 WEB (1080p) score for 10-bit custom format

### DIFF
--- a/docs/json/radarr/cf/10bit.json
+++ b/docs/json/radarr/cf/10bit.json
@@ -2,6 +2,7 @@
   "trash_id": "a5d148168c4506b55cf53984107c396e",
   "trash_scores": {
     "sqp-1-1080p": -10000,
+    "sqp-1-web-1080p": -10000,
     "sqp-1-2160p": -10000
   },
   "name": "10bit",


### PR DESCRIPTION
# Pull Request

## Purpose

Fix incorrect score for 10-bit custom format under new SQP-1 WEB (1080p) profile.

## Approach

- Add SQP-1 WEB (1080p) score for 10-bit custom format

## Open Questions and Pre-Merge TODOs

None

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
