### PR TITLE
feat(starr): Added Custom Format to boost 720p, 1080p and/or 2160p releases

### DIFF
--- a/docs/Radarr/Radarr-collection-of-custom-formats.md
+++ b/docs/Radarr/Radarr-collection-of-custom-formats.md
@@ -97,14 +97,17 @@ We've made 3 guides related to this.
 
 | Miscellaneous                          | Language profiles                                                  |
 | -------------------------------------- | ------------------------------------------------------------------ |
-| [Bad Dual Groups](#bad-dual-groups)    | [Language: German](#language-german)                               |
-| [Dutch Groups](#dutch-groups)          | [Language: German DL](#language-german-dl)                         |
-| [DV (Disk)](#dv-disk)                  | [Language: German DL (undefined)](#language-german-dl-undefined)   |
-| [DV (WEBDL)](#dv-webdl)                | [Language: Not English (English Only)](#language-not-english)      |
-| [DV HDR10+ Boost](#dv-hdr10plus-boost) | [Language: Not French (French Only)](#language-not-french)         |
-| [EVO (no WEBDL)](#evo-no-webdl)        | [Language: Not Original (Original Only)](#language-not-original)   |
-| [FreeLeech](#freeleech)                | [Language: Original + French](#language-original-plus-french)      |
-| [HDR10+ Boost](#hdr10plus-boost)       | [Language: Not German or English](#language-not-german-or-english) |
+| [720p](#720p)                          | [Language: German](#language-german)                               |
+| [1080p](#1080p)                        | [Language: German DL](#language-german-dl)                         |
+| [2160p](#2160p)                        | [Language: German DL (undefined)](#language-german-dl-undefined)   |
+| [Bad Dual Groups](#bad-dual-groups)    | [Language: Not English (English Only)](#language-not-english)      |
+| [Dutch Groups](#dutch-groups)          | [Language: Not French (French Only)](#language-not-french)         |
+| [DV (Disk)](#dv-disk)                  | [Language: Not Original (Original Only)](#language-not-original)   |
+| [DV (WEBDL)](#dv-webdl)                | [Language: Original + French](#language-original-plus-french)      |
+| [DV HDR10+ Boost](#dv-hdr10plus-boost) | [Language: Not German or English](#language-not-german-or-english) |
+| [EVO (no WEBDL)](#evo-no-webdl)        |                                                                    |
+| [FreeLeech](#freeleech)                |                                                                    |
+| [HDR10+ Boost](#hdr10plus-boost)       |                                                                    |
 | [HFR](#hfr)                            |                                                                    |
 | [Internal](#internal)                  |                                                                    |
 | [Line/Mic Dubbed](#linemic-dubbed)     |                                                                    |
@@ -1093,6 +1096,54 @@ We've made 3 guides related to this.
 ---
 
 ## Miscellaneous
+
+---
+
+### 720p
+
+??? question "720p - [Click to show/hide]"
+
+    {! include-markdown "../../includes/cf-descriptions/720p.md" !}
+
+??? example "JSON - [Click to show/hide]"
+
+    ```json
+    [[% filter indent(width=4) %]][[% include 'json/radarr/cf/720p.json' %]][[% endfilter %]]
+    ```
+
+<sub><sup>[TOP](#index)</sup></sub>
+
+---
+
+### 1080p
+
+??? question "1080p - [Click to show/hide]"
+
+    {! include-markdown "../../includes/cf-descriptions/1080p.md" !}
+
+??? example "JSON - [Click to show/hide]"
+
+    ```json
+    [[% filter indent(width=4) %]][[% include 'json/radarr/cf/1080p.json' %]][[% endfilter %]]
+    ```
+
+<sub><sup>[TOP](#index)</sup></sub>
+
+---
+
+### 2160p
+
+??? question "2160p - [Click to show/hide]"
+
+    {! include-markdown "../../includes/cf-descriptions/2160p.md" !}
+
+??? example "JSON - [Click to show/hide]"
+
+    ```json
+    [[% filter indent(width=4) %]][[% include 'json/radarr/cf/2160p.json' %]][[% endfilter %]]
+    ```
+
+<sub><sup>[TOP](#index)</sup></sub>
 
 ---
 

--- a/docs/Sonarr/sonarr-collection-of-custom-formats.md
+++ b/docs/Sonarr/sonarr-collection-of-custom-formats.md
@@ -94,14 +94,17 @@ We've made 3 guides related to this.
 
 | Miscellaneous                          | Language profiles                                                  |
 | -------------------------------------- | ------------------------------------------------------------------ |
-| [Bad Dual Groups](#bad-dual-groups)    | [Language: German](#language-german)                               |
-| [DV (Disk)](#dv-disk)                  | [Language: German DL](#language-german-dl)                         |
-| [DV (WEBDL)](#dv-webdl)                | [Language: German DL (undefined)](#language-german-dl-undefined)   |
-| [DV HDR10+ Boost](#dv-hdr10plus-boost) | [Language: Not English (English Only)](#language-not-english)      |
-| [FreeLeech](#freeleech)                | [Language: Not French (French Only)](#language-not-french)         |
-| [HDR10+ Boost](#hdr10plus-boost)       | [Language: Not Original (Original Only)](#language-not-original)   |
-| [HFR](#hfr)                            | [Language: Original + French](#language-original-plus-french)      |
-| [Internal](#internal)                  | [Language: Not German or English](#language-not-german-or-english) |
+| [720p](#720p)                          | [Language: German](#language-german)                               |
+| [1080p](#1080p)                        | [Language: German DL](#language-german-dl)                         |
+| [2160p](#2160p)                        | [Language: German DL (undefined)](#language-german-dl-undefined)   |
+| [Bad Dual Groups](#bad-dual-groups)    | [Language: Not English (English Only)](#language-not-english)      |
+| [DV (Disk)](#dv-disk)                  | [Language: Not French (French Only)](#language-not-french)         |
+| [DV (WEBDL)](#dv-webdl)                | [Language: Not Original (Original Only)](#language-not-original)   |
+| [DV HDR10+ Boost](#dv-hdr10plus-boost) | [Language: Original + French](#language-original-plus-french)      |
+| [FreeLeech](#freeleech)                | [Language: Not German or English](#language-not-german-or-english) |
+| [HDR10+ Boost](#hdr10plus-boost)       |                                                                    |
+| [HFR](#hfr)                            |                                                                    |
+| [Internal](#internal)                  |                                                                    |
 | [MPEG2](#mpeg2)                        |                                                                    |
 | [Multi](#multi)                        |                                                                    |
 | [No-RlsGroup](#no-rlsgroup)            |                                                                    |
@@ -885,6 +888,54 @@ We've made 3 guides related to this.
 ---
 
 ## Miscellaneous
+
+---
+
+### 720p
+
+??? question "720p - [Click to show/hide]"
+
+    {! include-markdown "../../includes/cf-descriptions/720p.md" !}
+
+??? example "JSON - [Click to show/hide]"
+
+    ```json
+    [[% filter indent(width=4) %]][[% include 'json/sonarr/cf/720p.json' %]][[% endfilter %]]
+    ```
+
+<sub><sup>[TOP](#index)</sup></sub>
+
+---
+
+### 1080p
+
+??? question "1080p - [Click to show/hide]"
+
+    {! include-markdown "../../includes/cf-descriptions/1080p.md" !}
+
+??? example "JSON - [Click to show/hide]"
+
+    ```json
+    [[% filter indent(width=4) %]][[% include 'json/sonarr/cf/1080p.json' %]][[% endfilter %]]
+    ```
+
+<sub><sup>[TOP](#index)</sup></sub>
+
+---
+
+### 2160p
+
+??? question "2160p - [Click to show/hide]"
+
+    {! include-markdown "../../includes/cf-descriptions/2160p.md" !}
+
+??? example "JSON - [Click to show/hide]"
+
+    ```json
+    [[% filter indent(width=4) %]][[% include 'json/sonarr/cf/2160p.json' %]][[% endfilter %]]
+    ```
+
+<sub><sup>[TOP](#index)</sup></sub>
 
 ---
 

--- a/includes/cf-descriptions/1080p.md
+++ b/includes/cf-descriptions/1080p.md
@@ -1,0 +1,3 @@
+<!-- markdownlint-disable MD041-->
+This Custom Format can boost 1080p releases. It is only useful if you use [Merge Qualities](/Radarr/Tips/Merge-quality/){:target="\_blank" rel="noopener noreferrer"} in your Quality Profile.
+<!-- markdownlint-enable MD041-->

--- a/includes/cf-descriptions/2160p.md
+++ b/includes/cf-descriptions/2160p.md
@@ -1,0 +1,3 @@
+<!-- markdownlint-disable MD041-->
+This Custom Format can boost 2160p releases. It is only useful if you use [Merge Qualities](/Radarr/Tips/Merge-quality/){:target="\_blank" rel="noopener noreferrer"} in your Quality Profile.
+<!-- markdownlint-enable MD041-->

--- a/includes/cf-descriptions/720p.md
+++ b/includes/cf-descriptions/720p.md
@@ -1,0 +1,3 @@
+<!-- markdownlint-disable MD041-->
+This Custom Format can boost 720p releases. It is only useful if you use [Merge Qualities](/Radarr/Tips/Merge-quality/){:target="\_blank" rel="noopener noreferrer"} in your Quality Profile.
+<!-- markdownlint-enable MD041-->

--- a/includes/german-guide/radarr-cf-german-resolution-scoring-en.md
+++ b/includes/german-guide/radarr-cf-german-resolution-scoring-en.md
@@ -1,13 +1,13 @@
 <!-- markdownlint-disable MD041-->
 ??? abstract "German Resolution - [Click to show/hide]"
 
-    | Custom Format                                                                                                                |                                 Score                                 | Trash ID                                               |
-    | ---------------------------------------------------------------------------------------------------------------------------- | :-------------------------------------------------------------------: | ------------------------------------------------------ |
-    | [{{ radarr['cf']['german-1080p-booster']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#german-1080p-booster)      | {{ radarr['cf']['german-1080p-booster']['trash_scores']['default'] }} | {{ radarr['cf']['german-1080p-booster']['trash_id'] }} |
-    | [{{ radarr['cf']['german-2160p-booster']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#german-2160p-booster)      | {{ radarr['cf']['german-2160p-booster']['trash_scores']['default'] }} | {{ radarr['cf']['german-2160p-booster']['trash_id'] }} |
-    | [{{ radarr['cf']['720p']['name'] }}](https://raw.githubusercontent.com/TRaSH-/Guides/master/docs/json/radarr/cf/720p.json)   |         {{ radarr['cf']['720p']['trash_scores']['default'] }}         | {{ radarr['cf']['720p']['trash_id'] }}                 |
-    | [{{ radarr['cf']['1080p']['name'] }}](https://raw.githubusercontent.com/TRaSH-/Guides/master/docs/json/radarr/cf/1080p.json) |        {{ radarr['cf']['1080p']['trash_scores']['default'] }}         | {{ radarr['cf']['1080p']['trash_id'] }}                |
-    | [{{ radarr['cf']['2160p']['name'] }}](https://raw.githubusercontent.com/TRaSH-/Guides/master/docs/json/radarr/cf/2160p.json) |        {{ radarr['cf']['2160p']['trash_scores']['default'] }}         | {{ radarr['cf']['2160p']['trash_id'] }}                |
+    | Custom Format                                                                                                           |                                 Score                                 | Trash ID                                               |
+    | ----------------------------------------------------------------------------------------------------------------------- | :-------------------------------------------------------------------: | ------------------------------------------------------ |
+    | [{{ radarr['cf']['german-1080p-booster']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#german-1080p-booster) | {{ radarr['cf']['german-1080p-booster']['trash_scores']['default'] }} | {{ radarr['cf']['german-1080p-booster']['trash_id'] }} |
+    | [{{ radarr['cf']['german-2160p-booster']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#german-2160p-booster) | {{ radarr['cf']['german-2160p-booster']['trash_scores']['default'] }} | {{ radarr['cf']['german-2160p-booster']['trash_id'] }} |
+    | [{{ radarr['cf']['720p']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#720p)                                 |         {{ radarr['cf']['720p']['trash_scores']['default'] }}         | {{ radarr['cf']['720p']['trash_id'] }}                 |
+    | [{{ radarr['cf']['1080p']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#1080p)                               |        {{ radarr['cf']['1080p']['trash_scores']['default'] }}         | {{ radarr['cf']['1080p']['trash_id'] }}                |
+    | [{{ radarr['cf']['2160p']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#2160p)                               |        {{ radarr['cf']['2160p']['trash_scores']['default'] }}         | {{ radarr['cf']['2160p']['trash_id'] }}                |
 
     ---
 

--- a/includes/german-guide/radarr-cf-german-resolution-scoring-hd-only-en.md
+++ b/includes/german-guide/radarr-cf-german-resolution-scoring-hd-only-en.md
@@ -1,11 +1,11 @@
 <!-- markdownlint-disable MD041-->
 ??? abstract "German Resolution - [Click to show/hide]"
 
-    | Custom Format                                                                                                                |                                 Score                                 | Trash ID                                               |
-    | ---------------------------------------------------------------------------------------------------------------------------- | :-------------------------------------------------------------------: | ------------------------------------------------------ |
-    | [{{ radarr['cf']['german-1080p-booster']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#german-1080p-booster)      | {{ radarr['cf']['german-1080p-booster']['trash_scores']['default'] }} | {{ radarr['cf']['german-1080p-booster']['trash_id'] }} |
-    | [{{ radarr['cf']['720p']['name'] }}](https://raw.githubusercontent.com/TRaSH-/Guides/master/docs/json/radarr/cf/720p.json)   |         {{ radarr['cf']['720p']['trash_scores']['default'] }}         | {{ radarr['cf']['720p']['trash_id'] }}                 |
-    | [{{ radarr['cf']['1080p']['name'] }}](https://raw.githubusercontent.com/TRaSH-/Guides/master/docs/json/radarr/cf/1080p.json) |        {{ radarr['cf']['1080p']['trash_scores']['default'] }}         | {{ radarr['cf']['1080p']['trash_id'] }}                |
+    | Custom Format                                                                                                           |                                 Score                                 | Trash ID                                               |
+    | ----------------------------------------------------------------------------------------------------------------------- | :-------------------------------------------------------------------: | ------------------------------------------------------ |
+    | [{{ radarr['cf']['german-1080p-booster']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#german-1080p-booster) | {{ radarr['cf']['german-1080p-booster']['trash_scores']['default'] }} | {{ radarr['cf']['german-1080p-booster']['trash_id'] }} |
+    | [{{ radarr['cf']['720p']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#720p)                                 |         {{ radarr['cf']['720p']['trash_scores']['default'] }}         | {{ radarr['cf']['720p']['trash_id'] }}                 |
+    | [{{ radarr['cf']['1080p']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#1080p)                               |        {{ radarr['cf']['1080p']['trash_scores']['default'] }}         | {{ radarr['cf']['1080p']['trash_id'] }}                |
 
     ---
 

--- a/includes/german-guide/sonarr-cf-german-resolution-scoring-en.md
+++ b/includes/german-guide/sonarr-cf-german-resolution-scoring-en.md
@@ -1,13 +1,13 @@
 <!-- markdownlint-disable MD041-->
 ??? abstract "German Resolution - [Click to show/hide]"
 
-    | Custom Format                                                                                                                |                                 Score                                 | Trash ID                                               |
-    | ---------------------------------------------------------------------------------------------------------------------------- | :-------------------------------------------------------------------: | ------------------------------------------------------ |
-    | [{{ sonarr['cf']['german-1080p-booster']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#german-1080p-booster)      | {{ sonarr['cf']['german-1080p-booster']['trash_scores']['default'] }} | {{ sonarr['cf']['german-1080p-booster']['trash_id'] }} |
-    | [{{ sonarr['cf']['german-2160p-booster']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#german-2160p-booster)      | {{ sonarr['cf']['german-2160p-booster']['trash_scores']['default'] }} | {{ sonarr['cf']['german-2160p-booster']['trash_id'] }} |
-    | [{{ sonarr['cf']['720p']['name'] }}](https://raw.githubusercontent.com/TRaSH-/Guides/master/docs/json/sonarr/cf/720p.json)   |         {{ sonarr['cf']['720p']['trash_scores']['default'] }}         | {{ sonarr['cf']['720p']['trash_id'] }}                 |
-    | [{{ sonarr['cf']['1080p']['name'] }}](https://raw.githubusercontent.com/TRaSH-/Guides/master/docs/json/sonarr/cf/1080p.json) |        {{ sonarr['cf']['1080p']['trash_scores']['default'] }}         | {{ sonarr['cf']['1080p']['trash_id'] }}                |
-    | [{{ sonarr['cf']['2160p']['name'] }}](https://raw.githubusercontent.com/TRaSH-/Guides/master/docs/json/sonarr/cf/2160p.json) |        {{ sonarr['cf']['2160p']['trash_scores']['default'] }}         | {{ sonarr['cf']['2160p']['trash_id'] }}                |
+    | Custom Format                                                                                                           |                                 Score                                 | Trash ID                                               |
+    | ----------------------------------------------------------------------------------------------------------------------- | :-------------------------------------------------------------------: | ------------------------------------------------------ |
+    | [{{ sonarr['cf']['german-1080p-booster']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#german-1080p-booster) | {{ sonarr['cf']['german-1080p-booster']['trash_scores']['default'] }} | {{ sonarr['cf']['german-1080p-booster']['trash_id'] }} |
+    | [{{ sonarr['cf']['german-2160p-booster']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#german-2160p-booster) | {{ sonarr['cf']['german-2160p-booster']['trash_scores']['default'] }} | {{ sonarr['cf']['german-2160p-booster']['trash_id'] }} |
+    | [{{ sonarr['cf']['720p']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#720p)                                 |         {{ sonarr['cf']['720p']['trash_scores']['default'] }}         | {{ sonarr['cf']['720p']['trash_id'] }}                 |
+    | [{{ sonarr['cf']['1080p']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#1080p)                               |        {{ sonarr['cf']['1080p']['trash_scores']['default'] }}         | {{ sonarr['cf']['1080p']['trash_id'] }}                |
+    | [{{ sonarr['cf']['2160p']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#2160p)                               |        {{ sonarr['cf']['2160p']['trash_scores']['default'] }}         | {{ sonarr['cf']['2160p']['trash_id'] }}                |
 
     ---
 

--- a/includes/german-guide/sonarr-cf-german-resolution-scoring-hd-only-en.md
+++ b/includes/german-guide/sonarr-cf-german-resolution-scoring-hd-only-en.md
@@ -1,11 +1,11 @@
 <!-- markdownlint-disable MD041-->
 ??? abstract "German Resolution - [Click to show/hide]"
 
-    | Custom Format                                                                                                                |                                 Score                                 | Trash ID                                               |
-    | ---------------------------------------------------------------------------------------------------------------------------- | :-------------------------------------------------------------------: | ------------------------------------------------------ |
-    | [{{ sonarr['cf']['german-1080p-booster']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#german-1080p-booster)      | {{ sonarr['cf']['german-1080p-booster']['trash_scores']['default'] }} | {{ sonarr['cf']['german-1080p-booster']['trash_id'] }} |
-    | [{{ sonarr['cf']['720p']['name'] }}](https://raw.githubusercontent.com/TRaSH-/Guides/master/docs/json/sonarr/cf/720p.json)   |         {{ sonarr['cf']['720p']['trash_scores']['default'] }}         | {{ sonarr['cf']['720p']['trash_id'] }}                 |
-    | [{{ sonarr['cf']['1080p']['name'] }}](https://raw.githubusercontent.com/TRaSH-/Guides/master/docs/json/sonarr/cf/1080p.json) |        {{ sonarr['cf']['1080p']['trash_scores']['default'] }}         | {{ sonarr['cf']['1080p']['trash_id'] }}                |
+    | Custom Format                                                                                                           |                                 Score                                 | Trash ID                                               |
+    | ----------------------------------------------------------------------------------------------------------------------- | :-------------------------------------------------------------------: | ------------------------------------------------------ |
+    | [{{ sonarr['cf']['german-1080p-booster']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#german-1080p-booster) | {{ sonarr['cf']['german-1080p-booster']['trash_scores']['default'] }} | {{ sonarr['cf']['german-1080p-booster']['trash_id'] }} |
+    | [{{ sonarr['cf']['720p']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#720p)                                 |         {{ sonarr['cf']['720p']['trash_scores']['default'] }}         | {{ sonarr['cf']['720p']['trash_id'] }}                 |
+    | [{{ sonarr['cf']['1080p']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#1080p)                               |        {{ sonarr['cf']['1080p']['trash_scores']['default'] }}         | {{ sonarr['cf']['1080p']['trash_id'] }}                |
 
     ---
 

--- a/includes/sqp/hd-radarr-resolution.md
+++ b/includes/sqp/hd-radarr-resolution.md
@@ -1,6 +1,8 @@
+<!-- markdownlint-disable MD041-->
 ??? abstract "Resolution - [Click to show/hide]"
 
-    | Custom Format                                                                                                                |                         Score                          | Trash ID                                |
-    | ---------------------------------------------------------------------------------------------------------------------------- | :----------------------------------------------------: | --------------------------------------- |
-    | [{{ radarr['cf']['1080p']['name'] }}](https://raw.githubusercontent.com/TRaSH-/Guides/master/docs/json/radarr/cf/1080p.json) | {{ radarr['cf']['1080p']['trash_scores']['default'] }} | {{ radarr['cf']['1080p']['trash_id'] }} |
-    | [{{ radarr['cf']['720p']['name'] }}](https://raw.githubusercontent.com/TRaSH-/Guides/master/docs/json/radarr/cf/720p.json)   | {{ radarr['cf']['720p']['trash_scores']['default'] }}  | {{ radarr['cf']['720p']['trash_id'] }}  |
+    | Custom Format                                                                             |                         Score                          | Trash ID                                |
+    | ----------------------------------------------------------------------------------------- | :----------------------------------------------------: | --------------------------------------- |
+    | [{{ radarr['cf']['1080p']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#1080p) | {{ radarr['cf']['1080p']['trash_scores']['default'] }} | {{ radarr['cf']['1080p']['trash_id'] }} |
+    | [{{ radarr['cf']['720p']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#720p)   | {{ radarr['cf']['720p']['trash_scores']['default'] }}  | {{ radarr['cf']['720p']['trash_id'] }}  |
+<!-- markdownlint-enable MD041-->

--- a/includes/sqp/uhd-radarr-resolution.md
+++ b/includes/sqp/uhd-radarr-resolution.md
@@ -1,8 +1,10 @@
+<!-- markdownlint-disable MD041-->
 ??? abstract "Resolution - [Click to show/hide]"
 
-    | Custom Format                                                                                                                |                                  Score                                   | Trash ID                                |
-    | ---------------------------------------------------------------------------------------------------------------------------- | :----------------------------------------------------------------------: | --------------------------------------- |
-    | [{{ radarr['cf']['1080p']['name'] }}](https://raw.githubusercontent.com/TRaSH-/Guides/master/docs/json/radarr/cf/1080p.json) |          {{ radarr['cf']['1080p']['trash_scores']['default'] }}          | {{ radarr['cf']['1080p']['trash_id'] }} |
-    | [{{ radarr['cf']['2160p']['name'] }}](https://raw.githubusercontent.com/TRaSH-/Guides/master/docs/json/radarr/cf/2160p.json) | :warning: {{ radarr['cf']['2160p']['trash_scores']['sqp-2'] }} :warning: | {{ radarr['cf']['2160p']['trash_id'] }} |
+    | Custom Format                                                                             |                                  Score                                   | Trash ID                                |
+    | ----------------------------------------------------------------------------------------- | :----------------------------------------------------------------------: | --------------------------------------- |
+    | [{{ radarr['cf']['1080p']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#1080p) |          {{ radarr['cf']['1080p']['trash_scores']['default'] }}          | {{ radarr['cf']['1080p']['trash_id'] }} |
+    | [{{ radarr['cf']['2160p']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#2160p) | :warning: {{ radarr['cf']['2160p']['trash_scores']['sqp-2'] }} :warning: | {{ radarr['cf']['2160p']['trash_id'] }} |
 
     !!! warning "Scores marked with a :warning: warning :warning: are different to those used in the main guide"
+<!-- markdownlint-enable MD041-->


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->

Added Custom Format to boost 720p, 1080p, and/or 2160p releases. These are only useful if you use [Merge Qualities](https://trash-guides.info/Radarr/Tips/Merge-quality/) in your Quality Profile.

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

Added Custom Format to boost 720p, 1080p and/or 2160p releases

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
