### PR TITLE
feat(starr): Improve streaming services recognition after renaming.

### DIFF
--- a/docs/json/radarr/cf/crav.json
+++ b/docs/json/radarr/cf/crav.json
@@ -14,6 +14,15 @@
       }
     },
     {
+      "name": "Crave Rename",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[(Crave)\\b|\\b(Crave)\\]"
+      }
+    },
+    {
       "name": "WEBDL",
       "implementation": "SourceSpecification",
       "negate": false,

--- a/docs/json/radarr/cf/crav.json
+++ b/docs/json/radarr/cf/crav.json
@@ -19,7 +19,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "\\[(Crave)\\b|\\b(Crave)\\]"
+        "value": "\\[(CRAV)\\b|\\b(CRAV)\\]"
       }
     },
     {

--- a/docs/json/radarr/cf/crav.json
+++ b/docs/json/radarr/cf/crav.json
@@ -8,7 +8,7 @@
       "name": "Crave",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,
-      "required": true,
+      "required": false,
       "fields": {
         "value": "\\b(crav(e)?)\\b[ ._-]web[ ._-]?(dl|rip)?\\b"
       }

--- a/docs/json/radarr/cf/hbo.json
+++ b/docs/json/radarr/cf/hbo.json
@@ -13,6 +13,15 @@
       }
     },
     {
+      "name": "HBO Rename",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[(HBO)\\b|\\b(HBO)\\]"
+      }
+    },
+    {
       "name": "WEBDL",
       "implementation": "SourceSpecification",
       "negate": false,

--- a/docs/json/radarr/cf/hbo.json
+++ b/docs/json/radarr/cf/hbo.json
@@ -7,7 +7,7 @@
       "name": "HBO",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,
-      "required": true,
+      "required": false,
       "fields": {
         "value": "\\b(hbo)(?![ ._-]max)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)"
       }

--- a/docs/json/radarr/cf/hmax.json
+++ b/docs/json/radarr/cf/hmax.json
@@ -13,6 +13,15 @@
       }
     },
     {
+      "name": "HMAX Rename",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[(HMAX)\\b|\\b(HMAX)\\]"
+      }
+    },
+    {
       "name": "WEBDL",
       "implementation": "SourceSpecification",
       "negate": false,

--- a/docs/json/radarr/cf/hmax.json
+++ b/docs/json/radarr/cf/hmax.json
@@ -7,7 +7,7 @@
       "name": "HBO Max",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,
-      "required": true,
+      "required": false,
       "fields": {
         "value": "\\b(hmax|hbom|hbo[ ._-]?max)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)"
       }

--- a/docs/json/radarr/cf/it.json
+++ b/docs/json/radarr/cf/it.json
@@ -7,7 +7,7 @@
       "name": "iTunes",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,
-      "required": true,
+      "required": false,
       "fields": {
         "value": "\\b(it|itunes)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)"
       }

--- a/docs/json/radarr/cf/it.json
+++ b/docs/json/radarr/cf/it.json
@@ -13,6 +13,15 @@
       }
     },
     {
+      "name": "iT Rename",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[(iT)\\b|\\b(iT)\\]"
+      }
+    },
+    {
       "name": "WEBDL",
       "implementation": "SourceSpecification",
       "negate": false,

--- a/docs/json/radarr/cf/itvx.json
+++ b/docs/json/radarr/cf/itvx.json
@@ -14,6 +14,15 @@
       }
     },
     {
+      "name": "ITVX Rename",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[(ITVX)\\b|\\b(ITVX)\\]"
+      }
+    },
+    {
       "name": "WEBDL",
       "implementation": "SourceSpecification",
       "negate": false,

--- a/docs/json/radarr/cf/itvx.json
+++ b/docs/json/radarr/cf/itvx.json
@@ -8,7 +8,7 @@
       "name": "ITVX",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,
-      "required": true,
+      "required": false,
       "fields": {
         "value": "\\bITV(X)?\\b[ ._-]web[ ._-]?(dl|rip)?\\b"
       }

--- a/docs/json/radarr/cf/itvx.json
+++ b/docs/json/radarr/cf/itvx.json
@@ -10,7 +10,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "\\bITV(X)?\\b[ ._-]web[ ._-]?(dl|rip)?\\b"
+        "value": "\\b(ITVX?)\\b[ ._-]web[ ._-]?(dl|rip)?\\b"
       }
     },
     {

--- a/docs/json/radarr/cf/max.json
+++ b/docs/json/radarr/cf/max.json
@@ -14,6 +14,15 @@
       }
     },
     {
+      "name": "MAX Rename",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[(MAX)\\b|\\b(MAX)\\]"
+      }
+    },
+    {
       "name": "WEBDL",
       "implementation": "SourceSpecification",
       "negate": false,

--- a/docs/json/radarr/cf/max.json
+++ b/docs/json/radarr/cf/max.json
@@ -8,7 +8,7 @@
       "name": "Max",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,
-      "required": true,
+      "required": false,
       "fields": {
         "value": "\\b((?<!hbo[ ._-])max)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)"
       }

--- a/docs/json/radarr/cf/now.json
+++ b/docs/json/radarr/cf/now.json
@@ -7,7 +7,7 @@
       "name": "NOW",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,
-      "required": true,
+      "required": false,
       "fields": {
         "value": "\\b(now)\\b[ ._-]web[ ._-]?(dl|rip)?\\b"
       }

--- a/docs/json/radarr/cf/now.json
+++ b/docs/json/radarr/cf/now.json
@@ -13,6 +13,15 @@
       }
     },
     {
+      "name": "NOW Rename",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[(NOW)\\b|\\b(NOW)\\]"
+      }
+    },
+    {
       "name": "WEBDL",
       "implementation": "SourceSpecification",
       "negate": false,

--- a/docs/json/radarr/cf/stan.json
+++ b/docs/json/radarr/cf/stan.json
@@ -19,7 +19,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "\\[(Stan)\\b|\\b(Stan)\\]"
+        "value": "\\[(STAN)\\b|\\b(STAN)\\]"
       }
     },
     {

--- a/docs/json/radarr/cf/stan.json
+++ b/docs/json/radarr/cf/stan.json
@@ -14,6 +14,15 @@
       }
     },
     {
+      "name": "Stan Rename",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[(Stan)\\b|\\b(Stan)\\]"
+      }
+    },
+    {
       "name": "WEBDL",
       "implementation": "SourceSpecification",
       "negate": false,

--- a/docs/json/radarr/cf/stan.json
+++ b/docs/json/radarr/cf/stan.json
@@ -8,7 +8,7 @@
       "name": "Stan",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,
-      "required": true,
+      "required": false,
       "fields": {
         "value": "\\b(stan)\\b[ ._-]web[ ._-]?(dl|rip)?\\b"
       }

--- a/docs/json/radarr/cf/tving.json
+++ b/docs/json/radarr/cf/tving.json
@@ -13,6 +13,15 @@
       }
     },
     {
+      "name": "TVING Rename",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[(TVING)\\b|\\b(TVING)\\]"
+      }
+    },
+    {
       "name": "WEBDL",
       "implementation": "SourceSpecification",
       "negate": false,

--- a/docs/json/radarr/cf/tving.json
+++ b/docs/json/radarr/cf/tving.json
@@ -7,7 +7,7 @@
       "name": "TVING",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,
-      "required": true,
+      "required": false,
       "fields": {
         "value": "\\b(tving)\\b[ ._-]web[ ._-]?(dl|rip)?\\b"
       }

--- a/docs/json/radarr/cf/viu.json
+++ b/docs/json/radarr/cf/viu.json
@@ -13,6 +13,15 @@
       }
     },
     {
+      "name": "VIU Rename",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[(VIU)\\b|\\b(VIU)\\]"
+      }
+    },
+    {
       "name": "WEBDL",
       "implementation": "SourceSpecification",
       "negate": false,

--- a/docs/json/radarr/cf/viu.json
+++ b/docs/json/radarr/cf/viu.json
@@ -7,7 +7,7 @@
       "name": "VIU",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,
-      "required": true,
+      "required": false,
       "fields": {
         "value": "\\b(viu)\\b[ ._-]web[ ._-]?(dl|rip)?\\b"
       }

--- a/docs/json/sonarr/cf/cc.json
+++ b/docs/json/sonarr/cf/cc.json
@@ -17,6 +17,15 @@
       }
     },
     {
+      "name": "CC Rename",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[(CC)\\b|\\b(CC)\\]"
+      }
+    },
+    {
       "name": "WEBDL",
       "implementation": "SourceSpecification",
       "negate": false,

--- a/docs/json/sonarr/cf/cc.json
+++ b/docs/json/sonarr/cf/cc.json
@@ -11,7 +11,7 @@
       "name": "Comedy Central",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,
-      "required": true,
+      "required": false,
       "fields": {
         "value": "\\b(CC)\\b[ ._-]web[ ._-]?(dl|rip)?\\b"
       }

--- a/docs/json/sonarr/cf/crav.json
+++ b/docs/json/sonarr/cf/crav.json
@@ -11,7 +11,7 @@
       "name": "Crave",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,
-      "required": true,
+      "required": false,
       "fields": {
         "value": "\\b(crav(e)?)\\b[ ._-]web[ ._-]?(dl|rip)?\\b"
       }

--- a/docs/json/sonarr/cf/crav.json
+++ b/docs/json/sonarr/cf/crav.json
@@ -22,7 +22,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "\\[(Crave)\\b|\\b(Crave)\\]"
+        "value": "\\[(CRAV)\\b|\\b(CRAV)\\]"
       }
     },
     {

--- a/docs/json/sonarr/cf/crav.json
+++ b/docs/json/sonarr/cf/crav.json
@@ -17,6 +17,15 @@
       }
     },
     {
+      "name": "Crave Rename",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[(Crave)\\b|\\b(Crave)\\]"
+      }
+    },
+    {
       "name": "WEBDL",
       "implementation": "SourceSpecification",
       "negate": false,

--- a/docs/json/sonarr/cf/dscp.json
+++ b/docs/json/sonarr/cf/dscp.json
@@ -11,9 +11,18 @@
       "name": "Discovery+",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,
-      "required": true,
+      "required": false,
       "fields": {
         "value": "\\b((dscp|dcp|disc)\\b|dscv\\+?)[ ._-]web[ ._-]?(dl|rip)?\\b"
+      }
+    },
+    {
+      "name": "DSCP Rename",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[(DSCP)\\b|\\b(DSCP)\\]"
       }
     },
     {

--- a/docs/json/sonarr/cf/hbo.json
+++ b/docs/json/sonarr/cf/hbo.json
@@ -10,7 +10,7 @@
       "name": "HBO",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,
-      "required": true,
+      "required": false,
       "fields": {
         "value": "\\b(hbo)(?![ ._-]max)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)"
       }

--- a/docs/json/sonarr/cf/hbo.json
+++ b/docs/json/sonarr/cf/hbo.json
@@ -16,6 +16,15 @@
       }
     },
     {
+      "name": "HBO Rename",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[(HBO)\\b|\\b(HBO)\\]"
+      }
+    },
+    {
       "name": "WEBDL",
       "implementation": "SourceSpecification",
       "negate": false,

--- a/docs/json/sonarr/cf/hmax.json
+++ b/docs/json/sonarr/cf/hmax.json
@@ -10,7 +10,7 @@
       "name": "HBO Max",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,
-      "required": true,
+      "required": false,
       "fields": {
         "value": "\\b(hmax|hbom|hbo[ ._-]?max)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)"
       }

--- a/docs/json/sonarr/cf/hmax.json
+++ b/docs/json/sonarr/cf/hmax.json
@@ -16,6 +16,15 @@
       }
     },
     {
+      "name": "HMAX Rename",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[(HMAX)\\b|\\b(HMAX)\\]"
+      }
+    },
+    {
       "name": "WEBDL",
       "implementation": "SourceSpecification",
       "negate": false,

--- a/docs/json/sonarr/cf/it.json
+++ b/docs/json/sonarr/cf/it.json
@@ -14,6 +14,33 @@
       "fields": {
         "value": "\\b(it|itunes)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)"
       }
+    },
+    {
+      "name": "iT Rename",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[(iT)\\b|\\b(iT)\\]"
+      }
+    },
+    {
+      "name": "WEBDL",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 3
+      }
+    },
+    {
+      "name": "WEBRIP",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 4
+      }
     }
   ]
 }

--- a/docs/json/sonarr/cf/it.json
+++ b/docs/json/sonarr/cf/it.json
@@ -10,7 +10,7 @@
       "name": "iTunes",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,
-      "required": true,
+      "required": false,
       "fields": {
         "value": "\\b(it|itunes)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)"
       }

--- a/docs/json/sonarr/cf/itvx.json
+++ b/docs/json/sonarr/cf/itvx.json
@@ -17,6 +17,15 @@
       }
     },
     {
+      "name": "ITVX Rename",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[(ITVX)\\b|\\b(ITVX)\\]"
+      }
+    },
+    {
       "name": "WEBDL",
       "implementation": "SourceSpecification",
       "negate": false,

--- a/docs/json/sonarr/cf/itvx.json
+++ b/docs/json/sonarr/cf/itvx.json
@@ -13,7 +13,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "\\bITV(X)?\\b[ ._-]web[ ._-]?(dl|rip)?\\b"
+        "value": "\\b(ITVX?)\\b[ ._-]web[ ._-]?(dl|rip)?\\b"
       }
     },
     {

--- a/docs/json/sonarr/cf/itvx.json
+++ b/docs/json/sonarr/cf/itvx.json
@@ -11,7 +11,7 @@
       "name": "ITVX",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,
-      "required": true,
+      "required": false,
       "fields": {
         "value": "\\bITV(X)?\\b[ ._-]web[ ._-]?(dl|rip)?\\b"
       }

--- a/docs/json/sonarr/cf/max.json
+++ b/docs/json/sonarr/cf/max.json
@@ -17,6 +17,15 @@
       }
     },
     {
+      "name": "MAX Rename",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[(MAX)\\b|\\b(MAX)\\]"
+      }
+    },
+    {
       "name": "WEBDL",
       "implementation": "SourceSpecification",
       "negate": false,

--- a/docs/json/sonarr/cf/max.json
+++ b/docs/json/sonarr/cf/max.json
@@ -11,7 +11,7 @@
       "name": "Max",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,
-      "required": true,
+      "required": false,
       "fields": {
         "value": "\\b((?<!hbo[ ._-])max)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)"
       }

--- a/docs/json/sonarr/cf/now.json
+++ b/docs/json/sonarr/cf/now.json
@@ -10,7 +10,7 @@
       "name": "NOW",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,
-      "required": true,
+      "required": false,
       "fields": {
         "value": "\\b(now)\\b[ ._-]web[ ._-]?(dl|rip)?\\b"
       }

--- a/docs/json/sonarr/cf/now.json
+++ b/docs/json/sonarr/cf/now.json
@@ -16,6 +16,15 @@
       }
     },
     {
+      "name": "NOW Rename",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[(NOW)\\b|\\b(NOW)\\]"
+      }
+    },
+    {
       "name": "WEBDL",
       "implementation": "SourceSpecification",
       "negate": false,

--- a/docs/json/sonarr/cf/red.json
+++ b/docs/json/sonarr/cf/red.json
@@ -17,6 +17,15 @@
       }
     },
     {
+      "name": "RED Rename",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[(RED)\\b|\\b(RED)\\]"
+      }
+    },
+    {
       "name": "WEBDL",
       "implementation": "SourceSpecification",
       "negate": false,

--- a/docs/json/sonarr/cf/red.json
+++ b/docs/json/sonarr/cf/red.json
@@ -11,7 +11,7 @@
       "name": "YouTube Red",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,
-      "required": true,
+      "required": false,
       "fields": {
         "value": "\\b(red|youtube red)\\b[ ._-]web[ ._-]?(dl|rip)?\\b"
       }

--- a/docs/json/sonarr/cf/sho.json
+++ b/docs/json/sonarr/cf/sho.json
@@ -11,7 +11,7 @@
       "name": "SHOWTIME",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,
-      "required": true,
+      "required": false,
       "fields": {
         "value": "\\b(sho|showtime)\\b[ ._-]web[ ._-]?(dl|rip)?\\b"
       }

--- a/docs/json/sonarr/cf/sho.json
+++ b/docs/json/sonarr/cf/sho.json
@@ -17,6 +17,15 @@
       }
     },
     {
+      "name": "SHO Rename",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[(SHO)\\b|\\b(SHO)\\]"
+      }
+    },
+    {
       "name": "WEBDL",
       "implementation": "SourceSpecification",
       "negate": false,

--- a/docs/json/sonarr/cf/stan.json
+++ b/docs/json/sonarr/cf/stan.json
@@ -17,6 +17,15 @@
       }
     },
     {
+      "name": "Stan Rename",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[(Stan)\\b|\\b(Stan)\\]"
+      }
+    },
+    {
       "name": "WEBDL",
       "implementation": "SourceSpecification",
       "negate": false,

--- a/docs/json/sonarr/cf/stan.json
+++ b/docs/json/sonarr/cf/stan.json
@@ -22,7 +22,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "\\[(Stan)\\b|\\b(Stan)\\]"
+        "value": "\\[(STAN)\\b|\\b(STAN)\\]"
       }
     },
     {

--- a/docs/json/sonarr/cf/stan.json
+++ b/docs/json/sonarr/cf/stan.json
@@ -11,7 +11,7 @@
       "name": "Stan",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,
-      "required": true,
+      "required": false,
       "fields": {
         "value": "\\b(stan)\\b[ ._-]web[ ._-]?(dl|rip)?\\b"
       }

--- a/docs/json/sonarr/cf/tving.json
+++ b/docs/json/sonarr/cf/tving.json
@@ -16,6 +16,15 @@
       }
     },
     {
+      "name": "TVING Rename",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[(TVING)\\b|\\b(TVING)\\]"
+      }
+    },
+    {
       "name": "WEBDL",
       "implementation": "SourceSpecification",
       "negate": false,

--- a/docs/json/sonarr/cf/tving.json
+++ b/docs/json/sonarr/cf/tving.json
@@ -10,7 +10,7 @@
       "name": "TVING",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,
-      "required": true,
+      "required": false,
       "fields": {
         "value": "\\b(tving)\\b[ ._-]web[ ._-]?(dl|rip)?\\b"
       }

--- a/docs/json/sonarr/cf/viu.json
+++ b/docs/json/sonarr/cf/viu.json
@@ -10,7 +10,7 @@
       "name": "VIU",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,
-      "required": true,
+      "required": false,
       "fields": {
         "value": "\\b(viu)\\b[ ._-]web[ ._-]?(dl|rip)?\\b"
       }

--- a/docs/json/sonarr/cf/viu.json
+++ b/docs/json/sonarr/cf/viu.json
@@ -16,6 +16,15 @@
       }
     },
     {
+      "name": "VIU Rename",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[(VIU)\\b|\\b(VIU)\\]"
+      }
+    },
+    {
       "name": "WEBDL",
       "implementation": "SourceSpecification",
       "negate": false,


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->

It seems that some streaming services' custom formats no longer matched after the rename, and when renamed a second time, they lost the streaming services completely.

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

Improve streaming services recognition after renaming.

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
