### PR TITLE
fix(starr-german): set german score for the scene CF to 0 and explain it in the german guide

### DIFF
--- a/docs/json/radarr/cf/scene.json
+++ b/docs/json/radarr/cf/scene.json
@@ -2,7 +2,7 @@
   "trash_id": "f537cf427b64c38c8e36298f657e4828",
   "trash_scores": {
     "default": -10000,
-    "german": -35000
+    "german": 0
   },
   "trash_regex": "https://regex101.com/r/BoIGFA/1",
   "name": "Scene",

--- a/docs/json/sonarr/cf/scene.json
+++ b/docs/json/sonarr/cf/scene.json
@@ -2,7 +2,7 @@
   "trash_id": "1b3994c551cbb92a2c781af061f4ab44",
   "trash_scores": {
     "default": -10000,
-    "german": -35000
+    "german": 0
   },
   "trash_regex": "https://regex101.com/r/BoIGFA/1",
   "name": "Scene",

--- a/includes/german-guide/radarr-german-misc-optional.md
+++ b/includes/german-guide/radarr-german-misc-optional.md
@@ -20,5 +20,5 @@
     - **{{ radarr['cf']['no-rlsgroup']['name'] }}:** [*Optional*] Some indexers strip out the release group which could result in LQ groups being scored incorrectly. For example, a lot of EVO releases end up with a stripped group name. These releases would appear as "upgrades" and could end up getting a decent score after other CFs are scored.
     - **{{ radarr['cf']['obfuscated']['name'] }}:** [*Optional*] Use these only if you wish to avoid renamed releases.
     - **{{ radarr['cf']['retags']['name'] }}:** [*Optional*] Use this if you want to avoid retagged releases. Retagged releases often are not consistent with the quality of the original group's release.
-    - **{{ radarr['cf']['scene']['name'] }}:** [*Optional*] Use this only if you want to avoid SCENE releases.
+    - :warning: **{{ radarr['cf']['scene']['name'] }}:** [*Optional*] We recommend not using this CF in the German Guide, as it often matches incorrectly due to the German release naming.
 <!-- markdownlint-enable MD041-->

--- a/includes/german-guide/sonarr-german-misc-optional.md
+++ b/includes/german-guide/sonarr-german-misc-optional.md
@@ -18,5 +18,5 @@
     - **{{ sonarr['cf']['no-rlsgroup']['name'] }}:** [*Optional*] Some indexers strip out the release group which could result in LQ groups being scored incorrectly. For example, a lot of EVO releases end up with a stripped group name. These releases would appear as "upgrades" and could end up getting a decent score after other CFs are scored.
     - **{{ sonarr['cf']['obfuscated']['name'] }}:** [*Optional*] Use these only if you wish to avoid renamed releases.
     - **{{ sonarr['cf']['retags']['name'] }}:** [*Optional*] Use this if you wish to avoid retagged releases. Retagged releases often are not consistent with the quality of the original group's release (e.g. TGx downsampling an NTb release from 5.1 audio to 2.0 audio, yet maintaining the NTb naming).
-    - **{{ sonarr['cf']['scene']['name'] }}:** [*Optional*] Use this only if you want to avoid SCENE releases.
+    - :warning: **{{ sonarr['cf']['scene']['name'] }}:** [*Optional*] We recommend not using this CF in the German Guide, as it often matches incorrectly due to the German release naming.
 <!-- markdownlint-enable MD041-->


### PR DESCRIPTION
# Pull Request

## Purpose

The Scene CF is often matching wrongly for german releases due to the different naming rules. To avoid the possibility of penalties for releases due to this we set the score to 0 and explained the situation in the guide.

## Approach

Set german score for scene to 0 and explain it in the guide.

## Requirements

- [ ] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
