### PR TITLE
style(guide): Consistency in the wording of `hardlinks` vs `hard links`

### DIFF
--- a/docs/Downloaders/3rd-party-tools.md
+++ b/docs/Downloaders/3rd-party-tools.md
@@ -12,7 +12,7 @@ This is a program used to manage your qBittorrent instance such as:
 - Automatically add cross-seed torrents in a paused state. _Note: cross-seed now allows for torrent injections directly to qBit, making this feature obsolete._
 - Recheck paused torrents sorted by lowest size and resume if completed
 - Remove orphaned files from your root directory that are not referenced by qBittorrent
-- Tag any torrents that have no hard links and allow the option to cleanup to delete these torrents and contents based on maximum ratio and/or time-seeded
+- Tag any torrents that have no hardlinks and allow the option to cleanup to delete these torrents and contents based on maximum ratio and/or time-seeded
 - RecycleBin function to move files into a RecycleBin folder instead of deleting the data directly when deleting a torrent
 - Built-in scheduler to run the script every x minutes. (Can use --run command to run without the scheduler)
 - Webhook notifications with Notifiarr and Apprise API integration.

--- a/docs/File-and-Folder-Structure/How-to-set-up/Unraid.md
+++ b/docs/File-and-Folder-Structure/How-to-set-up/Unraid.md
@@ -189,7 +189,7 @@ Sonarr, Radarr and Lidarr
 
 !!! info
 
-    Sonarr, Radarr, and Lidarr get access to everything because the download folder(s) and media folder will need to look like and be one mount, on the file system. Hard links will work properly and any moves will be atomic, rather than copying and deleting.
+    Sonarr, Radarr, and Lidarr get access to everything because the download folder(s) and media folder will need to look like and be one mount, on the file system. hardlinks will work properly and any moves will be atomic, rather than copying and deleting.
 
 {! include-markdown "../../../includes/file-and-folder-structure/docker-tree-full.md" !}
 

--- a/docs/File-and-Folder-Structure/How-to-set-up/Windows.md
+++ b/docs/File-and-Folder-Structure/How-to-set-up/Windows.md
@@ -1,16 +1,16 @@
 # Windows
 
-Windows is less flexible than some other operating systems in respect of support for hard links and instant (Atomic) moves. In most cases, you need to use a single disk containing both your download location and media library. However, there is an option detailed below that will allow you to make use of hard links and instant (Atomic) moves if you run a two-disk setup.
+Windows is less flexible than some other operating systems in respect of support for hardlinks and instant (Atomic) moves. In most cases, you need to use a single disk containing both your download location and media library. However, there is an option detailed below that will allow you to make use of hardlinks and instant (Atomic) moves if you run a two-disk setup.
 
 ## Recommendation
 
-If you want to make extensive use of hard links, we would recommend switching to another operating system. For more information and suggestions on this topic, join our Discord support channel. The link can be found at the bottom of every guide page.
+If you want to make extensive use of hardlinks, we would recommend switching to another operating system. For more information and suggestions on this topic, join our Discord support channel. The link can be found at the bottom of every guide page.
 
 ### Alternative recommendation
 
-If moving away from using Windows with multiple disks is not an option, we suggest ignoring hard links and instant (Atomic) moves and using [StableBit DrivePool](https://stablebit.com/){:target="\_blank" rel="noopener noreferrer"}. This will allow you to pool multiple disks to appear as one big disk, making it much easier to maintain and set up your file and folder structure.
+If moving away from using Windows with multiple disks is not an option, we suggest ignoring hardlinks and instant (Atomic) moves and using [StableBit DrivePool](https://stablebit.com/){:target="\_blank" rel="noopener noreferrer"}. This will allow you to pool multiple disks to appear as one big disk, making it much easier to maintain and set up your file and folder structure.
 
-!!! warning "It is possible that Windows Storage Spaces supports hard links, but this has not been verified by the Guides team. We are unable to provide support for setups that use Storage Spaces."
+!!! warning "It is possible that Windows Storage Spaces supports hardlinks, but this has not been verified by the Guides team. We are unable to provide support for setups that use Storage Spaces."
 
 ## Folder Structure
 

--- a/docs/File-and-Folder-Structure/Replace-copies-with-hardlinks.md
+++ b/docs/File-and-Folder-Structure/Replace-copies-with-hardlinks.md
@@ -66,7 +66,7 @@ The example below will hard link all duplicate files without prompting.
 
 ---
 
-!!! bug "Windows only allows a maximum of 1023 hard links per file"
+!!! bug "Windows only allows a maximum of 1023 hardlinks per file"
 
 !!! Warning "The `-Q` or `--quick` option only reads each file once, hashes it, and performs comparisons based solely on the hashes. There is a small but significant risk of a hash collision which is the purpose of the failsafe byte-for-byte comparison that this option explicitly bypasses. Do not use it on ANY data set for which any amount of data loss is unacceptable. You have been warned!"
 


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->

Consistency in the wording of `hardlinks` vs `hard links`

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

Checked the consistency in the wording of `hard links` vs. `hardlinks`; we went with `hardlinks` because the Starr apps use `hard links`, and the guide is based on the Starr apps. (See message at the bottom)
Sections where the GUI shows `hard links` we left as `hard links`.

I received the following reply, and I think this might be the best option.
```
i think the bigger point than grammar with this particular instance is the colloquial usage and acceptance of the term as "hardlink"
given that, for the purpose and entire point of your guide being generally arr related, they've set the stage of it being hardlink
i would go with that.
its not always a matter of being "technically grammar correct"
as much as being consistent, making your point clear, and being easy to follow
documentation is sometimes a balance between language and purpose
and in this case, i would argue that its better to be consistent across the apps users are using and your guide, than to take the high ground of "AI approves our usage of the term!" or something
```

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
