### PR TITLE
fix(guide-sync): Custom Format "10bit" regex to recognize capital "B" (10Bit / 10-Bit / 10.Bit)

### DIFF
--- a/docs/json/radarr/cf/10bit.json
+++ b/docs/json/radarr/cf/10bit.json
@@ -15,7 +15,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "10[.-]?bit"
+        "value": "10[.-]?[Bb]it"
       }
     },
     {

--- a/docs/json/sonarr/cf/10bit.json
+++ b/docs/json/sonarr/cf/10bit.json
@@ -9,7 +9,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "10[.-]?bit"
+        "value": "10[.-]?[Bb]it"
       }
     },
     {


### PR DESCRIPTION
# Pull Request

## Purpose

The currently existing custom format "10bit" has a regex that doesn't include any releases marked with a captial "B" such as "10Bit" / "10-Bit" / "10.Bit".

## Approach

The regex has been adjusted to include the capital "B" within a character class.

From:
```regex
10[.-]?bit
```
To:
```regex
10[.-]?[Bb]it
```

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
