### PR TITLE
feat(starr-anime): Fix CRUCiBLE regex

### DIFF
--- a/docs/json/radarr/cf/anime-bd-tier-03-seadex-muxers.json
+++ b/docs/json/radarr/cf/anime-bd-tier-03-seadex-muxers.json
@@ -75,7 +75,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "\\b(CRUCiBLE)\\b"
+        "value": "\\[CRUCiBLE\\]|-CRUCiBLE\\b"
       }
     },
     {

--- a/docs/json/sonarr/cf/anime-bd-tier-03-seadex-muxers.json
+++ b/docs/json/sonarr/cf/anime-bd-tier-03-seadex-muxers.json
@@ -84,7 +84,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "\\b(CRUCiBLE)\\b"
+        "value": "\\[CRUCiBLE\\]|-CRUCiBLE\\b"
       }
     },
     {


### PR DESCRIPTION
# Pull Request

## Purpose
CRUCiBLE is a common dictionary word, so need to limit the regex to only match anime group patters
<!-- Please provide a detailed description of why you created this pull request. -->

## Approach
Use narrower regex
<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
