### PR TITLE
fix(guide-sync): Add HD audio formats for the remux profiles

### DIFF
--- a/docs/json/radarr/cf-groups/advanced-audio-formats.json
+++ b/docs/json/radarr/cf-groups/advanced-audio-formats.json
@@ -76,22 +76,13 @@
   "quality_profiles": {
     "exclude": {
       "HD Bluray + WEB": "d1d67249d3890e49bc12e275d989a7e9",
-      "Remux + WEB 1080p": "9ca12ea80aa55ef916e3751f4b874151",
-      "Remux + WEB 2160p": "fd161a61e3ab826d3a22d53f935696dd",
-      "UHD Bluray + WEB": "64fb5f9858489bdac2af690e27c8f42f",
-      "Remux 2160p (Alternative)": "dd3cd75deb9645bae838d1c5da6388d5",
-      "Remux 2160p (Combined)": "d1d310673359205736b4b84acd5ea8c8",
       "[German] HD Bluray + WEB": "2b90e905c99490edc7c7a5787443748b",
       "[German] Remux + WEB 2160p": "79faa9943cef2f510b997b1f2a9f3ea6",
       "[German] UHD Bluray + WEB": "27cc3d153c0a799fd139ef1ff4c4cc42",
       "[German] UHD Bluray + WEB (Alternative)": "425da1ba30711b55d2eb371437ec98d7",
       "SQP-1 (1080p)": "0896c29d74de619df168d23b98104b22",
       "SQP-1 WEB (1080p)": "90a3370d2d30cbaf08d9c23b856a12c8",
-      "SQP-1 (2160p)": "5128baeb2b081b72126bc8482b2a86a0",
-      "SQP-2": "c3933358ba2356bafc41524f81471069",
-      "SQP-3": "2cf36c1f0106ffac993be003ade51865",
-      "SQP-4": "013f89e6da27519fe56cf482702a2db9",
-      "SQP-5": "a7bb1539fd147256b21b1098f3dc2016"
+      "SQP-1 (2160p)": "5128baeb2b081b72126bc8482b2a86a0"
     }
   }
 }


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->

Add HD audio formats for the remux profiles.

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

Removed the profiles from the HD audio formats group that should have HD Audio formats included.

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
