### PR TITLE
feat(sonarr): Add CREATiVE24 to Sonarr LQ (Release Title) CF

### DIFF
--- a/docs/json/sonarr/cf/lq-release-title.json
+++ b/docs/json/sonarr/cf/lq-release-title.json
@@ -8,12 +8,12 @@
   "includeCustomFormatWhenRenaming": false,
   "specifications": [
     {
-      "name": "TeeWee",
+      "name": "BEN THE MEN",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,
       "required": false,
       "fields": {
-        "value": "\\b(TeeWee)\\b"
+        "value": "\\b(BEN[ ._-]THE[ ._-]MEN)\\b"
       }
     },
     {
@@ -26,12 +26,21 @@
       }
     },
     {
-      "name": "BEN THE MEN",
+      "name": "CREATiVE24",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,
       "required": false,
       "fields": {
-        "value": "\\b(BEN[ ._-]THE[ ._-]MEN)\\b"
+        "value": "\\b(CREATiVE24)\\b"
+      }
+    },
+    {
+      "name": "TeeWee",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(TeeWee)\\b"
       }
     }
   ]


### PR DESCRIPTION
# Pull Request

## Purpose

- Add CREATiVE24 to Sonarr lq-release-title custom format
- Address #2258 

## Approach

- [x] Add CREATiVE24 to Sonarr lq-release-title custom format

## Open Questions and Pre-Merge TODOs

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
