### PR TITLE
fix(backend): Add missing AMZN from Sonarr 2160p QP JSON

### DIFF
--- a/docs/json/sonarr/quality-profiles/web-2160p.json
+++ b/docs/json/sonarr/quality-profiles/web-2160p.json
@@ -61,6 +61,7 @@
     "Repack/Proper": "ec8fa7296b64e8cd390a1600981f3923",
     "Repack v2": "eb3d5cc0a2be0db205fb823640db6a3c",
     "Repack v3": "44e7c4de10ae50265753082e5dc76047",
+    "AMZN": "d660701077794679fd59e8bdf4ce3a29",
     "ATVP": "f67c9ca88f463a48346062e8ad07713f",
     "CC": "77a7b25585c18af08f60b1547bb9b4fb",
     "DCU": "36b72f59f4ea20aad9316f475f2d9fbb",


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->

The Sonarr 2160p QP JSON was missing the AMZN CF ID, which is required for syncing to external sync tools.

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

Added the AMZN ID to the Sonarr 2160p QP JSON

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
