### PR TITLE
fix(starr): add more Groups to German Tier CFs

### DIFF
--- a/docs/json/radarr/cf/german-bluray-tier-03.json
+++ b/docs/json/radarr/cf/german-bluray-tier-03.json
@@ -12,7 +12,16 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "(RobertDeNiro)$"
+        "value": "^(RobertDeNiro)$"
+      }
+    },
+    {
+      "name": "LeetHD",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(LeetHD)$"
       }
     },
     {

--- a/docs/json/radarr/cf/german-lq.json
+++ b/docs/json/radarr/cf/german-lq.json
@@ -338,6 +338,15 @@
       "fields": {
         "value": "^(AVTOMAT)$"
       }
+    },
+    {
+      "name": "iSSEYMiYAKE",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(iSSEYMiYAKE)$"
+      }
     }
   ]
 }

--- a/docs/json/radarr/cf/german-scene.json
+++ b/docs/json/radarr/cf/german-scene.json
@@ -212,6 +212,33 @@
       "fields": {
         "value": "^(ENDSTATiON)$"
       }
+    },
+    {
+      "name": "HDARCHiV",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(HDARCHiV)$"
+      }
+    },
+    {
+      "name": "PL3X",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(PL3X)$"
+      }
+    },
+    {
+      "name": "WATCHABLE",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(WATCHABLE)$"
+      }
     }
   ]
 }

--- a/docs/json/radarr/cf/german-scene.json
+++ b/docs/json/radarr/cf/german-scene.json
@@ -203,6 +203,15 @@
       "fields": {
         "value": "^(W4K)$"
       }
+    },
+    {
+      "name": "ENDSTATiON",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(ENDSTATiON)$"
+      }
     }
   ]
 }

--- a/docs/json/sonarr/cf/german-bluray-tier-01.json
+++ b/docs/json/sonarr/cf/german-bluray-tier-01.json
@@ -21,7 +21,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "\\b(BUTTERCUP|HARTZ02|XiSS|DOGPACK404|PRiNCESSDiANA|DiVA)\\b"
+        "value": "\\b(BUTTERCUP|HARTZ02|XiSS|DOGPACK404|PRiNCESSDiANA|DiVA|D02KU)\\b"
       }
     },
     {

--- a/docs/json/sonarr/cf/german-lq.json
+++ b/docs/json/sonarr/cf/german-lq.json
@@ -338,6 +338,15 @@
       "fields": {
         "value": "^(AVTOMAT)$"
       }
+    },
+    {
+      "name": "iSSEYMiYAKE",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(iSSEYMiYAKE)$"
+      }
     }
   ]
 }

--- a/docs/json/sonarr/cf/german-scene.json
+++ b/docs/json/sonarr/cf/german-scene.json
@@ -185,6 +185,15 @@
       "fields": {
         "value": "^(muhHD)$"
       }
+    },
+    {
+      "name": "ENDSTATiON",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(ENDSTATiON)$"
+      }
     }
   ]
 }

--- a/docs/json/sonarr/cf/german-scene.json
+++ b/docs/json/sonarr/cf/german-scene.json
@@ -194,6 +194,33 @@
       "fields": {
         "value": "^(ENDSTATiON)$"
       }
+    },
+    {
+      "name": "HDARCHiV",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(HDARCHiV)$"
+      }
+    },
+    {
+      "name": "PL3X",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(PL3X)$"
+      }
+    },
+    {
+      "name": "WATCHABLE",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(WATCHABLE)$"
+      }
     }
   ]
 }

--- a/docs/json/sonarr/cf/german-web-tier-01.json
+++ b/docs/json/sonarr/cf/german-web-tier-01.json
@@ -21,7 +21,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "\\b(BUTTERCUP|HARTZ02|XiSS|DOGPACK404|PRiNCESSDiANA|DiVA)\\b"
+        "value": "\\b(BUTTERCUP|HARTZ02|XiSS|DOGPACK404|PRiNCESSDiANA|DiVA|D02KU)\\b"
       }
     },
     {
@@ -58,15 +58,6 @@
       "required": false,
       "fields": {
         "value": "^(TVS)$"
-      }
-    },
-    {
-      "name": "D02KU",
-      "implementation": "ReleaseGroupSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "^(D02KU)$"
       }
     },
     {


### PR DESCRIPTION
# Pull Request

## Purpose

- ENDSTATiON, PL3X, HDARCHiV, WATCHABLE to German Scene
- iSSEYMiYAKE to German LQ - Reason: using LD without putting it into the Release Name (see:`Terrifier.3.2024.German.DL.AC3D.1080p.AMZN.WEB.H264-iSSEYMiYAKE`) 
- LeetHD to German Tier 03
- D02KU to ZeroTwo Alias Condition

## Approach

Add the Groups to the appropriate CFs

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
