### PR TITLE
feat(starr-anime): Add shincaps to Anime LQ Groups

### DIFF
--- a/docs/json/radarr/cf/anime-lq-groups.json
+++ b/docs/json/radarr/cf/anime-lq-groups.json
@@ -997,6 +997,15 @@
       }
     },
     {
+      "name": "shincaps",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(shincaps)\\b"
+      }
+    },
+    {
       "name": "SLAX",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,

--- a/docs/json/sonarr/cf/anime-lq-groups.json
+++ b/docs/json/sonarr/cf/anime-lq-groups.json
@@ -997,6 +997,15 @@
       }
     },
     {
+      "name": "shincaps",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(shincaps)\\b"
+      }
+    },
+    {
       "name": "SLAX",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,


### PR DESCRIPTION
# Pull Request

## Purpose
shincaps posts raw tv footage at low quality or `.ts` files, so need to add them at LQ quality
<!-- Please provide a detailed description of why you created this pull request. -->

## Approach
Just add them to anime LQ CF
<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
