### PR TITLE
feat(starr): Add RlsGrp `tokar86a` to the `Bad Dual Groups` Custom Format

### DIFF
--- a/docs/json/radarr/cf/bad-dual-groups.json
+++ b/docs/json/radarr/cf/bad-dual-groups.json
@@ -190,6 +190,15 @@
       }
     },
     {
+      "name": "tokar86a",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(tokar86a)$"
+      }
+    },
+    {
       "name": "TvR",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,

--- a/docs/json/sonarr/cf/bad-dual-groups.json
+++ b/docs/json/sonarr/cf/bad-dual-groups.json
@@ -181,6 +181,15 @@
       }
     },
     {
+      "name": "tokar86a",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(tokar86a)$"
+      }
+    },
+    {
       "name": "vnlls",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,

--- a/includes/cf-descriptions/bad-dual-groups.md
+++ b/includes/cf-descriptions/bad-dual-groups.md
@@ -1,5 +1,5 @@
 <!-- markdownlint-disable MD041-->
-**Bad dual/Multi groups**<br>
+**Bad Dual/Multi groups**<br>
 
 These release groups do not use the original language of the media as the first audio track. Since ffprobe relies on the first audio track to determine the primary language of the release, incorrect ordering can lead to parsing issues. This may result in failed imports, misidentified files, or even download loops. To ensure proper handling, the original language should always be the first audio track in the release.
 <!-- markdownlint-enable MD041-->

--- a/includes/cf-descriptions/bad-dual-groups.md
+++ b/includes/cf-descriptions/bad-dual-groups.md
@@ -1,7 +1,7 @@
 <!-- markdownlint-disable MD041-->
 **Bad dual/Multi groups**<br>
 
-These release groups do not use the original language as the first audio track, the first audio language track is used to determine which language the original media file uses. Therefore, the first audio language track should always be the original language audio track, not a random one. If the first audio language track is not the original, they may fail to import the file, or it could result in download loops.
+These release groups do not use the original language of the media as the first audio track. Since ffprobe relies on the first audio track to determine the primary language of the release, incorrect ordering can lead to parsing issues. This may result in failed imports, misidentified files, or even download loops. To ensure proper handling, the original language should always be the first audio track in the release.
 
 Examples:
 

--- a/includes/cf-descriptions/bad-dual-groups.md
+++ b/includes/cf-descriptions/bad-dual-groups.md
@@ -1,5 +1,10 @@
 <!-- markdownlint-disable MD041-->
-**Bad dual groups**<br>
+**Bad dual/Multi groups**<br>
 
-These groups take the original release and add their language (e.g., Portuguese) as the main audio track (AAC 2.0). After renaming and FFprobe, the media file will be recognized as Portuguese AAC audio. Adding the best audio as the first track is a common rule. They also often translate or rename the release name to Portuguese.
+These release groups do not use the original language as the first audio track, the first audio language track is used to determine which language the original media file uses. Therefore, the first audio language track should always be the original language audio track, not a random one. If the first audio language track is not the original, they may fail to import the file, or it could result in download loops.
+
+Examples:
+
+- These groups take the original release and add their language (e.g., Portuguese) as the main audio track (AAC 2.0). After renaming and FFprobe, the media file will be recognized as Portuguese AAC audio. Adding the best audio as the first track is a common rule. They also often translate or rename the release name to Portuguese.
+- These groups do not use the original language as the first audio track.
 <!-- markdownlint-enable MD041-->

--- a/includes/cf-descriptions/bad-dual-groups.md
+++ b/includes/cf-descriptions/bad-dual-groups.md
@@ -2,9 +2,4 @@
 **Bad dual/Multi groups**<br>
 
 These release groups do not use the original language of the media as the first audio track. Since ffprobe relies on the first audio track to determine the primary language of the release, incorrect ordering can lead to parsing issues. This may result in failed imports, misidentified files, or even download loops. To ensure proper handling, the original language should always be the first audio track in the release.
-
-Examples:
-
-- These groups take the original release and add their language (e.g., Portuguese) as the main audio track (AAC 2.0). After renaming and FFprobe, the media file will be recognized as Portuguese AAC audio. Adding the best audio as the first track is a common rule. They also often translate or rename the release name to Portuguese.
-- These groups do not use the original language as the first audio track.
 <!-- markdownlint-enable MD041-->


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->

Inconsistent first audio track choice breaks automation tools such as Radarr and Sonarr.

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

Add RlsGrp `tokar86a` to the `Bad Dual Groups` Custom Format.

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
