### PR TITLE
feat(radarr): add ZeroTwo aliases to German Tier 01 CFs

### DIFF
--- a/docs/json/radarr/cf/german-bluray-tier-01.json
+++ b/docs/json/radarr/cf/german-bluray-tier-01.json
@@ -12,7 +12,16 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "(ZeroTwo)$"
+        "value": "^(ZeroTwo)$"
+      }
+    },
+    {
+      "name": "ZeroTwo Aliases",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\b(BUTTERCUP|HARTZ02|XiSS|DOGPACK404|PRiNCESSDiANA|DiVA)\b"
       }
     },
     {
@@ -21,7 +30,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "(TSCC)$"
+        "value": "^(TSCC)$"
       }
     },
     {
@@ -30,7 +39,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "(TvR)$"
+        "value": "^(TvR)$"
       }
     },
     {
@@ -39,7 +48,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "(NIMA4K)$"
+        "value": "^(NIMA4K)$"
       }
     },
     {
@@ -48,7 +57,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "(TVS)$"
+        "value": "^(TVS)$"
       }
     },
     {
@@ -57,7 +66,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "(PXL)$"
+        "value": "^(PXL)$"
       }
     },
     {
@@ -66,7 +75,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "(CNY)$"
+        "value": "^(CNY)$"
       }
     },
     {

--- a/docs/json/radarr/cf/german-web-tier-01.json
+++ b/docs/json/radarr/cf/german-web-tier-01.json
@@ -12,7 +12,16 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "(ZeroTwo)$"
+        "value": "^(ZeroTwo)$"
+      }
+    },
+    {
+      "name": "ZeroTwo Aliases",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\b(BUTTERCUP|HARTZ02|XiSS|DOGPACK404|PRiNCESSDiANA|DiVA)\b"
       }
     },
     {
@@ -21,7 +30,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "(TSCC)$"
+        "value": "^(TSCC)$"
       }
     },
     {
@@ -30,7 +39,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "(TvR)$"
+        "value": "^(TvR)$"
       }
     },
     {
@@ -39,7 +48,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "(NIMA4K)$"
+        "value": "^(NIMA4K)$"
       }
     },
     {
@@ -48,7 +57,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "(TVS)$"
+        "value": "^(TVS)$"
       }
     },
     {
@@ -57,7 +66,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "(D02KU)$"
+        "value": "^(D02KU)$"
       }
     },
     {
@@ -66,7 +75,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "(PXL)$"
+        "value": "^(PXL)$"
       }
     },
     {
@@ -75,7 +84,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "(QfG)$"
+        "value": "^(QfG)$"
       }
     },
     {
@@ -84,7 +93,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "(CNY)$"
+        "value": "^(CNY)$"
       }
     },
     {


### PR DESCRIPTION
# Pull Request

## Purpose

The renowned German group ZeroTwo has a couple of aliases which need to be added to the German Tiers.

## Approach

Add the aliases into the German Bluray and Web Tier 01, to have aliases more easily maintainable we decided to add them into one condition called ZeroTwo Aliases. 

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
