### PR TITLE
feat(starr-german): Add Groups to German Tiers

### DIFF
--- a/docs/json/radarr/cf/german-bluray-tier-01.json
+++ b/docs/json/radarr/cf/german-bluray-tier-01.json
@@ -88,6 +88,15 @@
       }
     },
     {
+      "name": "MAMA",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(MAMA)$"
+      }
+    },
+    {
       "name": "Bluray",
       "implementation": "SourceSpecification",
       "negate": false,

--- a/docs/json/radarr/cf/german-lq-release-title.json
+++ b/docs/json/radarr/cf/german-lq-release-title.json
@@ -14,6 +14,15 @@
       "fields": {
         "value": "([._-])iTunes(?:HD|SD)?\\1.+?-TVS$"
       }
+    },
+    {
+      "name": "Jellyfin-Plex",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "Jellyfin-Plex$"
+      }
     }
   ]
 }

--- a/docs/json/radarr/cf/german-microsized.json
+++ b/docs/json/radarr/cf/german-microsized.json
@@ -32,6 +32,15 @@
       "fields": {
         "value": "^(GTF)$"
       }
+    },
+    {
+      "name": "JellyfinPlex",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(JellyfinPlex)$"
+      }
     }
   ]
 }

--- a/docs/json/radarr/cf/german-remux-tier-01.json
+++ b/docs/json/radarr/cf/german-remux-tier-01.json
@@ -52,6 +52,15 @@
       }
     },
     {
+      "name": "MAMA",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(MAMA)$"
+      }
+    },
+    {
       "name": "Remux",
       "implementation": "QualityModifierSpecification",
       "negate": false,

--- a/docs/json/radarr/cf/german-scene.json
+++ b/docs/json/radarr/cf/german-scene.json
@@ -266,6 +266,15 @@
       "fields": {
         "value": "^(RSG)$"
       }
+    },
+    {
+      "name": "OCA",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(OCA)$"
+      }
     }
   ]
 }

--- a/docs/json/sonarr/cf/german-lq-release-title.json
+++ b/docs/json/sonarr/cf/german-lq-release-title.json
@@ -14,6 +14,15 @@
       "fields": {
         "value": "([._-])iTunes(?:HD|SD)?\\1.+?-TVS$"
       }
+    },
+    {
+      "name": "Jellyfin-Plex",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "Jellyfin-Plex$"
+      }
     }
   ]
 }

--- a/docs/json/sonarr/cf/german-microsized.json
+++ b/docs/json/sonarr/cf/german-microsized.json
@@ -32,6 +32,15 @@
       "fields": {
         "value": "^(GTF)$"
       }
+    },
+    {
+      "name": "JellyfinPlex",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(JellyfinPlex)$"
+      }
     }
   ]
 }

--- a/docs/json/sonarr/cf/german-scene.json
+++ b/docs/json/sonarr/cf/german-scene.json
@@ -302,6 +302,24 @@
       "fields": {
         "value": "^(OCA)$"
       }
+    },
+    {
+      "name": "RIPLEY",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(RIPLEY)$"
+      }
+    },
+    {
+      "name": "GTVG",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(GTVG)$"
+      }
     }
   ]
 }

--- a/docs/json/sonarr/cf/german-scene.json
+++ b/docs/json/sonarr/cf/german-scene.json
@@ -257,6 +257,33 @@
       "fields": {
         "value": "^(TVNATiON)$"
       }
+    },
+    {
+      "name": "FENDT",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(FENDT)$"
+      }
+    },
+    {
+      "name": "ACED",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(ACED)$"
+      }
+    },
+    {
+      "name": "FKKTV",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(FKKTV)$"
+      }
     }
   ]
 }

--- a/docs/json/sonarr/cf/german-scene.json
+++ b/docs/json/sonarr/cf/german-scene.json
@@ -284,6 +284,24 @@
       "fields": {
         "value": "^(FKKTV)$"
       }
+    },
+    {
+      "name": "euHD",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(euHD)$"
+      }
+    },
+    {
+      "name": "OCA",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(OCA)$"
+      }
     }
   ]
 }

--- a/docs/json/sonarr/cf/german-web-tier-02.json
+++ b/docs/json/sonarr/cf/german-web-tier-02.json
@@ -52,6 +52,15 @@
       }
     },
     {
+      "name": "4SF Aliases",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(4SJ)\\b"
+      }
+    },
+    {
       "name": "ABJ",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,


### PR DESCRIPTION
# Pull Request

## Purpose

- [x] FENDT to German Scene (Sonarr)
- [x] ACED to German Scene (Sonarr)
- [x] FKKTV to German Scene (Sonarr)
- [x] euHD in German Scene (Sonarr)
- [x] OCA in German Scene
- [x] MAMA in Tier 01 (Radarr)
- [x] 4SJ in 4SF Aliases
- [x] RIPLEY in German Scene (Sonarr)
- [x] GTVG in German Scene (Sonarr)
- [x] JellyfinPlex in German Microsized https://www.xrel.to/p2p/group-5586-jellyfinplex/releases.html 
- [x] Jellyfin-Plex in German LQ (release title)

## Approach

Add groups to CFs

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
