### PR TITLE
chore(backend-test): add `MinUpgradeFormatScore` for the 3rd party sync apps

### DIFF
--- a/docs/json/radarr/quality-profiles/german-hd-bluray-web.json
+++ b/docs/json/radarr/quality-profiles/german-hd-bluray-web.json
@@ -6,6 +6,7 @@
   "upgradeAllowed": true,
   "cutoff": "Merged QPs",
   "minFormatScore": 0,
+  "MinUpgradeFormatScore": 1,
   "cutoffFormatScore": 25000,
   "language":"Any",
   "items": [

--- a/docs/json/radarr/quality-profiles/german-uhd-bluray-web-alternative.json
+++ b/docs/json/radarr/quality-profiles/german-uhd-bluray-web-alternative.json
@@ -6,6 +6,7 @@
   "upgradeAllowed": true,
   "cutoff": "Merged QPs",
   "minFormatScore": 0,
+  "MinUpgradeFormatScore": 1,
   "cutoffFormatScore": 25000,
   "language":"Any",
   "items": [

--- a/docs/json/radarr/quality-profiles/german-uhd-bluray-web.json
+++ b/docs/json/radarr/quality-profiles/german-uhd-bluray-web.json
@@ -6,6 +6,7 @@
   "upgradeAllowed": true,
   "cutoff": "Merged QPs",
   "minFormatScore": 0,
+  "MinUpgradeFormatScore": 1,
   "cutoffFormatScore": 25000,
   "language":"Any",
   "items": [

--- a/docs/json/radarr/quality-profiles/german-uhd-remux-web.json
+++ b/docs/json/radarr/quality-profiles/german-uhd-remux-web.json
@@ -6,6 +6,7 @@
   "upgradeAllowed": true,
   "cutoff": "Merged QPs",
   "minFormatScore": 0,
+  "MinUpgradeFormatScore": 1,
   "cutoffFormatScore": 25000,
   "language":"Any",
   "items": [


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->

This is a test to solve an error when you try to add a new QP to your Starr app with Notifiarr. Perhaps we should just add it to the JSON for future reference/changes and to be consistent.

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

Added `MinUpgradeFormatScore` to a QP JSON.

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
