### PR TITLE
feat(starr-anime): Fix PMR regex to match if at end of filename

### DIFF
--- a/docs/json/radarr/cf/anime-bd-tier-05-remuxes.json
+++ b/docs/json/radarr/cf/anime-bd-tier-05-remuxes.json
@@ -57,7 +57,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "\\b(PMR)\\b.*(Remux)"
+        "value": "\\b(PMR)\\b.*(Remux)|(Remux).*\\b(PMR)\\b"
       }
     },
     {

--- a/docs/json/radarr/cf/anime-bd-tier-05-remuxes.json
+++ b/docs/json/radarr/cf/anime-bd-tier-05-remuxes.json
@@ -57,7 +57,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "\\b(PMR)\\b.*(Remux)|(Remux).*\\b(PMR)\\b"
+        "value": "^(?=.*\\b(PMR)\\b)(?=.*\\b(Remux)\\b)"
       }
     },
     {

--- a/docs/json/sonarr/cf/anime-bd-tier-05-remuxes.json
+++ b/docs/json/sonarr/cf/anime-bd-tier-05-remuxes.json
@@ -66,7 +66,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "\\b(PMR)\\b.*(Remux)"
+        "value": "\\b(PMR)\\b.*(Remux)|(Remux).*\\b(PMR)\\b"
       }
     },
     {

--- a/docs/json/sonarr/cf/anime-bd-tier-05-remuxes.json
+++ b/docs/json/sonarr/cf/anime-bd-tier-05-remuxes.json
@@ -66,7 +66,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "\\b(PMR)\\b.*(Remux)|(Remux).*\\b(PMR)\\b"
+        "value": "^(?=.*\\b(PMR)\\b)(?=.*\\b(Remux)\\b)"
       }
     },
     {


### PR DESCRIPTION
# Pull Request

## Purpose
Right now, PMR regex requires it to be in the front of the filename due to requiring REMUX after it, so I added an option for REMUX to come first and PMR at end so it can match both filenames below
`[PMR] The Eminence in Shadow Season 2 (BD Remux 1080p AVC FLAC) [Dual Audio]`
`The Eminence in Shadow - S02E01 (BD Remux 1080p AVC FLAC) [Dual Audio] [PMR].mkv`
<!-- Please provide a detailed description of why you created this pull request. -->

## Approach
Just created the same regex as flipped and allowed condition to match on either
<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
