### PR TITLE
fix(radarr): Add missing entries to unwanted section of the german guide

### DIFF
--- a/includes/german-guide/radarr-german-unwanted-en.md
+++ b/includes/german-guide/radarr-german-unwanted-en.md
@@ -11,9 +11,9 @@
     | [{{ radarr['cf']['german-lq']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#german-lq)                                   |           {{ radarr['cf']['german-lq']['trash_scores']['default'] }}            | {{ radarr['cf']['german-lq']['trash_id'] }}             |
     | [{{ radarr['cf']['german-microsized']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#german-microsized)                   |       {{ radarr['cf']['german-microsized']['trash_scores']['default'] }}        | {{ radarr['cf']['german-microsized']['trash_id'] }}     |
     | [{{ radarr['cf']['x265-hd']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#x265-hd) :warning:                             |        :warning: {{ radarr['cf']['x265-hd']['trash_scores']['german'] }}        | {{ radarr['cf']['x265-hd']['trash_id'] }}               |
-    | [{{ radarr['cf']['extras']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#extras)                                         |        {{ radarr['cf']['extras']['trash_scores']['default'] }}                  | {{ radarr['cf']['extras']['trash_id'] }}                |
-    | [{{ radarr['cf']['av1']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#av1)                                               |          {{ radarr['cf']['av1']['trash_scores']['default'] }}                   | {{ radarr['cf']['av1']['trash_id'] }}                   |
-    | [{{ radarr['cf']['upscaled']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#upscaled)                                     |       {{ radarr['cf']['upscaled']['trash_scores']['default'] }}                 | {{ radarr['cf']['upscaled']['trash_id'] }}              |
+    | [{{ radarr['cf']['extras']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#extras)                                         |             {{ radarr['cf']['extras']['trash_scores']['default'] }}             | {{ radarr['cf']['extras']['trash_id'] }}                |
+    | [{{ radarr['cf']['av1']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#av1)                                               |              {{ radarr['cf']['av1']['trash_scores']['default'] }}               | {{ radarr['cf']['av1']['trash_id'] }}                   |
+    | [{{ radarr['cf']['upscaled']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#upscaled)                                     |            {{ radarr['cf']['upscaled']['trash_scores']['default'] }}            | {{ radarr['cf']['upscaled']['trash_id'] }}              |
 
     ---
 

--- a/includes/german-guide/radarr-german-unwanted-en.md
+++ b/includes/german-guide/radarr-german-unwanted-en.md
@@ -11,6 +11,9 @@
     | [{{ radarr['cf']['german-lq']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#german-lq)                                   |           {{ radarr['cf']['german-lq']['trash_scores']['default'] }}            | {{ radarr['cf']['german-lq']['trash_id'] }}             |
     | [{{ radarr['cf']['german-microsized']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#german-microsized)                   |       {{ radarr['cf']['german-microsized']['trash_scores']['default'] }}        | {{ radarr['cf']['german-microsized']['trash_id'] }}     |
     | [{{ radarr['cf']['x265-hd']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#x265-hd) :warning:                             |        :warning: {{ radarr['cf']['x265-hd']['trash_scores']['german'] }}        | {{ radarr['cf']['x265-hd']['trash_id'] }}               |
+    | [{{ radarr['cf']['extras']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#extras)                                         |        {{ radarr['cf']['extras']['trash_scores']['default'] }}                  | {{ radarr['cf']['extras']['trash_id'] }}                |
+    | [{{ radarr['cf']['av1']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#av1)                                               |          {{ radarr['cf']['av1']['trash_scores']['default'] }}                   | {{ radarr['cf']['av1']['trash_id'] }}                   |
+    | [{{ radarr['cf']['upscaled']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#upscaled)                                     |       {{ radarr['cf']['upscaled']['trash_scores']['default'] }}                 | {{ radarr['cf']['upscaled']['trash_id'] }}              |
 
     ---
 
@@ -24,6 +27,9 @@
     - **{{ radarr['cf']['german-lq']['name'] }}:** A collection of known Low Quality German groups that are often banned from the the top trackers because the lack of quality or other reasons.
     - **{{ radarr['cf']['german-microsized']['name'] }}:** A collection of German groups producing low quality micro-sized releases.
     - :warning: **{{ radarr['cf']['x265-hd']['name'] }}:** This blocks/ignores 720/1080p (HD) releases that are encoded in x265. However as there are certain german groups (ZeroTwo, VECTOR, ...) which produce high bitrate 1080p x265 encodes we recommend setting the score of this custom format to 0.
+    - **{{ radarr['cf']['extras']['name'] }}:** Blocks releases that only contain extras
+    - **{{ radarr['cf']['av1']['name'] }}:** This blocks all releases encoded in AV1.
+    - **{{ radarr['cf']['upscaled']['name'] }}:** A custom format to prevent Radarr from grabbing upscaled releases.
 
     ??? note "Optional - [Click to show/hide]"
 


### PR DESCRIPTION
# Pull Request

## Purpose

Upscaled, AV1 and Extras were missing in the unwanted section of the German Guide

## Approach

Added the missing CFs

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
