### PR TITLE
feat(guide-sync): Add Season Pack to Sonarr Profile Groups

### DIFF
--- a/docs/json/sonarr/cf-groups/season-packs.json
+++ b/docs/json/sonarr/cf-groups/season-packs.json
@@ -1,0 +1,12 @@
+{
+  "name": "[Optional] Season Packs",
+  "trash_id": "d920fd959d220306888f40b6f38e1578",
+  "trash_description": "Add this Custom Format if you prefer season packs, this will upgrade your already downloaded single episodes.",
+  "custom_formats": [
+    {
+      "name": "Season Pack",
+      "trash_id": "3bc5f395426614e155e585a2f056cdf1",
+      "required": true
+    }
+  ]
+}

--- a/docs/json/sonarr/cf/season-pack.json
+++ b/docs/json/sonarr/cf/season-pack.json
@@ -1,5 +1,8 @@
 {
   "trash_id": "3bc5f395426614e155e585a2f056cdf1",
+  "trash_scores": {
+    "default": 10
+  },
   "name": "Season Pack",
   "includeCustomFormatWhenRenaming": false,
   "specifications": [


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->

Add Season Pack to Sonarr Profile Groups

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

- [x] Added Season Pack to Sonarr Profile Groups
- [x] Added default score of `10` to the `Season Pack` Custom Format

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
