### PR TITLE
chore(cleanup): remove reference to animebytes.tv

### DIFF
--- a/docs/Radarr/radarr-setup-quality-profiles-anime.md
+++ b/docs/Radarr/radarr-setup-quality-profiles-anime.md
@@ -9,11 +9,7 @@ _aka How to set up Custom Formats (Anime)_<br><br>
 It's recommended to run two Radarr instances. One for Anime Movies and one for Normal Movies, or you can make use of Quality Profiles and score different Custom Formats (CFs) as required.
 
 The aim of this guide is to grab the best release overall (as per [SeaDex](https://releases.moe/){:target="\_blank" rel="noopener noreferrer"}) and not necessarily just dual audio.
-The vast majority of releases can be found on [Nyaa](https://nyaa.si/){:target="\_blank" rel="noopener noreferrer"} or [AB](https://animebytes.tv/){:target="\_blank" rel="noopener noreferrer"}
-
-!!! info ""
-
-    Nyaa is a public tracker while AB is an invite only tracker.
+The vast majority of releases can be found on [Nyaa](https://nyaa.si/){:target="\_blank" rel="noopener noreferrer"}
 
 ---
 

--- a/docs/Sonarr/sonarr-setup-quality-profiles-anime.md
+++ b/docs/Sonarr/sonarr-setup-quality-profiles-anime.md
@@ -15,11 +15,7 @@ _aka How to set up Custom Formats (Anime)_<br><br>
 It's recommended to run two Sonarr instances. One for Anime and one for normal TV shows, or you can make use of Quality Profiles and score different Custom Formats (CFs) as required.
 
 This guide aims to grab the best release overall (as per [SeaDex](https://releases.moe/){:target="\_blank" rel="noopener noreferrer"}) and not necessarily just dual audio.
-The vast majority of releases can be found on [Nyaa](https://nyaa.si/){:target="\_blank" rel="noopener noreferrer"} or [AB](https://animebytes.tv/){:target="\_blank" rel="noopener noreferrer"}
-
-!!! info ""
-
-    Nyaa is a public tracker while AB is an invite-only tracker.
+The vast majority of releases can be found on [Nyaa](https://nyaa.si/){:target="\_blank" rel="noopener noreferrer"}
 
 ---
 


### PR DESCRIPTION
# Pull Request

## Purpose

Removes references to animebytes.tv from "Quality Profiles Anime" guides. We do not accept new members and have found that a lot of new users are approaching us in attempt to create account after discovering our site from this guide.

## Approach

Simply removes reference to site from guide text; left public Nyaa as-is.

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
