### PR TITLE
fix(radarr): remove MULTI recommendation from German Guide

### DIFF
--- a/docs/Radarr/radarr-setup-quality-profiles-german-en.md
+++ b/docs/Radarr/radarr-setup-quality-profiles-german-en.md
@@ -90,15 +90,6 @@ There are a couple of changes that are needed for German Custom Formats to work 
     !!! tip "Movie format/folder with the German movie name."
         Radarr supports the ISO-2 naming convention for naming movies, so replacing `{Movie CleanTitle}` with `{Movie CleanTitle:de}` will change the name to its German version.
 
-??? abstract "Change the Indexers Multi Languages option - [Click to show/hide]"
-    In Radarr, you can tell that MULTi in an indexer means that a release possesses at least certain audio. You should select `Original` and `German` for this guide.
-    This option should only be used for German indexers. Doing so on "international" indexers can create false positives with the German Audio CFs.
-
-    If you do not see the option, you need to activate Radarr's "Advanced Options."
-
-    ??? success "Screenshot example - [Click to show/hide]"
-        ![French Radarr MULTi settings](images/german-starr-multi-settings.png)
-
 ---
 
 ## Dealing with German Umlauts and German titles


### PR DESCRIPTION
# Pull Request

## Purpose

The MULTi Settings on Indexers is not needed for German releases as this Tag is not used. We need to remove it so it doesn't create false positives. 

## Approach

Removed the MULTi Recommendation

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
