### PR TITLE
feat(starr-anime): Add SoM to Anime Web Tier 1, move CRUCiBLE to Anime BD Tier 3

### DIFF
--- a/docs/json/radarr/cf/anime-bd-tier-03-seadex-muxers.json
+++ b/docs/json/radarr/cf/anime-bd-tier-03-seadex-muxers.json
@@ -70,6 +70,15 @@
       }
     },
     {
+      "name": "CRUCiBLE",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(CRUCiBLE)\\b"
+      }
+    },
+    {
       "name": "CTR",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,

--- a/docs/json/radarr/cf/anime-bd-tier-05-remuxes.json
+++ b/docs/json/radarr/cf/anime-bd-tier-05-remuxes.json
@@ -34,15 +34,6 @@
       }
     },
     {
-      "name": "CRUCiBLE",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "\\b(CRUCiBLE)\\b"
-      }
-    },
-    {
       "name": "D4C",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,

--- a/docs/json/radarr/cf/anime-web-tier-01-muxers.json
+++ b/docs/json/radarr/cf/anime-web-tier-01-muxers.json
@@ -106,6 +106,15 @@
       }
     },
     {
+      "name": "SoM",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[SoM\\]|-SoM\\b"
+      }
+    },
+    {
       "name": "Vodes",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,

--- a/docs/json/sonarr/cf/anime-bd-tier-03-seadex-muxers.json
+++ b/docs/json/sonarr/cf/anime-bd-tier-03-seadex-muxers.json
@@ -79,6 +79,15 @@
       }
     },
     {
+      "name": "CRUCiBLE",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(CRUCiBLE)\\b"
+      }
+    },
+    {
       "name": "CTR",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,

--- a/docs/json/sonarr/cf/anime-bd-tier-05-remuxes.json
+++ b/docs/json/sonarr/cf/anime-bd-tier-05-remuxes.json
@@ -43,15 +43,6 @@
       }
     },
     {
-      "name": "CRUCiBLE",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "\\b(CRUCiBLE)\\b"
-      }
-    },
-    {
       "name": "D4C",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,

--- a/docs/json/sonarr/cf/anime-web-tier-01-muxers.json
+++ b/docs/json/sonarr/cf/anime-web-tier-01-muxers.json
@@ -115,6 +115,15 @@
       }
     },
     {
+      "name": "SoM",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[SoM\\]|-SoM\\b"
+      }
+    },
+    {
       "name": "Vodes",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,


### PR DESCRIPTION
# Pull Request

## Purpose
Add SoM to Anime Web Tier 1 due to some of their top Dragon Ball releases being Web instead of only DVD
Move CRUCiBLE to Anime BD Tier 3 from Anime BD Tier 5 due to them being a top 15 SeaDex group and having consistent remuxes

<!-- Please provide a detailed description of why you created this pull request. -->

## Approach
Standard approach for anime regex. We may need to eventually split out anime remux groups into their own tiers due to size, but for now, it's too messy. Easier to keep our existing approach and wait to see the real appetite for carving remuxes into their own tiers.
<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

## Requirements

- [ ] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
