### PR TITLE
fix(Starr): Fix HDR10 regex to correctly exclude +/Plus

### DIFF
--- a/docs/json/radarr/cf/hdr-undefined.json
+++ b/docs/json/radarr/cf/hdr-undefined.json
@@ -39,7 +39,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "\\bHDR10(\\b[^+|Plus])"
+        "value": "\\bHDR10(?!\\+|Plus)\\b"
       }
     },
     {

--- a/docs/json/radarr/cf/hdr.json
+++ b/docs/json/radarr/cf/hdr.json
@@ -30,7 +30,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "\\bHDR10(\\b[^+|Plus])"
+        "value": "\\bHDR10(?!\\+|Plus)\\b"
       }
     },
     {

--- a/docs/json/radarr/cf/hdr10.json
+++ b/docs/json/radarr/cf/hdr10.json
@@ -12,7 +12,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\bHDR10(\\b[^+|Plus])"
+        "value": "\\bHDR10(?!\\+|Plus)\\b"
       }
     },
     {

--- a/docs/json/radarr/cf/hlg.json
+++ b/docs/json/radarr/cf/hlg.json
@@ -39,7 +39,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "\\bHDR10(\\b[^+|Plus])"
+        "value": "\\bHDR10(?!\\+|Plus)\\b"
       }
     },
     {

--- a/docs/json/radarr/cf/pq.json
+++ b/docs/json/radarr/cf/pq.json
@@ -39,7 +39,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "\\bHDR10(\\b[^+|Plus])"
+        "value": "\\bHDR10(?!\\+|Plus)\\b"
       }
     },
     {

--- a/docs/json/sonarr/cf/hdr-undefined.json
+++ b/docs/json/sonarr/cf/hdr-undefined.json
@@ -39,7 +39,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "\\bHDR10(\\b[^+|Plus])"
+        "value": "\\bHDR10(?!\\+|Plus)\\b"
       }
     },
     {

--- a/docs/json/sonarr/cf/hdr.json
+++ b/docs/json/sonarr/cf/hdr.json
@@ -30,7 +30,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "\\bHDR10(\\b[^+|Plus])"
+        "value": "\\bHDR10(?!\\+|Plus)\\b"
       }
     },
     {

--- a/docs/json/sonarr/cf/hdr10.json
+++ b/docs/json/sonarr/cf/hdr10.json
@@ -12,7 +12,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\bHDR10(\\b[^+|Plus])"
+        "value": "\\bHDR10(?!\\+|Plus)\\b"
       }
     },
     {

--- a/docs/json/sonarr/cf/hlg.json
+++ b/docs/json/sonarr/cf/hlg.json
@@ -39,7 +39,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "\\bHDR10(\\b[^+|Plus])"
+        "value": "\\bHDR10(?!\\+|Plus)\\b"
       }
     },
     {

--- a/docs/json/sonarr/cf/pq.json
+++ b/docs/json/sonarr/cf/pq.json
@@ -30,7 +30,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "\\bHDR10(\\b[^+|Plus])"
+        "value": "\\bHDR10(?!\\+|Plus)\\b"
       }
     },
     {


### PR DESCRIPTION
# Pull Request

## Purpose

To fix an incorrect regex for HDR10.

## Approach

Use a negative lookahead condition to properly exclude +/Plus from matching

## Open Questions and Pre-Merge TODOs

None

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
