### PR TITLE
fix(sonarr-french): CF on FR Anime Tier 3 (kazuizui)

### DIFF
--- a/docs/json/sonarr/cf/french-anime-tier-03.json
+++ b/docs/json/sonarr/cf/french-anime-tier-03.json
@@ -50,7 +50,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "\\b(kazuizui)\\b"
+        "value": "\\b(kazui(zui)?)\\b"
       }
     },
     {


### PR DESCRIPTION
# Pull Request

## Purpose

The CF kazuizui is updated to match kazuizui and kazui (Who's his old name)

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
