### PR TITLE
fix(starr-german): Make DL Tag required and negated for the German Language CF to avoid double scoring.

### DIFF
--- a/docs/json/radarr/cf/language-german.json
+++ b/docs/json/radarr/cf/language-german.json
@@ -28,7 +28,7 @@
       "name": "DL",
       "implementation": "ReleaseTitleSpecification",
       "negate": true,
-      "required": false,
+      "required": true,
       "fields": {
         "value": "(?<!WEB[-_. ]?)\\b(DL)\\b"
       }

--- a/docs/json/sonarr/cf/language-german.json
+++ b/docs/json/sonarr/cf/language-german.json
@@ -28,7 +28,7 @@
       "name": "DL",
       "implementation": "ReleaseTitleSpecification",
       "negate": true,
-      "required": false,
+      "required": true,
       "fields": {
         "value": "(?<!WEB[-_. ]?)\\b(DL)\\b"
       }


### PR DESCRIPTION
# Pull Request

## Purpose

Fix double scoring recently brought up in [Discord](https://discord.com/channels/492590071455940612/1320818257581838376/1339861976473403434)

## Approach

Make DL Tag required and negated for the German Language CF to avoid double scoring.

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
