### PR TITLE
fix(ci): allow exceptLanguage in CF schema validation

### DIFF
--- a/schemas/specs/language-spec.json
+++ b/schemas/specs/language-spec.json
@@ -12,6 +12,9 @@
           "properties": {
             "value": {
               "type": "integer"
+            },
+            "exceptLanguage": {
+              "type": "boolean"
             }
           },
           "required": ["value"],


### PR DESCRIPTION
# Pull Request

## Purpose

Fix `exceptLanguage` not being allowed in Custom Format jsons.

## Approach

Add `exceptLanguage` to the allowed `fields` types as a `boolean` value.

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
