### PR TITLE
feat(starr-anime): Add DemiHuman to Anime BD Tier 02

### DIFF
--- a/docs/json/radarr/cf/anime-bd-tier-02-seadex-muxers.json
+++ b/docs/json/radarr/cf/anime-bd-tier-02-seadex-muxers.json
@@ -169,6 +169,15 @@
       }
     },
     {
+      "name": "DemiHuman",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[DemiHuman\\]|-DemiHuman\\b"
+      }
+    },
+    {
       "name": "Drag",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,

--- a/docs/json/sonarr/cf/anime-bd-tier-02-seadex-muxers.json
+++ b/docs/json/sonarr/cf/anime-bd-tier-02-seadex-muxers.json
@@ -178,6 +178,15 @@
       }
     },
     {
+      "name": "DemiHuman",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[DemiHuman\\]|-DemiHuman\\b"
+      }
+    },
+    {
       "name": "Drag",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,


### PR DESCRIPTION
# Pull Request

## Purpose
Add DemiHuman to Anime BD Tier 02 since almost all of their releases are marked as best on SeaDex
<!-- Please provide a detailed description of why you created this pull request. -->

## Approach
Standard anime regex
<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
