### PR TITLE
chore(guide): Add upcoming QP language option for the 3rd party sync apps

### DIFF
--- a/docs/json/radarr/quality-profiles/german-hd-bluray-web.json
+++ b/docs/json/radarr/quality-profiles/german-hd-bluray-web.json
@@ -5,7 +5,8 @@
   "upgradeAllowed": true,
   "cutoff": "Merged QPs",
   "minFormatScore": 0,
-  "cutoffFormatScore": 250000,
+  "cutoffFormatScore": 25000,
+  "language":"Any",
   "items": [
     { "name": "Unknown", "allowed": false },
     { "name": "WORKPRINT", "allowed": false },

--- a/docs/json/radarr/quality-profiles/german-uhd-bluray-web-alternative.json
+++ b/docs/json/radarr/quality-profiles/german-uhd-bluray-web-alternative.json
@@ -5,7 +5,8 @@
   "upgradeAllowed": true,
   "cutoff": "Merged QPs",
   "minFormatScore": 0,
-  "cutoffFormatScore": 250000,
+  "cutoffFormatScore": 25000,
+  "language":"Any",
   "items": [
     { "name": "Unknown", "allowed": false },
     { "name": "WORKPRINT", "allowed": false },

--- a/docs/json/radarr/quality-profiles/german-uhd-bluray-web.json
+++ b/docs/json/radarr/quality-profiles/german-uhd-bluray-web.json
@@ -5,7 +5,8 @@
   "upgradeAllowed": true,
   "cutoff": "Merged QPs",
   "minFormatScore": 0,
-  "cutoffFormatScore": 250000,
+  "cutoffFormatScore": 25000,
+  "language":"Any",
   "items": [
     { "name": "Unknown", "allowed": false },
     { "name": "WORKPRINT", "allowed": false },

--- a/docs/json/radarr/quality-profiles/german-uhd-remux-web.json
+++ b/docs/json/radarr/quality-profiles/german-uhd-remux-web.json
@@ -5,7 +5,8 @@
   "upgradeAllowed": true,
   "cutoff": "Merged QPs",
   "minFormatScore": 0,
-  "cutoffFormatScore": 250000,
+  "cutoffFormatScore": 25000,
+  "language":"Any",
   "items": [
     { "name": "Unknown", "allowed": false },
     { "name": "WORKPRINT", "allowed": false },

--- a/docs/json/radarr/quality-profiles/hd-bluray-web.json
+++ b/docs/json/radarr/quality-profiles/hd-bluray-web.json
@@ -5,6 +5,7 @@
   "cutoff": "Bluray-1080p",
   "minFormatScore": 0,
   "cutoffFormatScore": 10000,
+  "language":"Original",
   "items": [
     { "name": "Unknown", "allowed": false },
     { "name": "WORKPRINT", "allowed": false },

--- a/docs/json/radarr/quality-profiles/remux-web-1080p.json
+++ b/docs/json/radarr/quality-profiles/remux-web-1080p.json
@@ -5,6 +5,7 @@
   "cutoff": "Remux-1080p",
   "minFormatScore": 0,
   "cutoffFormatScore": 10000,
+  "language":"Original",
   "items": [
     { "name": "Unknown", "allowed": false },
     { "name": "WORKPRINT", "allowed": false },

--- a/docs/json/radarr/quality-profiles/remux-web-2160p.json
+++ b/docs/json/radarr/quality-profiles/remux-web-2160p.json
@@ -5,6 +5,7 @@
   "cutoff": "Remux-2160p",
   "minFormatScore": 0,
   "cutoffFormatScore": 10000,
+  "language":"Original",
   "items": [
     { "name": "Unknown", "allowed": false },
     { "name": "WORKPRINT", "allowed": false },

--- a/docs/json/radarr/quality-profiles/sqp-1-1080p.json
+++ b/docs/json/radarr/quality-profiles/sqp-1-1080p.json
@@ -6,6 +6,7 @@
   "cutoff": "Bluray|WEB-1080p",
   "minFormatScore": 1000,
   "cutoffFormatScore": 10000,
+  "language":"Original",
   "items": [
     { "name": "Unknown", "allowed": false },
     { "name": "WORKPRINT", "allowed": false },

--- a/docs/json/radarr/quality-profiles/sqp-1-2160p.json
+++ b/docs/json/radarr/quality-profiles/sqp-1-2160p.json
@@ -6,6 +6,7 @@
   "cutoff": "Bluray-2160p",
   "minFormatScore": 1000,
   "cutoffFormatScore": 10000,
+  "language":"Original",
   "items": [
     { "name": "Unknown", "allowed": false },
     { "name": "WORKPRINT", "allowed": false },

--- a/docs/json/radarr/quality-profiles/sqp-1-web-1080p.json
+++ b/docs/json/radarr/quality-profiles/sqp-1-web-1080p.json
@@ -6,6 +6,7 @@
   "cutoff": "Bluray|WEB-1080p",
   "minFormatScore": 1000,
   "cutoffFormatScore": 10000,
+  "language":"Original",
   "items": [
     { "name": "Unknown", "allowed": false },
     { "name": "WORKPRINT", "allowed": false },

--- a/docs/json/radarr/quality-profiles/sqp-2.json
+++ b/docs/json/radarr/quality-profiles/sqp-2.json
@@ -6,6 +6,7 @@
   "cutoff": "WEB|Remux|Bluray|2160p",
   "minFormatScore": 550,
   "cutoffFormatScore": 10000,
+  "language":"Original",
   "items": [
     { "name": "Unknown", "allowed": false },
     { "name": "WORKPRINT", "allowed": false },

--- a/docs/json/radarr/quality-profiles/sqp-3.json
+++ b/docs/json/radarr/quality-profiles/sqp-3.json
@@ -6,6 +6,7 @@
   "cutoff": "WEB|Remux|2160p",
   "minFormatScore": 550,
   "cutoffFormatScore": 10000,
+  "language":"Original",
   "items": [
     { "name": "Unknown", "allowed": false },
     { "name": "WORKPRINT", "allowed": false },

--- a/docs/json/radarr/quality-profiles/sqp-4.json
+++ b/docs/json/radarr/quality-profiles/sqp-4.json
@@ -6,6 +6,7 @@
   "cutoff": "WEB|2160p",
   "minFormatScore": 550,
   "cutoffFormatScore": 10000,
+  "language":"Original",
   "items": [
     { "name": "Unknown", "allowed": false },
     { "name": "WORKPRINT", "allowed": false },

--- a/docs/json/radarr/quality-profiles/sqp-5.json
+++ b/docs/json/radarr/quality-profiles/sqp-5.json
@@ -6,6 +6,7 @@
   "cutoff": "WEBDL|Bluray|2160p",
   "minFormatScore": 550,
   "cutoffFormatScore": 10000,
+  "language":"Original",
   "items": [
     { "name": "Unknown", "allowed": false },
     { "name": "WORKPRINT", "allowed": false },

--- a/docs/json/radarr/quality-profiles/uhd-bluray-web.json
+++ b/docs/json/radarr/quality-profiles/uhd-bluray-web.json
@@ -3,6 +3,9 @@
   "name": "UHD Bluray + WEB",
   "upgradeAllowed": true,
   "cutoff": "Bluray-2160p",
+  "minFormatScore": 0,
+  "cutoffFormatScore": 10000,
+  "language":"Original",
   "items": [
     { "name": "Unknown", "allowed": false },
     { "name": "WORKPRINT", "allowed": false },
@@ -47,8 +50,6 @@
     },
     { "name": "Bluray-2160p", "allowed": true }
   ],
-  "minFormatScore": 0,
-  "cutoffFormatScore": 10000,
   "formatItems": {
     "DV HDR10Plus": "c53085ddbd027d9624b320627748612f",
     "DV HDR10": "e23edd2482476e595fb990b12e7c609c",


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->

Add upcoming QP language option for the 3rd party sync apps.

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

- Add upcoming QP language option for the 3rd party sync apps
- Fixed: wrong max score for the German Quality Profiles
- Fixed inconsistent in one of the Quality Profiles

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
