### PR TITLE
fix(radarr): Adapt German CF to avoid matching DL

### DIFF
--- a/docs/json/radarr/cf/language-german.json
+++ b/docs/json/radarr/cf/language-german.json
@@ -23,6 +23,15 @@
       "fields": {
         "value": -2
       }
+    },
+    {
+      "name": "DL",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": true,
+      "required": false,
+      "fields": {
+        "value": "(?<!WEB[-_. ]?)\\b(DL)\\b"
+      }
     }
   ]
 }


### PR DESCRIPTION
# Pull Request

## Purpose

Apparently if Trackers report a file as German only and the title contains German.DL both the "German" CF as well as the "German DL (undefined)" CF are matching. Thats not desired.

## Approach

Change the German CF to not match DL.

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
