### PR TITLE
feat(radarr): German Guide - add "not english or german" CF and explanation for the max CF score

### DIFF
--- a/docs/Radarr/Radarr-collection-of-custom-formats.md
+++ b/docs/Radarr/Radarr-collection-of-custom-formats.md
@@ -95,36 +95,36 @@ We've made 3 guides related to this.
 
 ---
 
-| Miscellaneous                          | Language profiles                                                |
-| -------------------------------------- | ---------------------------------------------------------------- |
-| [Bad Dual Groups](#bad-dual-groups)    | [Language: German](#language-german)                             |
-| [Dutch Groups](#dutch-groups)          | [Language: German DL](#language-german-dl)                       |
-| [DV (Disk)](#dv-disk)                  | [Language: German DL (undefined)](#language-german-dl-undefined) |
-| [DV (WEBDL)](#dv-webdl)                | [Language: Not English (English Only)](#language-not-english)    |
-| [DV HDR10+ Boost](#dv-hdr10plus-boost) | [Language: Not French (French Only)](#language-not-french)       |
-| [EVO (no WEBDL)](#evo-no-webdl)        | [Language: Not Original (Original Only)](#language-not-original) |
-| [FreeLeech](#freeleech)                | [Language: Original + French](#language-original-plus-french)    |
-| [HDR10+ Boost](#hdr10plus-boost)       |                                                                  |
-| [HFR](#hfr)                            |                                                                  |
-| [Internal](#internal)                  |                                                                  |
-| [Line/Mic Dubbed](#linemic-dubbed)     |                                                                  |
-| [MPEG2](#mpeg2)                        |                                                                  |
-| [Multi](#multi)                        |                                                                  |
-| [No-RlsGroup](#no-rlsgroup)            |                                                                  |
-| [Obfuscated](#obfuscated)              |                                                                  |
-| [Repack/Proper](#repackproper)         |                                                                  |
-| [Repack2](#repack2)                    |                                                                  |
-| [Repack3](#repack3)                    |                                                                  |
-| [Retags](#retags)                      |                                                                  |
-| [Scene](#scene)                        |                                                                  |
-| [SDR (no WEBDL)](#sdr-no-webdl)        |                                                                  |
-| [SDR](#sdr)                            |                                                                  |
-| [VC-1](#vc-1)                          |                                                                  |
-| [VP9](#vp9)                            |                                                                  |
-| [x264](#x264)                          |                                                                  |
-| [x265 (no HDR/DV)](#x265-no-hdrdv)     |                                                                  |
-| [x265](#x265)                          |                                                                  |
-| [x266](#x266)                          |                                                                  |
+| Miscellaneous                          | Language profiles                                                  |
+| -------------------------------------- | ------------------------------------------------------------------ |
+| [Bad Dual Groups](#bad-dual-groups)    | [Language: German](#language-german)                               |
+| [Dutch Groups](#dutch-groups)          | [Language: German DL](#language-german-dl)                         |
+| [DV (Disk)](#dv-disk)                  | [Language: German DL (undefined)](#language-german-dl-undefined)   |
+| [DV (WEBDL)](#dv-webdl)                | [Language: Not English (English Only)](#language-not-english)      |
+| [DV HDR10+ Boost](#dv-hdr10plus-boost) | [Language: Not French (French Only)](#language-not-french)         |
+| [EVO (no WEBDL)](#evo-no-webdl)        | [Language: Not Original (Original Only)](#language-not-original)   |
+| [FreeLeech](#freeleech)                | [Language: Original + French](#language-original-plus-french)      |
+| [HDR10+ Boost](#hdr10plus-boost)       | [Language: Not German or English](#language-not-german-or-english) |
+| [HFR](#hfr)                            |                                                                    |
+| [Internal](#internal)                  |                                                                    |
+| [Line/Mic Dubbed](#linemic-dubbed)     |                                                                    |
+| [MPEG2](#mpeg2)                        |                                                                    |
+| [Multi](#multi)                        |                                                                    |
+| [No-RlsGroup](#no-rlsgroup)            |                                                                    |
+| [Obfuscated](#obfuscated)              |                                                                    |
+| [Repack/Proper](#repackproper)         |                                                                    |
+| [Repack2](#repack2)                    |                                                                    |
+| [Repack3](#repack3)                    |                                                                    |
+| [Retags](#retags)                      |                                                                    |
+| [Scene](#scene)                        |                                                                    |
+| [SDR (no WEBDL)](#sdr-no-webdl)        |                                                                    |
+| [SDR](#sdr)                            |                                                                    |
+| [VC-1](#vc-1)                          |                                                                    |
+| [VP9](#vp9)                            |                                                                    |
+| [x264](#x264)                          |                                                                    |
+| [x265 (no HDR/DV)](#x265-no-hdrdv)     |                                                                    |
+| [x265](#x265)                          |                                                                    |
+| [x266](#x266)                          |                                                                    |
 
 ---
 
@@ -3594,6 +3594,22 @@ We've made 3 guides related to this.
 
     ```json
     [[% filter indent(width=4) %]][[% include 'json/radarr/cf/language-german.json' %]][[% endfilter %]]
+    ```
+
+<sub><sup>[TOP](#index)</sup></sub>
+
+---
+
+### Language: Not German or English
+
+??? question "German - [Click to show/hide]"
+
+    {! include-markdown "../../includes/cf-descriptions/language-not-german-english.md" !}
+
+??? example "JSON - [Click to show/hide]"
+
+    ```json
+    [[% filter indent(width=4) %]][[% include 'json/radarr/cf/language-not-german-english.json' %]][[% endfilter %]]
     ```
 
 <sub><sup>[TOP](#index)</sup></sub>

--- a/docs/Radarr/radarr-setup-quality-profiles-german-en.md
+++ b/docs/Radarr/radarr-setup-quality-profiles-german-en.md
@@ -75,10 +75,10 @@ There are a couple of changes that are needed for German Custom Formats to work 
         Radarr supports the ISO-2 naming convention for naming movies, so replacing `{Movie CleanTitle}` with `{Movie CleanTitle:de}` will change the name to its German version.
 
 ??? abstract "Set the Maximum Custom Format Score - [Click to show/hide]"
-    To allow upgradeability until the best possible quality, we set the `Upgrade Until Custom Format Score` to `25k` which is more than the highest reachable score.
+    To allow upgradeability to the best possible quality, we set the `Upgrade Until Custom Format Score` to `25k`, which is more than the highest reachable score.
 
     !!! tip "Tip"
-        If you want to cut off upgrades at a specific score feel free to adapt this setting based on your needs.
+        If you want to stop upgrades at a specific score, feel free to adapt this setting based on your needs.
 
 ---
 

--- a/docs/Radarr/radarr-setup-quality-profiles-german-en.md
+++ b/docs/Radarr/radarr-setup-quality-profiles-german-en.md
@@ -74,6 +74,12 @@ There are a couple of changes that are needed for German Custom Formats to work 
     !!! tip "Movie format/folder with the German movie name."
         Radarr supports the ISO-2 naming convention for naming movies, so replacing `{Movie CleanTitle}` with `{Movie CleanTitle:de}` will change the name to its German version.
 
+??? abstract "Set the Maximum Custom Format Score - [Click to show/hide]"
+    To allow upgradeability until the best possible quality, we set the `Upgrade Until Custom Format Score` to `25k` which is more than the highest reachable score.
+
+    !!! tip "Tip"
+        If you want to cut off upgrades at a specific score feel free to adapt this setting based on your needs.
+
 ---
 
 ## Dealing with German Umlauts and German titles

--- a/docs/json/radarr/cf/language-not-german-english.json
+++ b/docs/json/radarr/cf/language-not-german-english.json
@@ -1,7 +1,7 @@
 {
   "trash_id": "4eadb75fb23d09dfc0a8e3f687e72287",
   "trash_scores": {
-      "default": -20000
+    "default": -20000
   },
   "name": "Not German or English",
   "includeCustomFormatWhenRenaming": false,

--- a/docs/json/radarr/cf/language-not-german-english.json
+++ b/docs/json/radarr/cf/language-not-german-english.json
@@ -1,0 +1,37 @@
+{
+  "trash_id": "4eadb75fb23d09dfc0a8e3f687e72287",
+  "trash_scores": {
+      "default": -20000
+  },
+  "name": "Not German or English",
+  "includeCustomFormatWhenRenaming": false,
+  "specifications": [
+    {
+      "name": "Not English Language",
+      "implementation": "LanguageSpecification",
+      "negate": true,
+      "required": true,
+      "fields": {
+        "value": 1
+      }
+    },
+    {
+      "name": "Not German Language",
+      "implementation": "LanguageSpecification",
+      "negate": true,
+      "required": true,
+      "fields": {
+        "value": 4
+      }
+    },
+    {
+      "name": "Not German in Title",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": true,
+      "required": true,
+      "fields": {
+        "value": "(?i)\\bgerman\\b"
+      }
+    }
+  ]
+}

--- a/docs/json/radarr/quality-profiles/german-hd-bluray-web.json
+++ b/docs/json/radarr/quality-profiles/german-hd-bluray-web.json
@@ -1,6 +1,7 @@
 {
   "trash_id": "2b90e905c99490edc7c7a5787443748b",
   "name": "[German] HD Bluray + WEB",
+  "trash_description": "German Quality Profile that covers:<br>- WEBDL-720p<br>- Bluray-720p<br>- WEBDL-1080p<br>- Bluray-1080p",
   "trash_score_set": "german",
   "upgradeAllowed": true,
   "cutoff": "Merged QPs",
@@ -58,6 +59,7 @@
     "German": "86bc3115eb4e9873ac96904a4a68e19e",
     "German DL": "f845be10da4f442654c13e1f2c3d6cd5",
     "German DL (undefined)": "6aad77771dabe9d3e9d7be86f310b867",
+    "Not German or English": "4eadb75fb23d09dfc0a8e3f687e72287",
     "German Bluray Tier 01": "54795711b78ea87e56127928c423689b",
     "German Bluray Tier 02": "1bfc773c53283d47c68e535811da30b7",
     "German Bluray Tier 03": "aee01d40cd1bf4bcded81ee62f0f3659",

--- a/docs/json/radarr/quality-profiles/german-uhd-bluray-web-alternative.json
+++ b/docs/json/radarr/quality-profiles/german-uhd-bluray-web-alternative.json
@@ -1,6 +1,7 @@
 {
   "trash_id": "425da1ba30711b55d2eb371437ec98d7",
   "name": "[German] UHD Bluray + WEB (Alternative)",
+  "trash_description": "German Quality Profile that covers:<br>- WEBDL-720p<br>- Bluray-720p<br>- WEBDL-1080p<br>- Bluray-1080p<br>- WEBDL-2160p<br>- - Bluray-2160p",
   "trash_score_set": "german",
   "upgradeAllowed": true,
   "cutoff": "Merged QPs",
@@ -57,6 +58,7 @@
     "German": "86bc3115eb4e9873ac96904a4a68e19e",
     "German DL": "f845be10da4f442654c13e1f2c3d6cd5",
     "German DL (undefined)": "6aad77771dabe9d3e9d7be86f310b867",
+    "Not German or English": "4eadb75fb23d09dfc0a8e3f687e72287",
     "German Bluray Tier 01": "54795711b78ea87e56127928c423689b",
     "German Bluray Tier 02": "1bfc773c53283d47c68e535811da30b7",
     "German Bluray Tier 03": "aee01d40cd1bf4bcded81ee62f0f3659",

--- a/docs/json/radarr/quality-profiles/german-uhd-bluray-web.json
+++ b/docs/json/radarr/quality-profiles/german-uhd-bluray-web.json
@@ -1,6 +1,7 @@
 {
   "trash_id": "27cc3d153c0a799fd139ef1ff4c4cc42",
   "name": "[German] UHD Bluray + WEB",
+  "trash_description": "German Quality Profile that covers:<br>- Bluray-720p<br>- WEBDL-1080p<br>- Bluray-1080p<br>- WEBDL-2160p<br>- Bluray-2160p",
   "trash_score_set": "german",
   "upgradeAllowed": true,
   "cutoff": "Merged QPs",
@@ -63,6 +64,7 @@
     "German": "86bc3115eb4e9873ac96904a4a68e19e",
     "German DL": "f845be10da4f442654c13e1f2c3d6cd5",
     "German DL (undefined)": "6aad77771dabe9d3e9d7be86f310b867",
+    "Not German or English": "4eadb75fb23d09dfc0a8e3f687e72287",
     "German Bluray Tier 01": "54795711b78ea87e56127928c423689b",
     "German Bluray Tier 02": "1bfc773c53283d47c68e535811da30b7",
     "German Bluray Tier 03": "aee01d40cd1bf4bcded81ee62f0f3659",

--- a/docs/json/radarr/quality-profiles/german-uhd-remux-web.json
+++ b/docs/json/radarr/quality-profiles/german-uhd-remux-web.json
@@ -1,6 +1,7 @@
 {
   "trash_id": "79faa9943cef2f510b997b1f2a9f3ea6",
   "name": "[German] Remux + WEB 2160p",
+  "trash_description": "German Quality Profile that covers:<br>- WEBDL-2160p<br>- Remux-2160p",
   "trash_score_set": "german",
   "upgradeAllowed": true,
   "cutoff": "Merged QPs",
@@ -63,6 +64,7 @@
     "German": "86bc3115eb4e9873ac96904a4a68e19e",
     "German DL": "f845be10da4f442654c13e1f2c3d6cd5",
     "German DL (undefined)": "6aad77771dabe9d3e9d7be86f310b867",
+    "Not German or English": "4eadb75fb23d09dfc0a8e3f687e72287",
     "German Remux Tier 01": "8608a2ed20c636b8a62de108e9147713",
     "German Remux Tier 02": "f9cf598d55ce532d63596b060a6db9ee",
     "German Web Tier 01": "a2ab25194f463f057a5559c03c84a3df",

--- a/includes/cf-descriptions/language-not-german-english.md
+++ b/includes/cf-descriptions/language-not-german-english.md
@@ -1,0 +1,5 @@
+<!-- markdownlint-disable MD041-->
+**Language: Not German or English**<br>
+
+Used to avoid releases which do not contain German or Eenglish audio.
+<!-- markdownlint-enable MD041-->

--- a/includes/cf-descriptions/language-not-german-english.md
+++ b/includes/cf-descriptions/language-not-german-english.md
@@ -1,5 +1,5 @@
 <!-- markdownlint-disable MD041-->
 **Language: Not German or English**<br>
 
-Used to avoid releases which do not contain German or Eenglish audio.
+Used to avoid releases which do not contain German or English audio.
 <!-- markdownlint-enable MD041-->

--- a/includes/german-guide/radarr-german-audio-version-en.md
+++ b/includes/german-guide/radarr-german-audio-version-en.md
@@ -1,17 +1,19 @@
 <!-- markdownlint-disable MD041-->
 ??? abstract "German Audio - [Click to show/hide]"
 
-    | Custom Format                                                                                                                           | Score                                                                         | Trash ID                                                       |
-    | --------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- | -------------------------------------------------------------- |
-    | [{{ radarr['cf']['language-german']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#language-german)                           | {{ radarr['cf']['language-german']['trash_scores']['default'] }}              | {{ radarr['cf']['language-german']['trash_id'] }}              |
-    | [{{ radarr['cf']['language-german-dl']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#language-german-dl)                     | {{ radarr['cf']['language-german-dl']['trash_scores']['german'] }}            | {{ radarr['cf']['language-german-dl']['trash_id'] }}           |
-    | [{{ radarr['cf']['language-german-dl-undefined']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#language-german-dl-undefined) | {{ radarr['cf']['language-german-dl-undefined']['trash_scores']['default'] }} | {{ radarr['cf']['language-german-dl-undefined']['trash_id'] }} |
+    | Custom Format                                                                                                                            | Score                                                                         | Trash ID                                                       |
+    | ---------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- | -------------------------------------------------------------- |
+    | [{{ radarr['cf']['language-german']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#language-german)                            | {{ radarr['cf']['language-german']['trash_scores']['default'] }}              | {{ radarr['cf']['language-german']['trash_id'] }}              |
+    | [{{ radarr['cf']['language-german-dl']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#language-german-dl)                      | {{ radarr['cf']['language-german-dl']['trash_scores']['german'] }}            | {{ radarr['cf']['language-german-dl']['trash_id'] }}           |
+    | [{{ radarr['cf']['language-german-dl-undefined']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#language-german-dl-undefined)  | {{ radarr['cf']['language-german-dl-undefined']['trash_scores']['default'] }} | {{ radarr['cf']['language-german-dl-undefined']['trash_id'] }} |
+    | [{{ radarr['cf']['language-not-german-english']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#language-not-german-or-english) | {{ radarr['cf']['language-not-german-english']['trash_scores']['default'] }}  | {{ radarr['cf']['language-not-german-english']['trash_id'] }}  |
 
     ---
 
     Breakdown and Why
 
-    - **{{ radarr['cf']['language-german-dl']['name'] }}:** This custom format helps Radarr/Sonarr recognize German Dual Language audio releases. It will add `German DL` to your filename.
+    - **{{ radarr['cf']['language-german-dl']['name'] }}:** This custom format helps Radarr recognize German Dual Language audio releases. It will add `German DL` to your filename.
     - **{{ radarr['cf']['language-german-dl-undefined']['name'] }}:** This Custom Format is mainly used to fix files that are wrongly named after import. For example, suppose the filename suggests it is only German but actually contains German and English audio. It is also useful for users who use a non-optimal file naming that does not follow suggested naming schemes, example: `John Wick Kapitel 2 (2017) [2160p] [HDR] [7.1, 7.1] [ger, eng] [Vio]`
-    - **{{ radarr['cf']['language-german']['name'] }}:** This custom format helps Radarr/Sonarr recognize German audio releases that contain only a German language track and no others. It will add `German` to your filename.
+    - **{{ radarr['cf']['language-german']['name'] }}:** This custom format helps Radarr recognize German audio releases that contain only a German language track and no others. It will add `German` to your filename.
+    - **{{ radarr['cf']['language-not-german-english']['name'] }}:** This custom format is used to avoid releases which do not contain German or English audio.
 <!-- markdownlint-enable MD041-->


### PR DESCRIPTION
# Pull Request

## Purpose

1. We want to explain why we use 25k as the max CF score
2. We need a CF to avoid releases which do not contain German or English Audio

## Approach

Added paragraph to address 1 
Added "Not English or German" CF to address 2

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
