### PR TITLE
fix(radarr): Add missing SQP-1 (2160p) score for HD Bluray Tier 02

### DIFF
--- a/docs/json/radarr/cf/hd-bluray-tier-02.json
+++ b/docs/json/radarr/cf/hd-bluray-tier-02.json
@@ -4,6 +4,7 @@
     "default": 1750,
     "sqp-1-1080p": 1050,
     "sqp-1-web-1080p": 1050,
+    "sqp-1-2160p": 1050,
     "sqp-1-web-2160p": 1050,
     "french-multi-vf": 0
   },


### PR DESCRIPTION
# Pull Request

## Purpose

Resolve an issue where the sync tools would pull the wrong score for HD Bluray Tier 02

## Approach

Add missing SQP-1 (2160p) score for HD Bluray Tier 02

## Open Questions and Pre-Merge TODOs

None

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
