### PR TITLE
fix(radarr): German Guide - add negated remux quality modifier to bluray groups to avoid double scoring

### DIFF
--- a/docs/json/radarr/cf/german-bluray-tier-01.json
+++ b/docs/json/radarr/cf/german-bluray-tier-01.json
@@ -77,6 +77,15 @@
       "fields": {
         "value": 9
       }
+    },
+    {
+      "name": "Not Remux",
+      "implementation": "QualityModifierSpecification",
+      "negate": true,
+      "required": true,
+      "fields": {
+        "value": 5
+      }
     }
   ]
 }

--- a/docs/json/radarr/cf/german-bluray-tier-02.json
+++ b/docs/json/radarr/cf/german-bluray-tier-02.json
@@ -59,6 +59,15 @@
       "fields": {
         "value": 9
       }
+    },
+    {
+      "name": "Not Remux",
+      "implementation": "QualityModifierSpecification",
+      "negate": true,
+      "required": true,
+      "fields": {
+        "value": 5
+      }
     }
   ]
 }

--- a/docs/json/radarr/cf/german-bluray-tier-03.json
+++ b/docs/json/radarr/cf/german-bluray-tier-03.json
@@ -23,6 +23,15 @@
       "fields": {
         "value": 9
       }
+    },
+    {
+      "name": "Not Remux",
+      "implementation": "QualityModifierSpecification",
+      "negate": true,
+      "required": true,
+      "fields": {
+        "value": 5
+      }
     }
   ]
 }


### PR DESCRIPTION
# Pull Request

## Purpose

If a group is in the Bluray and the Remux Tiers we have double scoring.

## Approach

Add a negated remux condition to the bluray groups.

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
