### PR TITLE
fix(radarr): Add RILE and W4K to German Scene; AVTOMAT to German LQ

### DIFF
--- a/docs/json/radarr/cf/german-lq.json
+++ b/docs/json/radarr/cf/german-lq.json
@@ -329,6 +329,15 @@
       "fields": {
         "value": "(LizardSquad)$"
       }
+    },
+    {
+      "name": "AVTOMAT",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(AVTOMAT)$"
+      }
     }
   ]
 }

--- a/docs/json/radarr/cf/german-scene.json
+++ b/docs/json/radarr/cf/german-scene.json
@@ -185,6 +185,24 @@
       "fields": {
         "value": "^(muhHD)$"
       }
+    },
+    {
+      "name": "RILE",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(RILE)$"
+      }
+    },
+    {
+      "name": "W4K",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(W4K)$"
+      }
     }
   ]
 }

--- a/docs/json/radarr/cf/german-scene.json
+++ b/docs/json/radarr/cf/german-scene.json
@@ -187,12 +187,12 @@
       }
     },
     {
-      "name": "RILE",
+      "name": "RiLE",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,
       "required": false,
       "fields": {
-        "value": "^(RILE)$"
+        "value": "^(RiLE)$"
       }
     },
     {


### PR DESCRIPTION
# Pull Request

## Purpose

Add RILE and W4K to the German Scene CF
Add AVTOMAT to German LQ for stealing from WAYNE

## Approach

Add the Groups to the CF

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
