### PR TITLE
feat(radarr): Add new Sing-Along Versions custom format

### DIFF
--- a/docs/Radarr/Radarr-collection-of-custom-formats.md
+++ b/docs/Radarr/Radarr-collection-of-custom-formats.md
@@ -58,9 +58,9 @@ We've made 3 guides related to this.
 | [IMAX](#imax)                                 | [Generated Dynamic HDR](#generated-dynamic-hdr) | [UHD Bluray Tier 02](#uhd-bluray-tier-02) |
 | [Masters of Cinema](#masters-of-cinema)       | [LQ](#lq)                                       | [UHD Bluray Tier 03](#uhd-bluray-tier-03) |
 | [Open Matte](#open-matte)                     | [LQ (Release Title)](#lq-release-title)         | [HD Bluray Tier 01](#hd-bluray-tier-01)   |
-| [Remaster](#remaster)                         | [Upscaled](#upscaled)                           | [HD Bluray Tier 02](#hd-bluray-tier-02)   |
-| [Special Edition](#special-edition)           | [x265 (HD)](#x265-hd)                           | [HD Bluray Tier 03](#hd-bluray-tier-03)   |
-| [Theatrical Cut](#theatrical-cut)             |                                                 | [WEB Tier 01](#web-tier-01)               |
+| [Remaster](#remaster)                         | [Sing-Along Versions](#sing-along-versions)     | [HD Bluray Tier 02](#hd-bluray-tier-02)   |
+| [Special Edition](#special-edition)           | [Upscaled](#upscaled)                           | [HD Bluray Tier 03](#hd-bluray-tier-03)   |
+| [Theatrical Cut](#theatrical-cut)             | [x265 (HD)](#x265-hd)                           | [WEB Tier 01](#web-tier-01)               |
 | [Vinegar Syndrome](#vinegar-syndrome)         |                                                 | [WEB Tier 02](#web-tier-02)               |
 |                                               |                                                 | [WEB Tier 03](#web-tier-03)               |
 
@@ -1014,7 +1014,7 @@ We've made 3 guides related to this.
 
 <sub>Low-Quality Releases = LQ</sub>
 
-??? question "LQ (Release Title)- [Click to show/hide]"
+??? question "LQ (Release Title) - [Click to show/hide]"
 
     A collection of terms seen in the titles of Low-Quality releases that are not captured by using a release group name.
 
@@ -1022,6 +1022,22 @@ We've made 3 guides related to this.
 
     ```json
     [[% filter indent(width=4) %]][[% include 'json/radarr/cf/lq-release-title.json' %]][[% endfilter %]]
+    ```
+
+<sub><sup>[TOP](#index)</sup></sub>
+
+---
+
+### Sing-Along Versions
+
+??? question "Sing-Along Versions - [Click to show/hide]"
+
+    Versions of musical films that have sing-along lyrics hardcoded into the video stream.
+
+??? example "JSON - [Click to show/hide]"
+
+    ```json
+    [[% filter indent(width=4) %]][[% include 'json/radarr/cf/sing-along-versions.json' %]][[% endfilter %]]
     ```
 
 <sub><sup>[TOP](#index)</sup></sub>

--- a/docs/json/radarr/cf/sing-along-versions.json
+++ b/docs/json/radarr/cf/sing-along-versions.json
@@ -1,0 +1,20 @@
+{
+  "trash_id": "712d74cd88bceb883ee32f773656b1f5",
+  "trash_scores": {
+    "default": -10000
+  },
+  "trash_regex": "https://regex101.com/r/U9NMJU/1",
+  "name": "Sing-Along Versions",
+  "includeCustomFormatWhenRenaming": false,
+  "specifications": [
+    {
+      "name": "Sing-Along",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": true,
+      "fields": {
+        "value": "(?<=\\b[12]\\d{3}\\b).*\\b(Sing[-_. ]Along)\\b"
+      }
+    }
+  ]
+}

--- a/docs/json/radarr/quality-profiles/hd-bluray-web.json
+++ b/docs/json/radarr/quality-profiles/hd-bluray-web.json
@@ -70,6 +70,7 @@
     "x265 (HD)": "dc98083864ea246d05a42df0d05f81cc",
     "3D": "b8cd450cbfa689c0259a01d9e29ba3d6",
     "Extras": "0a3f082873eb454bde444150b70253cc",
+    "Sing-Along Versions": "712d74cd88bceb883ee32f773656b1f5",
     "AV1": "cae4ca30163749b891686f95532519bd",
     "AMZN": "b3b3a6ac74ecbd56bcdbefa4799fb9df",
     "ATVP": "40e9380490e748672c2522eaaeb692f7",

--- a/docs/json/radarr/quality-profiles/remux-web-1080p.json
+++ b/docs/json/radarr/quality-profiles/remux-web-1080p.json
@@ -70,6 +70,7 @@
     "x265 (HD)": "dc98083864ea246d05a42df0d05f81cc",
     "3D": "b8cd450cbfa689c0259a01d9e29ba3d6",
     "Extras": "0a3f082873eb454bde444150b70253cc",
+    "Sing-Along Versions": "712d74cd88bceb883ee32f773656b1f5",
     "AV1": "cae4ca30163749b891686f95532519bd",
     "AMZN": "b3b3a6ac74ecbd56bcdbefa4799fb9df",
     "ATVP": "40e9380490e748672c2522eaaeb692f7",

--- a/docs/json/radarr/quality-profiles/remux-web-2160p.json
+++ b/docs/json/radarr/quality-profiles/remux-web-2160p.json
@@ -82,6 +82,7 @@
     "3D": "b8cd450cbfa689c0259a01d9e29ba3d6",
     "Upscaled": "bfd8eb01832d646a0a89c4deb46f8564",
     "Extras": "0a3f082873eb454bde444150b70253cc",
+    "Sing-Along Versions": "712d74cd88bceb883ee32f773656b1f5",
     "AV1": "cae4ca30163749b891686f95532519bd",
     "AMZN": "b3b3a6ac74ecbd56bcdbefa4799fb9df",
     "ATVP": "40e9380490e748672c2522eaaeb692f7",

--- a/docs/json/radarr/quality-profiles/sqp-1-1080p.json
+++ b/docs/json/radarr/quality-profiles/sqp-1-1080p.json
@@ -87,6 +87,7 @@
     "x265 (HD)": "dc98083864ea246d05a42df0d05f81cc",
     "3D": "b8cd450cbfa689c0259a01d9e29ba3d6",
     "Extras": "0a3f082873eb454bde444150b70253cc",
+    "Sing-Along Versions": "712d74cd88bceb883ee32f773656b1f5",
     "10 bit": "a5d148168c4506b55cf53984107c396e",
     "AV1": "cae4ca30163749b891686f95532519bd",
     "1080p": "820b09bb9acbfde9c35c71e0e565dad8",

--- a/docs/json/radarr/quality-profiles/sqp-1-2160p.json
+++ b/docs/json/radarr/quality-profiles/sqp-1-2160p.json
@@ -103,6 +103,7 @@
     "3D": "b8cd450cbfa689c0259a01d9e29ba3d6",
     "Upscaled": "bfd8eb01832d646a0a89c4deb46f8564",
     "Extras": "0a3f082873eb454bde444150b70253cc",
+    "Sing-Along Versions": "712d74cd88bceb883ee32f773656b1f5",
     "10 bit": "a5d148168c4506b55cf53984107c396e",
     "AV1": "cae4ca30163749b891686f95532519bd",
     "1080p": "820b09bb9acbfde9c35c71e0e565dad8",

--- a/docs/json/radarr/quality-profiles/sqp-1-web-1080p.json
+++ b/docs/json/radarr/quality-profiles/sqp-1-web-1080p.json
@@ -91,6 +91,7 @@
     "x265 (HD)": "dc98083864ea246d05a42df0d05f81cc",
     "3D": "b8cd450cbfa689c0259a01d9e29ba3d6",
     "Extras": "0a3f082873eb454bde444150b70253cc",
+    "Sing-Along Versions": "712d74cd88bceb883ee32f773656b1f5",
     "10 bit": "a5d148168c4506b55cf53984107c396e",
     "AV1": "cae4ca30163749b891686f95532519bd",
     "1080p": "820b09bb9acbfde9c35c71e0e565dad8",

--- a/docs/json/radarr/quality-profiles/sqp-2.json
+++ b/docs/json/radarr/quality-profiles/sqp-2.json
@@ -87,6 +87,7 @@
     "3D": "b8cd450cbfa689c0259a01d9e29ba3d6",
     "Upscaled": "bfd8eb01832d646a0a89c4deb46f8564",
     "Extras": "0a3f082873eb454bde444150b70253cc",
+    "Sing-Along Versions": "712d74cd88bceb883ee32f773656b1f5",
     "AV1": "cae4ca30163749b891686f95532519bd",
     "1080p": "820b09bb9acbfde9c35c71e0e565dad8",
     "2160p": "fb392fb0d61a010ae38e49ceaa24a1ef",

--- a/docs/json/radarr/quality-profiles/sqp-3.json
+++ b/docs/json/radarr/quality-profiles/sqp-3.json
@@ -84,6 +84,7 @@
     "3D": "b8cd450cbfa689c0259a01d9e29ba3d6",
     "Upscaled": "bfd8eb01832d646a0a89c4deb46f8564",
     "Extras": "0a3f082873eb454bde444150b70253cc",
+    "Sing-Along Versions": "712d74cd88bceb883ee32f773656b1f5",
     "AV1": "cae4ca30163749b891686f95532519bd",
     "1080p": "820b09bb9acbfde9c35c71e0e565dad8",
     "2160p": "fb392fb0d61a010ae38e49ceaa24a1ef",

--- a/docs/json/radarr/quality-profiles/sqp-4.json
+++ b/docs/json/radarr/quality-profiles/sqp-4.json
@@ -79,6 +79,7 @@
     "3D": "b8cd450cbfa689c0259a01d9e29ba3d6",
     "Upscaled": "bfd8eb01832d646a0a89c4deb46f8564",
     "Extras": "0a3f082873eb454bde444150b70253cc",
+    "Sing-Along Versions": "712d74cd88bceb883ee32f773656b1f5",
     "AV1": "cae4ca30163749b891686f95532519bd",
     "1080p": "820b09bb9acbfde9c35c71e0e565dad8",
     "2160p": "fb392fb0d61a010ae38e49ceaa24a1ef",

--- a/docs/json/radarr/quality-profiles/sqp-5.json
+++ b/docs/json/radarr/quality-profiles/sqp-5.json
@@ -87,6 +87,7 @@
     "3D": "b8cd450cbfa689c0259a01d9e29ba3d6",
     "Upscaled": "bfd8eb01832d646a0a89c4deb46f8564",
     "Extras": "0a3f082873eb454bde444150b70253cc",
+    "Sing-Along Versions": "712d74cd88bceb883ee32f773656b1f5",
     "AV1": "cae4ca30163749b891686f95532519bd",
     "1080p": "820b09bb9acbfde9c35c71e0e565dad8",
     "2160p": "fb392fb0d61a010ae38e49ceaa24a1ef",

--- a/docs/json/radarr/quality-profiles/uhd-bluray-web.json
+++ b/docs/json/radarr/quality-profiles/uhd-bluray-web.json
@@ -82,6 +82,7 @@
     "3D": "b8cd450cbfa689c0259a01d9e29ba3d6",
     "Upscaled": "bfd8eb01832d646a0a89c4deb46f8564",
     "Extras": "0a3f082873eb454bde444150b70253cc",
+    "Sing-Along Versions": "712d74cd88bceb883ee32f773656b1f5",
     "AV1": "cae4ca30163749b891686f95532519bd",
     "AMZN": "b3b3a6ac74ecbd56bcdbefa4799fb9df",
     "ATVP": "40e9380490e748672c2522eaaeb692f7",

--- a/includes/cf/radarr-unwanted-uhd.md
+++ b/includes/cf/radarr-unwanted-uhd.md
@@ -10,6 +10,7 @@
     | [{{ radarr['cf']['3d']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#3d)                                       |          {{ radarr['cf']['3d']['trash_scores']['default'] }}           | {{ radarr['cf']['3d']['trash_id'] }}                    |
     | [{{ radarr['cf']['upscaled']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#upscaled)                           |       {{ radarr['cf']['upscaled']['trash_scores']['default'] }}        | {{ radarr['cf']['upscaled']['trash_id'] }}              |
     | [{{ radarr['cf']['extras']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#extras)                               |        {{ radarr['cf']['extras']['trash_scores']['default'] }}         | {{ radarr['cf']['extras']['trash_id'] }}                |
+    | [{{ radarr['cf']['sing-along-versions']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#sing-along-versions)     |  {{ radarr['cf']['sing-along-versions']['trash_scores']['default'] }}  | {{ radarr['cf']['sing-along-versions']['trash_id'] }}   |
     | [{{ radarr['cf']['av1']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#av1)                                     |          {{ radarr['cf']['av1']['trash_scores']['default'] }}          | {{ radarr['cf']['av1']['trash_id'] }}                   |
 
     ---
@@ -27,6 +28,7 @@
     - **{{ radarr['cf']['3d']['name'] }}:** Is 3D still a thing for home use ?
     - **{{ radarr['cf']['upscaled']['name'] }}:** A custom format to prevent Radarr from grabbing upscaled releases.
     - **{{ radarr['cf']['extras']['name'] }}:** Blocks releases that only contain extras
+    - **{{ radarr['cf']['sing-along-versions']['name'] }}:** Blocks releases that contain hardcoded sing-along lyrics for musical sections
     - **{{ radarr['cf']['av1']['name'] }}:** This blocks all releases encoded in AV1.
 
         {! include-markdown "../../includes/cf-descriptions/av1.md" !}

--- a/includes/cf/radarr-unwanted.md
+++ b/includes/cf/radarr-unwanted.md
@@ -9,6 +9,7 @@
     | [{{ radarr['cf']['x265-hd']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#x265-hd) :warning:                   |        {{ radarr['cf']['x265-hd']['trash_scores']['default'] }}        | {{ radarr['cf']['x265-hd']['trash_id'] }}               |
     | [{{ radarr['cf']['3d']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#3d)                                       |          {{ radarr['cf']['3d']['trash_scores']['default'] }}           | {{ radarr['cf']['3d']['trash_id'] }}                    |
     | [{{ radarr['cf']['extras']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#extras)                               |        {{ radarr['cf']['extras']['trash_scores']['default'] }}         | {{ radarr['cf']['extras']['trash_id'] }}                |
+    | [{{ radarr['cf']['sing-along-versions']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#sing-along-versions)     |  {{ radarr['cf']['sing-along-versions']['trash_scores']['default'] }}  | {{ radarr['cf']['sing-along-versions']['trash_id'] }}   |
     | [{{ radarr['cf']['av1']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#av1)                                     |          {{ radarr['cf']['av1']['trash_scores']['default'] }}          | {{ radarr['cf']['av1']['trash_id'] }}                   |
 
     ---
@@ -25,6 +26,7 @@
 
     - **{{ radarr['cf']['3d']['name'] }}:** Is 3D still a thing for home use ?
     - **{{ radarr['cf']['extras']['name'] }}:** Blocks releases that only contain extras
+    - **{{ radarr['cf']['sing-along-versions']['name'] }}:** Blocks releases that contain hardcoded sing-along lyrics for musical sections
     - **{{ radarr['cf']['av1']['name'] }}:** This blocks all releases encoded in AV1.
 
         {! include-markdown "../../includes/cf-descriptions/av1.md" !}

--- a/includes/sqp/radarr-unwanted-sqp1.md
+++ b/includes/sqp/radarr-unwanted-sqp1.md
@@ -9,6 +9,7 @@
     | [{{ radarr['cf']['x265-hd']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#x265-hd) :warning:                   |        {{ radarr['cf']['x265-hd']['trash_scores']['default'] }}        | {{ radarr['cf']['x265-hd']['trash_id'] }}               |
     | [{{ radarr['cf']['3d']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#3d)                                       |          {{ radarr['cf']['3d']['trash_scores']['default'] }}           | {{ radarr['cf']['3d']['trash_id'] }}                    |
     | [{{ radarr['cf']['extras']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#extras)                               |        {{ radarr['cf']['extras']['trash_scores']['default'] }}         | {{ radarr['cf']['extras']['trash_id'] }}                |
+    | [{{ radarr['cf']['sing-along-versions']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#sing-along-versions)     |  {{ radarr['cf']['sing-along-versions']['trash_scores']['default'] }}  | {{ radarr['cf']['sing-along-versions']['trash_id'] }}   |
     | [{{ radarr['cf']['10bit']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#10bit)                                 |       {{ radarr['cf']['10bit']['trash_scores']['sqp-1-1080p'] }}       | {{ radarr['cf']['10bit']['trash_id'] }}                 |
     | [{{ radarr['cf']['av1']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#av1)                                     |          {{ radarr['cf']['av1']['trash_scores']['default'] }}          | {{ radarr['cf']['av1']['trash_id'] }}                   |
 
@@ -26,6 +27,7 @@
 
     - **{{ radarr['cf']['3d']['name'] }}:** Is 3D still a thing for home use ?
     - **{{ radarr['cf']['extras']['name'] }}:** Blocks releases that only contain extras
+    - **{{ radarr['cf']['sing-along-versions']['name'] }}:** Blocks releases that contain hardcoded sing-along lyrics for musical sections
     - **{{ radarr['cf']['10bit']['name'] }}:** Blocks releases that use Hi10P
     - **{{ radarr['cf']['av1']['name'] }}:** This blocks all releases encoded in AV1.
 

--- a/includes/sqp/radarr-unwanted-uhd-sqp1.md
+++ b/includes/sqp/radarr-unwanted-uhd-sqp1.md
@@ -10,6 +10,7 @@
     | [{{ radarr['cf']['3d']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#3d)                                       |          {{ radarr['cf']['3d']['trash_scores']['default'] }}           | {{ radarr['cf']['3d']['trash_id'] }}                    |
     | [{{ radarr['cf']['upscaled']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#upscaled)                           |       {{ radarr['cf']['upscaled']['trash_scores']['default'] }}        | {{ radarr['cf']['upscaled']['trash_id'] }}              |
     | [{{ radarr['cf']['extras']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#extras)                               |        {{ radarr['cf']['extras']['trash_scores']['default'] }}         | {{ radarr['cf']['extras']['trash_id'] }}                |
+    | [{{ radarr['cf']['sing-along-versions']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#sing-along-versions)     |  {{ radarr['cf']['sing-along-versions']['trash_scores']['default'] }}  | {{ radarr['cf']['sing-along-versions']['trash_id'] }}   |
     | [{{ radarr['cf']['10bit']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#10bit)                                 |       {{ radarr['cf']['10bit']['trash_scores']['sqp-1-2160p'] }}       | {{ radarr['cf']['10bit']['trash_id'] }}                 |
     | [{{ radarr['cf']['av1']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#av1)                                     |          {{ radarr['cf']['av1']['trash_scores']['default'] }}          | {{ radarr['cf']['av1']['trash_id'] }}                   |
 
@@ -28,6 +29,7 @@
     - **{{ radarr['cf']['3d']['name'] }}:** Is 3D still a thing for home use ?
     - **{{ radarr['cf']['upscaled']['name'] }}:** A custom format to prevent Radarr from grabbing upscaled releases.
     - **{{ radarr['cf']['extras']['name'] }}:** Blocks releases that only contain extras
+    - **{{ radarr['cf']['sing-along-versions']['name'] }}:** Blocks releases that contain hardcoded sing-along lyrics for musical sections
     - **{{ radarr['cf']['10bit']['name'] }}:** Blocks releases that use Hi10P
     - **{{ radarr['cf']['av1']['name'] }}:** This blocks all releases encoded in AV1.
 


### PR DESCRIPTION
# Pull Request

## Purpose

Provide a way for Sing-Along versions of movies to be matched and blocked
Resolve #2234 

## Approach

- [x] Create new Radarr custom format JSON for Sing-Along Versions, with a default score of -10000
- [x] Added new custom format with info to all profile unwanted panels, and profile JSONs
- [x] Added new custom format to Radarr's Collection of Custom Formats page

## Open Questions and Pre-Merge TODOs

None

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
