### PR TITLE
fix(starr): SCENE custom formats matching most German language releases.

### DIFF
--- a/docs/json/radarr/cf/scene.json
+++ b/docs/json/radarr/cf/scene.json
@@ -25,6 +25,15 @@
       "fields": {
         "value": "\\b(INFLATE|DEFLATE)\\b"
       }
+    },
+    {
+      "name": "Not GERMAN",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": true,
+      "required": true,
+      "fields": {
+        "value": "\\b(GERMAN)\\b"
+      }
     }
   ]
 }

--- a/docs/json/sonarr/cf/scene.json
+++ b/docs/json/sonarr/cf/scene.json
@@ -25,6 +25,15 @@
       "fields": {
         "value": "\\b(INFLATE|DEFLATE[)\\]]?)$"
       }
+    },
+    {
+      "name": "Not GERMAN",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": true,
+      "required": true,
+      "fields": {
+        "value": "\\b(GERMAN)$"
+      }
     }
   ]
 }


### PR DESCRIPTION
# Pull Request

## Purpose

To amend the Scene custom formats so they do not match the majority of German language releases
Fix #2289 

## Approach

Add `Not GERMAN` conditions to the Radarr and Sonarr Scene custom formats.

## Open Questions and Pre-Merge TODOs

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
