### PR TITLE
feat(starr-german): add regex matching double german to to `German LQ (release title)`

### DIFF
--- a/docs/json/radarr/cf/german-lq-release-title.json
+++ b/docs/json/radarr/cf/german-lq-release-title.json
@@ -23,6 +23,15 @@
       "fields": {
         "value": "Jellyfin-Plex$"
       }
+    },
+    {
+      "name": "German Tag after RG",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\.German\\..+?\\.?German$"
+      }
     }
   ]
 }

--- a/docs/json/sonarr/cf/german-lq-release-title.json
+++ b/docs/json/sonarr/cf/german-lq-release-title.json
@@ -23,6 +23,15 @@
       "fields": {
         "value": "Jellyfin-Plex$"
       }
+    },
+    {
+      "name": "German Tag after RG",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\.German\\..+?\\.?German$"
+      }
     }
   ]
 }


### PR DESCRIPTION
# Pull Request

## Purpose

Some Releases have a German tag twice in their release name, mostly after the Release Group. This leads to wrong matching and scoring. To avoid this behavior we decided to add this pattern to `German LQ (release title)`

Example: `Prinzessin.Mononoke.1997.German.DL.1080p.BluRay.x264.CONTRiBUTiON.German`

## Approach

Add `\.German\..+?\.?German$` to German LQ (release title)

## Requirements

- [ ] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
