### PR TITLE
Revert "build(deps): bump mkdocs-material from 9.6.1 to 9.6.3"

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,7 +2,7 @@ mkdocs-glightbox==0.4.0
 mkdocs-awesome-pages-plugin==2.10.1
 mkdocs-git-revision-date-localized-plugin==1.3.0
 mkdocs-macros-plugin==1.3.7
-mkdocs-material==9.6.3
+mkdocs-material==9.6.1
 mkdocs-minify-plugin==0.8.0
 mkdocs-redirects==1.2.2
 mkdocs-include-markdown-plugin==7.1.4


### PR DESCRIPTION
Reverts TRaSH-Guides/Guides#2270

Reverting due to potential breaking changes to the PR banner