### PR TITLE
fix(sonarr): update sonarr web tier 02 anime-sonarr score to 250

### DIFF
--- a/docs/json/sonarr/cf/web-tier-02.json
+++ b/docs/json/sonarr/cf/web-tier-02.json
@@ -2,7 +2,7 @@
   "trash_id": "58790d4e2fdcd9733aa7ae68ba2bb503",
   "trash_scores": {
     "default": 1650,
-    "anime-sonarr": 150,
+    "anime-sonarr": 250,
     "french-multi-vf": 0
   },
   "name": "WEB Tier 02",


### PR DESCRIPTION
# Pull Request

## Purpose

Fix an incorrect score in the Sonarr web tier 02 for anime-sonarr
Fix #2163 

## Approach

- [x] Update the sonarr web tier 02 anime-sonarr score to 250

## Open Questions and Pre-Merge TODOs

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
