### PR TITLE
feat(Guide): Add C1NEM4 and SUNSCREEN to Radarr LQ Custom Format

### DIFF
--- a/docs/json/radarr/cf/lq.json
+++ b/docs/json/radarr/cf/lq.json
@@ -97,6 +97,15 @@
       }
     },
     {
+      "name": "C1NEM4",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(C1NEM4)$"
+      }
+    },
+    {
       "name": "C4K",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,
@@ -670,6 +679,15 @@
       "required": false,
       "fields": {
         "value": "^(STUTTERSHIT)$"
+      }
+    },
+    {
+      "name": "SUNSCREEN",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(SUNSCREEN)$"
       }
     },
     {


### PR DESCRIPTION
# Pull Request
## Purpose

Both use the same source, filled with advertisements including; floating texts, clips in-between scenes, and large graphics.

Resolves #2201   
## Approach

Added: `SUNSCREEN` and `C1NEM4` to Radarr `LQ` Custom Format
## Open Questions and Pre-Merge TODOs
## Requirements

   * [x]  These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).

  * [x]  I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).

