### PR TITLE
feat(radarr): Only match B&W edition after year

### DIFF
--- a/docs/json/radarr/cf/black-and-white-editions.json
+++ b/docs/json/radarr/cf/black-and-white-editions.json
@@ -12,7 +12,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "\\b((B(lack)?[ ._-]?(out|(and|[n&])[ ._-]?(W(hite)?|Chrome))))\\b(?!$)"
+        "value": "(?<=\\b[12]\\d{3}\\b).*\\b((B(lack)?[ ._-]?(out|(and|[n&])[ ._-]?(W(hite)?|Chrome))))\\b(?!$)"
       }
     },
     {
@@ -21,7 +21,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "\\b(Monochrome)\\b(?!$)"
+        "value": "(?<=\\b[12]\\d{3}\\b).*\\b(Monochrome)\\b(?!$)"
       }
     },
     {
@@ -39,7 +39,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "\\b(Shush[ ._-]?Cut)\\b(?!$)"
+        "value": "(?<=\\b[12]\\d{3}\\b).*\\b(Shush[ ._-]?Cut)\\b(?!$)"
       }
     },
     {
@@ -48,7 +48,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "\\b((No|Minus)[ ._-]?Colou?r)\\b(?!$)"
+        "value": "(?<=\\b[12]\\d{3}\\b).*\\b((No|Minus)[ ._-]?Colou?r)\\b(?!$)"
       }
     },
     {
@@ -66,7 +66,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "\\b(Darkness?[ ._-]?(and|&)[ ._-]?(Light))\\b(?!$)"
+        "value": "(?<=\\b[12]\\d{3}\\b).*\\b(Darkness?[ ._-]?(and|&)[ ._-]?(Light))\\b(?!$)"
       }
     }
   ]


### PR DESCRIPTION
# Pull Request

## Purpose
The B&W edition CF had a few conditions that matched after year only, but some of the other conditions were generic, causing it to match on movie titles such as the below.

![image](https://github.com/user-attachments/assets/13973e21-0432-48d0-b094-e41f8fc3c05e)

<!-- Please provide a detailed description of why you created this pull request. -->

## Approach
Extend the regex to match after year to each condition
<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
