### PR TITLE
fix(starr): Remove duplicate information about Bad Dual Groups and Scene from the German Guides

### DIFF
--- a/includes/german-guide/radarr-german-unwanted-en.md
+++ b/includes/german-guide/radarr-german-unwanted-en.md
@@ -30,11 +30,4 @@
     - **{{ radarr['cf']['extras']['name'] }}:** Blocks releases that only contain extras
     - **{{ radarr['cf']['av1']['name'] }}:** This blocks all releases encoded in AV1.
     - **{{ radarr['cf']['upscaled']['name'] }}:** A custom format to prevent Radarr from grabbing upscaled releases.
-
-    ??? note "Optional - [Click to show/hide]"
-
-        This includes optional Custom Formats made by Trash for the original guide. Please be sure to understand what those do before adding them. Moreover, it includes two Custom Formats you may use at your own risk if you want Dual Language:
-
-        - [{{ radarr['cf']['bad-dual-groups']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#bad-dual-groups), which can be controversial for people looking for Dual Language release. I encourage you not to use it.
-        - [{{ radarr['cf']['scene']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#scene), it may include Scene groups already in [{{ radarr['cf']['german-scene']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#german-scene) Custom Format. This is used for fallback to be sure to get a Dual Language release.
 <!-- markdownlint-enable MD041-->

--- a/includes/german-guide/sonarr-german-unwanted-en.md
+++ b/includes/german-guide/sonarr-german-unwanted-en.md
@@ -24,11 +24,4 @@
     - **{{ sonarr['cf']['extras']['name'] }}:** Blocks releases that only contain extras
     - **{{ sonarr['cf']['av1']['name'] }}:** This blocks all releases encoded in AV1.
     - **{{ sonarr['cf']['upscaled']['name'] }}:** A custom format to prevent Sonarr from grabbing upscaled releases.
-
-    ??? note "Optional - [Click to show/hide]"
-
-        This includes optional Custom Formats made by Trash for the original guide. Please be sure to understand what those do before adding them. Moreover, it includes two Custom Formats you may use at your own risk if you want Dual Language:
-
-        - [{{ sonarr['cf']['bad-dual-groups']['name'] }}](/Sonarr/Sonarr-collection-of-custom-formats/#bad-dual-groups), which can be controversial for people looking for Dual Language release. I encourage you not to use it.
-        - [{{ sonarr['cf']['scene']['name'] }}](/Sonarr/Sonarr-collection-of-custom-formats/#scene), it may include Scene groups already in [{{ sonarr['cf']['german-scene']['name'] }}](/Sonarr/Sonarr-collection-of-custom-formats/#german-scene) Custom Format. This is used for fallback to be sure to get a Dual Language release.
 <!-- markdownlint-enable MD041-->


### PR DESCRIPTION
# Pull Request

## Purpose

The Information about Bad Dual Groups and Scene is already in the "Misc Optional" section, additional this paragraph confused more than it helped so we decided to remove it.

## Approach

Remove the paragraph from the Sonarr and Radarr Guide.

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
