### PR TITLE
fix(starr):  add DUAL-VARYG to Dual Audio Custom Anime Format

### DIFF
--- a/docs/json/radarr/cf/anime-dual-audio.json
+++ b/docs/json/radarr/cf/anime-dual-audio.json
@@ -9,7 +9,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "dual[ ._-]?audio|[([]dual[])]|(JA|ZH|KO)\\+EN|EN\\+(JA|ZH|KO)"
+        "value": "dual[ ._-]?(audio|varyg)|[([]dual[])]|(JA|ZH|KO)\\+EN|EN\\+(JA|ZH|KO)"
       }
     },
     {

--- a/docs/json/sonarr/cf/anime-dual-audio.json
+++ b/docs/json/sonarr/cf/anime-dual-audio.json
@@ -9,7 +9,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "dual[ ._-]?audio|[([]dual[])]|(JA|ZH|KO)\\+EN|EN\\+(JA|ZH|KO)"
+        "value": "dual[ ._-]?(audio|varyg)|[([]dual[])]|(JA|ZH|KO)\\+EN|EN\\+(JA|ZH|KO)"
       }
     },
     {


### PR DESCRIPTION
# Pull Request
Update Anime Dual Audio Custom Format with ability to parse Dual VARYG as well

## Purpose
Due to DUAL VARYG file naming it doesn't match default Dual Audio regex, with tweaked regex it works just fine

## Approach
```
BLEACH.Thousand.Year.Blood.War.S01E36.BABY.HOLD.YOUR.HAND.2.NEVER.ENDING.MY.DREAM.1080p.DSNP.WEB-DL.AAC2.0.H.264.DUAL-VARYG.mkv
```
doesn't meat dual audio format regext:
![image](https://github.com/user-attachments/assets/3a3cabfb-cf61-4408-8da4-9dcdcd649364)

where new regex handles it well:
<img width="963" alt="image" src="https://github.com/user-attachments/assets/a2be68c7-acf9-4d24-9114-2cd4ddda1b2a" />

## Open Questions and Pre-Merge TODOs
None

## Requirements

- [X] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [X] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
