### PR TITLE
feat(starr-german): add LQ (release title) CF to the german guide

### DIFF
--- a/docs/json/sonarr/cf/lq-release-title.json
+++ b/docs/json/sonarr/cf/lq-release-title.json
@@ -1,7 +1,8 @@
 {
   "trash_id": "e2315f990da2e2cbfc9fa5b7a6fcfe48",
   "trash_scores": {
-    "default": -10000
+    "default": -10000,
+    "german": -35000
   },
   "name": "LQ (Release Title)",
   "includeCustomFormatWhenRenaming": false,

--- a/includes/german-guide/radarr-german-unwanted-en.md
+++ b/includes/german-guide/radarr-german-unwanted-en.md
@@ -8,6 +8,7 @@
     | [{{ radarr['cf']['3d']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#3d)                                                 |               {{ radarr['cf']['3d']['trash_scores']['german'] }}                | {{ radarr['cf']['3d']['trash_id'] }}                      |
     | [{{ radarr['cf']['line-mic-dubbed']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#linemic-dubbed)                        |         {{ radarr['cf']['line-mic-dubbed']['trash_scores']['german'] }}         | {{ radarr['cf']['line-mic-dubbed']['trash_id'] }}         |
     | [{{ radarr['cf']['lq']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#lq)                                                 |               {{ radarr['cf']['lq']['trash_scores']['german'] }}                | {{ radarr['cf']['lq']['trash_id'] }}                      |
+    | [{{ radarr['cf']['lq-release-title']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#lq-release-title)                     |        {{ radarr['cf']['lq-release-title']['trash_scores']['german'] }}         | {{ radarr['cf']['lq-release-title']['trash_id'] }}        |
     | [{{ radarr['cf']['german-lq']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#german-lq)                                   |           {{ radarr['cf']['german-lq']['trash_scores']['default'] }}            | {{ radarr['cf']['german-lq']['trash_id'] }}               |
     | [{{ radarr['cf']['german-lq-release-title']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#german-lq-release-title)       |    {{ radarr['cf']['german-lq-release-title']['trash_scores']['default'] }}     | {{ radarr['cf']['german-lq-release-title']['trash_id'] }} |
     | [{{ radarr['cf']['german-microsized']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#german-microsized)                   |       {{ radarr['cf']['german-microsized']['trash_scores']['default'] }}        | {{ radarr['cf']['german-microsized']['trash_id'] }}       |
@@ -25,6 +26,7 @@
     - **{{ radarr['cf']['3d']['name'] }}:** Is 3D still a thing for home use ?
     - **{{ radarr['cf']['line-mic-dubbed']['name'] }}:** This blocks Line and Mic Dubs.
     - **{{ radarr['cf']['lq']['name'] }}:** A collection of known Low Quality groups that are often banned from the the top trackers because the lack of quality or other reasons.
+    - **{{ radarr['cf']['lq-release-title']['name'] }}:** A collection of terms seen in the titles of low-quality releases that are not captured by using a release group name.
     - **{{ radarr['cf']['german-lq']['name'] }}:** A collection of known Low Quality German groups that are often banned from the the top trackers because the lack of quality or other reasons.
     - **{{ radarr['cf']['german-lq-release-title']['name'] }}:** A collection of terms seen in the titles of low-quality releases that are not captured by using a release group name.
     - **{{ radarr['cf']['german-microsized']['name'] }}:** A collection of German groups producing low quality micro-sized releases.

--- a/includes/german-guide/sonarr-german-unwanted-en.md
+++ b/includes/german-guide/sonarr-german-unwanted-en.md
@@ -5,6 +5,7 @@
     | ----------------------------------------------------------------------------------------------------------------------------- | :----------------------------------------------------------------------: | --------------------------------------------------------- |
     | [{{ sonarr['cf']['br-disk']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#br-disk)                                 |         {{ sonarr['cf']['br-disk']['trash_scores']['german'] }}          | {{ sonarr['cf']['br-disk']['trash_id'] }}                 |
     | [{{ sonarr['cf']['lq']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#lq)                                           |            {{ sonarr['cf']['lq']['trash_scores']['german'] }}            | {{ sonarr['cf']['lq']['trash_id'] }}                      |
+    | [{{ sonarr['cf']['lq-release-title']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#lq-release-title)               |     {{ sonarr['cf']['lq-release-title']['trash_scores']['german'] }}     | {{ sonarr['cf']['lq-release-title']['trash_id'] }}        |
     | [{{ sonarr['cf']['german-lq']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#german-lq)                             |        {{ sonarr['cf']['german-lq']['trash_scores']['default'] }}        | {{ sonarr['cf']['german-lq']['trash_id'] }}               |
     | [{{ sonarr['cf']['german-lq-release-title']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#german-lq-release-title) | {{ sonarr['cf']['german-lq-release-title']['trash_scores']['default'] }} | {{ sonarr['cf']['german-lq-release-title']['trash_id'] }} |
     | [{{ sonarr['cf']['german-microsized']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#german-microsized)             |    {{ sonarr['cf']['german-microsized']['trash_scores']['default'] }}    | {{ sonarr['cf']['german-microsized']['trash_id'] }}       |
@@ -19,6 +20,7 @@
 
     - **{{ sonarr['cf']['br-disk']['name'] }}:** This is a custom format to help Sonarr recognize & ignore BR-DISK (ISO's and Blu-ray folder structure) in addition to the standard BR-DISK quality.
     - **{{ sonarr['cf']['lq']['name'] }}:** A collection of known Low Quality groups that are often banned from the the top trackers because the lack of quality or other reasons.
+    - **{{ sonarr['cf']['lq-release-title']['name'] }}:** A collection of terms seen in the titles of low-quality releases that are not captured by using a release group name.
     - **{{ sonarr['cf']['german-lq']['name'] }}:** A collection of known Low Quality German groups that are often banned from the the top trackers because the lack of quality or other reasons.
     - **{{ radarr['cf']['german-lq-release-title']['name'] }}:** A collection of terms seen in the titles of low-quality releases that are not captured by using a release group name.
     - **{{ sonarr['cf']['german-microsized']['name'] }}:** A collection of German groups producing low quality micro-sized releases.


### PR DESCRIPTION
# Pull Request

## Purpose

The CF `LQ (release title)` was missing in the german guide, it could be helpful for users who also want to get english releases.

## Approach

Add the CF to the Guide.

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
