### PR TITLE
fix(guides): update zfs/truenas blurbs for smb and fallocate

### DIFF
--- a/docs/Downloaders/Deluge/Basic-Setup.md
+++ b/docs/Downloaders/Deluge/Basic-Setup.md
@@ -40,10 +40,6 @@ Pre-allocate disk space for the added torrents. This limits fragmentation and al
 
     **Suggested: `Enabled`**
 
-!!! warning
-
-    Do not set Pre-allocated disk space if you are using ZFS as your filesystem as ZFS [does not support fallocate](https://github.com/openzfs/zfs/issues/326){:target="\_blank" rel="noopener noreferrer"}
-
 {! include-markdown "../../../includes/downloaders/warning-path-location.md" !}
 
 ---

--- a/docs/Downloaders/qBittorrent/Basic-Setup.md
+++ b/docs/Downloaders/qBittorrent/Basic-Setup.md
@@ -36,10 +36,6 @@
 
         **Suggested: `Enabled`**
 
-    !!! warning
-
-        Do not set Pre-allocated disk space if you are using ZFS as your filesystem as ZFS [does not support fallocate](https://github.com/openzfs/zfs/issues/326){:target="_blank" rel="noopener noreferrer"}
-
 ### Saving Management
 
 ![Saving Management](images/qb-options-downloads-saving-management.png)

--- a/docs/File-and-Folder-Structure/How-to-set-up/TrueNAS-Core.md
+++ b/docs/File-and-Folder-Structure/How-to-set-up/TrueNAS-Core.md
@@ -8,7 +8,7 @@
 
     TrueNAS Core defaults to `lz4` encryption as the compression level when creating a pool. This is fine for most workloads, and can be safely inherited down to other datasets under the top-level dataset. `ztsd` is currently the default in FreeBSD, however, TrueNAS Core still defaults to `lz4`. Given that media files are not very compressible by nature, the only benefit that compression provides, in this case, is to supplementary files such as `.srt`, `.nfo`, etc.
 
-    Additionally, since SMB does not support hardlinks we will only be covering the creation and use of NFS shares.
+    While SMB shares do support hardlinks when Unix extensions are enabled we will only be covering the creation and use of NFS shares.
 
 ---
 


### PR DESCRIPTION
# Pull Request

## Purpose

Fixes #2158 and #2150

## Approach

- [x] Update TrueNAS Core documentation to note that SMB supports hardlinks with Unix extensions enabled
- [x] Remove warnings about using fallocate with ZFS as https://github.com/openzfs/zfs/issues/326 has since been resolved (fixed in https://github.com/openzfs/zfs/pull/10408)

## Open Questions and Pre-Merge TODOs

<!-- - [x] Use GitHub checklists. When solved, check the box and explain the answer. -->

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
