### PR TITLE
feat(starr-german): German Tier update

### DIFF
--- a/docs/json/radarr/cf/german-bluray-tier-01.json
+++ b/docs/json/radarr/cf/german-bluray-tier-01.json
@@ -21,7 +21,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "\\b(BUTTERCUP|HARTZ02|XiSS|DOGPACK404|PRiNCESSDiANA|DiVA)\\b"
+        "value": "\\b(BUTTERCUP|HARTZ02|XiSS|DOGPACK404|PRiNCESSDiANA|DiVA|WAREZCX|BiTCHNUGGET)\\b"
       }
     },
     {
@@ -76,6 +76,15 @@
       "required": false,
       "fields": {
         "value": "^(CNY)$"
+      }
+    },
+    {
+      "name": "WeebPinn",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(WeebPinn)$"
       }
     },
     {

--- a/docs/json/radarr/cf/german-bluray-tier-03.json
+++ b/docs/json/radarr/cf/german-bluray-tier-03.json
@@ -34,15 +34,6 @@
       }
     },
     {
-      "name": "HQC",
-      "implementation": "ReleaseGroupSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "^(HQC)$"
-      }
-    },
-    {
       "name": "Bluray",
       "implementation": "SourceSpecification",
       "negate": false,

--- a/docs/json/radarr/cf/german-bluray-tier-03.json
+++ b/docs/json/radarr/cf/german-bluray-tier-03.json
@@ -25,6 +25,24 @@
       }
     },
     {
+      "name": "RHD",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(RHD)$"
+      }
+    },
+    {
+      "name": "HQC",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(HQC)$"
+      }
+    },
+    {
       "name": "Bluray",
       "implementation": "SourceSpecification",
       "negate": false,

--- a/docs/json/radarr/cf/german-lq.json
+++ b/docs/json/radarr/cf/german-lq.json
@@ -356,6 +356,33 @@
       "fields": {
         "value": "^(TVP)$"
       }
+    },
+    {
+      "name": "AIDA",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(AIDA)$"
+      }
+    },
+    {
+      "name": "UTOPiA",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(UTOPiA)$"
+      }
+    },
+    {
+      "name": "FRAGGERS",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(FRAGGERS)$"
+      }
     }
   ]
 }

--- a/docs/json/radarr/cf/german-lq.json
+++ b/docs/json/radarr/cf/german-lq.json
@@ -347,6 +347,15 @@
       "fields": {
         "value": "^(iSSEYMiYAKE)$"
       }
+    },
+    {
+      "name": "TVP",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(TVP)$"
+      }
     }
   ]
 }

--- a/docs/json/radarr/cf/german-remux-tier-01.json
+++ b/docs/json/radarr/cf/german-remux-tier-01.json
@@ -43,6 +43,15 @@
       }
     },
     {
+      "name": "WeebPinn",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(WeebPinn)$"
+      }
+    },
+    {
       "name": "Remux",
       "implementation": "QualityModifierSpecification",
       "negate": false,

--- a/docs/json/radarr/cf/german-remux-tier-02.json
+++ b/docs/json/radarr/cf/german-remux-tier-02.json
@@ -16,6 +16,15 @@
       }
     },
     {
+      "name": "RHD",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(RHD)$"
+      }
+    },
+    {
       "name": "Remux",
       "implementation": "QualityModifierSpecification",
       "negate": false,

--- a/docs/json/radarr/cf/german-scene.json
+++ b/docs/json/radarr/cf/german-scene.json
@@ -257,6 +257,15 @@
       "fields": {
         "value": "^(ENCOUNTERS)$"
       }
+    },
+    {
+      "name": "RSG",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(RSG)$"
+      }
     }
   ]
 }

--- a/docs/json/radarr/cf/german-scene.json
+++ b/docs/json/radarr/cf/german-scene.json
@@ -239,6 +239,24 @@
       "fields": {
         "value": "^(WATCHABLE)$"
       }
+    },
+    {
+      "name": "OHD",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(OHD)$"
+      }
+    },
+    {
+      "name": "ENCOUNTERS",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(ENCOUNTERS)$"
+      }
     }
   ]
 }

--- a/docs/json/radarr/cf/german-web-tier-01.json
+++ b/docs/json/radarr/cf/german-web-tier-01.json
@@ -21,7 +21,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "\\b(BUTTERCUP|HARTZ02|XiSS|DOGPACK404|PRiNCESSDiANA|DiVA)\\b"
+        "value": "\\b(BUTTERCUP|HARTZ02|XiSS|DOGPACK404|PRiNCESSDiANA|DiVA|WAREZCX|BiTCHNUGGET)\\b"
       }
     },
     {
@@ -94,6 +94,42 @@
       "required": false,
       "fields": {
         "value": "^(CNY)$"
+      }
+    },
+    {
+      "name": "WeebPinn",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(WeebPinn)$"
+      }
+    },
+    {
+      "name": "MEDiATHEK",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(MEDiATHEK)$"
+      }
+    },
+    {
+      "name": "RiiR",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(RiiR)$"
+      }
+    },
+    {
+      "name": "RiiR Aliases",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(TOJ)\\b"
       }
     },
     {

--- a/docs/json/sonarr/cf/german-bluray-tier-01.json
+++ b/docs/json/sonarr/cf/german-bluray-tier-01.json
@@ -21,7 +21,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "\\b(BUTTERCUP|HARTZ02|XiSS|DOGPACK404|PRiNCESSDiANA|DiVA|D02KU)\\b"
+        "value": "\\b(BUTTERCUP|HARTZ02|XiSS|DOGPACK404|PRiNCESSDiANA|DiVA|D02KU|WAREZCX|BiTCHNUGGET)\\b"
       }
     },
     {
@@ -76,6 +76,15 @@
       "required": false,
       "fields": {
         "value": "^(CNY)$"
+      }
+    },
+    {
+      "name": "WeebPinn",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(WeebPinn)$"
       }
     },
     {

--- a/docs/json/sonarr/cf/german-bluray-tier-03.json
+++ b/docs/json/sonarr/cf/german-bluray-tier-03.json
@@ -16,6 +16,15 @@
       }
     },
     {
+      "name": "HQC",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(HQC)$"
+      }
+    },
+    {
       "name": "Bluray",
       "implementation": "SourceSpecification",
       "negate": false,

--- a/docs/json/sonarr/cf/german-lq.json
+++ b/docs/json/sonarr/cf/german-lq.json
@@ -356,6 +356,33 @@
       "fields": {
         "value": "^(TVP)$"
       }
+    },
+    {
+      "name": "AIDA",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(AIDA)$"
+      }
+    },
+    {
+      "name": "UTOPiA",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(UTOPiA)$"
+      }
+    },
+    {
+      "name": "FRAGGERS",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(FRAGGERS)$"
+      }
     }
   ]
 }

--- a/docs/json/sonarr/cf/german-lq.json
+++ b/docs/json/sonarr/cf/german-lq.json
@@ -347,6 +347,15 @@
       "fields": {
         "value": "^(iSSEYMiYAKE)$"
       }
+    },
+    {
+      "name": "TVP",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(TVP)$"
+      }
     }
   ]
 }

--- a/docs/json/sonarr/cf/german-remux-tier-02.json
+++ b/docs/json/sonarr/cf/german-remux-tier-02.json
@@ -16,6 +16,15 @@
       }
     },
     {
+      "name": "HQC",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(HQC)$"
+      }
+    },
+    {
       "name": "Remux",
       "implementation": "SourceSpecification",
       "negate": false,

--- a/docs/json/sonarr/cf/german-scene.json
+++ b/docs/json/sonarr/cf/german-scene.json
@@ -221,6 +221,24 @@
       "fields": {
         "value": "^(WATCHABLE)$"
       }
+    },
+    {
+      "name": "OHD",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(OHD)$"
+      }
+    },
+    {
+      "name": "ENCOUNTERS",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(ENCOUNTERS)$"
+      }
     }
   ]
 }

--- a/docs/json/sonarr/cf/german-scene.json
+++ b/docs/json/sonarr/cf/german-scene.json
@@ -239,6 +239,24 @@
       "fields": {
         "value": "^(ENCOUNTERS)$"
       }
+    },
+    {
+      "name": "RSG",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(RSG)$"
+      }
+    },
+    {
+      "name": "TVNATiON",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(TVNATiON)$"
+      }
     }
   ]
 }

--- a/docs/json/sonarr/cf/german-web-tier-01.json
+++ b/docs/json/sonarr/cf/german-web-tier-01.json
@@ -21,7 +21,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "\\b(BUTTERCUP|HARTZ02|XiSS|DOGPACK404|PRiNCESSDiANA|DiVA|D02KU)\\b"
+        "value": "\\b(BUTTERCUP|HARTZ02|XiSS|DOGPACK404|PRiNCESSDiANA|DiVA|D02KU|WAREZCX|BiTCHNUGGET)\\b"
       }
     },
     {
@@ -85,6 +85,42 @@
       "required": false,
       "fields": {
         "value": "^(CNY)$"
+      }
+    },
+    {
+      "name": "WeebPinn",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(WeebPinn)$"
+      }
+    },
+    {
+      "name": "MEDiATHEK",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(MEDiATHEK)$"
+      }
+    },
+    {
+      "name": "RiiR",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(RiiR)$"
+      }
+    },
+    {
+      "name": "RiiR Aliases",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(TOJ)\\b"
       }
     },
     {

--- a/docs/json/sonarr/cf/german-web-tier-03.json
+++ b/docs/json/sonarr/cf/german-web-tier-03.json
@@ -25,6 +25,15 @@
       }
     },
     {
+      "name": "HQC",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(HQC)$"
+      }
+    },
+    {
       "name": "WebDL",
       "implementation": "SourceSpecification",
       "negate": false,


### PR DESCRIPTION
# Pull Request

German Tier update

## Purpose

- [x] MEDiATHEK in German WEB Tier 01
- [x] RiiR in German WEB Tier 01
- [x] TOJ in RiiR Aliases
- [x] OHD in German Scene
- [x] WeebPinn in German Tier 01
- [x] ENCOUNTERS in German Scene
- [x] WAREZCX, BiTCHNUGGET in ZeroTwo Aliases
- [x] TVNATiON in German Scene (Shows)
- [x] TVP in German LQ
- [x] HQC in Tier 03 (Shows)
- [x] RSG in German Scene
- [x] RHD in Tier 03 (Movies)
- [x] AIDA, FRAGGERS, UTOPiA in German LQ

## Approach

Add Groups to CFs

## Open Questions and Pre-Merge TODOs

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
