### PR TITLE
feat(starr): Add `EZTVx.to`, `eztv.io`, (etc.) to the Retags Custom Format

### DIFF
--- a/docs/json/radarr/cf/retags.json
+++ b/docs/json/radarr/cf/retags.json
@@ -31,7 +31,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "\\[eztv([ ._-]re)?\\]"
+        "value": "\\[eztvx?[ ._-]?(io|re|to)?\\]"
       }
     },
     {

--- a/docs/json/sonarr/cf/retags.json
+++ b/docs/json/sonarr/cf/retags.json
@@ -22,7 +22,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "\\[eztv([ ._-]re)?\\]"
+        "value": "\\[eztvx?[ ._-]?(io|re|to)?\\]"
       }
     },
     {


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->

Add `EZTVx.to`, `eztv.io`, (etc.) to the Retags Custom Format

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

Added `EZTVx.to`, `eztv.io`, (etc.) to the Retags Custom Format

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
