### PR TITLE
Revert "Revert "build(deps): bump mkdocs-material from 9.6.1 to 9.6.3…

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,7 +2,7 @@ mkdocs-glightbox==0.4.0
 mkdocs-awesome-pages-plugin==2.10.1
 mkdocs-git-revision-date-localized-plugin==1.3.0
 mkdocs-macros-plugin==1.3.7
-mkdocs-material==9.6.1
+mkdocs-material==9.6.3
 mkdocs-minify-plugin==0.8.0
 mkdocs-redirects==1.2.2
 mkdocs-include-markdown-plugin==7.1.4


### PR DESCRIPTION
…" (#2275)"

This reverts commit c64aec215ad1e3b5b66bce98bc9004f8162d02f3.

# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [ ] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
