### PR TITLE
feat(starr-anime): Enhance Bilibili Streaming Service and Remux Tier CFs

### DIFF
--- a/docs/json/radarr/cf/anime-bd-tier-05-remuxes.json
+++ b/docs/json/radarr/cf/anime-bd-tier-05-remuxes.json
@@ -34,6 +34,15 @@
       }
     },
     {
+      "name": "CRUCiBLE",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(CRUCiBLE)\\b"
+      }
+    },
+    {
       "name": "D4C",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,
@@ -49,6 +58,15 @@
       "required": false,
       "fields": {
         "value": "\\b(E[.-]N[.-]D)\\b"
+      }
+    },
+    {
+      "name": "PMR",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(PMR)\\b.*(Remux)"
       }
     },
     {

--- a/docs/json/sonarr/cf/anime-bd-tier-05-remuxes.json
+++ b/docs/json/sonarr/cf/anime-bd-tier-05-remuxes.json
@@ -43,6 +43,15 @@
       }
     },
     {
+      "name": "CRUCiBLE",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(CRUCiBLE)\\b"
+      }
+    },
+    {
       "name": "D4C",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,
@@ -58,6 +67,15 @@
       "required": false,
       "fields": {
         "value": "\\b(E[.-]N[.-]D)\\b"
+      }
+    },
+    {
+      "name": "PMR",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(PMR)\\b.*(Remux)"
       }
     },
     {

--- a/docs/json/sonarr/cf/bilibili.json
+++ b/docs/json/sonarr/cf/bilibili.json
@@ -36,7 +36,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\b(Bilibili)\\b"
+        "value": "\\b(Bili(bili)?)\\b"
       }
     }
   ]


### PR DESCRIPTION
# Pull Request

## Purpose
Enhance Bilibili to match on BILI and add PMR and CRUCiBLE to Anime Remux Tiers due to a higher number of best releases on SeaDex from those groups
<!-- Please provide a detailed description of why you created this pull request. -->

## Approach
Needed to ensure PMR matches on Remux only to prevent matches on their BMDV and misc releases
<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
