### PR TITLE
feat(radarr): Update Radarr Tiers

### DIFF
--- a/docs/json/radarr/cf/hd-bluray-tier-03.json
+++ b/docs/json/radarr/cf/hd-bluray-tier-03.json
@@ -38,6 +38,15 @@
       }
     },
     {
+      "name": "ATELiER",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(ATELiER)$"
+      }
+    },
+    {
       "name": "BHDStudio",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,
@@ -53,6 +62,15 @@
       "required": false,
       "fields": {
         "value": "^(hallowed)$"
+      }
+    },
+    {
+      "name": "HiFi",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(HiFi)$"
       }
     },
     {

--- a/docs/json/radarr/cf/remux-tier-03.json
+++ b/docs/json/radarr/cf/remux-tier-03.json
@@ -18,6 +18,15 @@
       }
     },
     {
+      "name": "ATELiER",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(ATELiER)$"
+      }
+    },
+    {
       "name": "decibeL",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,

--- a/docs/json/radarr/cf/web-tier-03.json
+++ b/docs/json/radarr/cf/web-tier-03.json
@@ -54,6 +54,15 @@
       }
     },
     {
+      "name": "NPMS",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(NPMS)$"
+      }
+    },
+    {
       "name": "ROCCaT",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,


### PR DESCRIPTION
# Pull Request

## Purpose

Update the Radarr tiers with new 'known-good' groups

## Approach

- [x] Add `ATELiER` to Remux and HD Bluray Tiers 03 (Radarr)
- [x] Add `NPMS` to Web Tier 03 (Radarr)
- [x] Add `HiFi` to HD Bluray Tier 03 (Radarr)

## Open Questions and Pre-Merge TODOs

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
