### PR TITLE
fix(guide-sync): Add missing quality sources for the new  Anime profiles

### DIFF
--- a/docs/json/radarr/quality-profiles/anime-remux-1080p.json
+++ b/docs/json/radarr/quality-profiles/anime-remux-1080p.json
@@ -12,6 +12,13 @@
   "language": "Original",
   "items": [
     { "name": "Unknown", "allowed": false },
+    { "name": "WORKPRINT", "allowed": false },
+    { "name": "CAM", "allowed": false },
+    { "name": "TELESYNC", "allowed": false },
+    { "name": "TELECINE", "allowed": false },
+    { "name": "REGIONAL", "allowed": false },
+    { "name": "DVDSCR", "allowed": false },
+    { "name": "DVD-R", "allowed": false },
     { "name": "HDTV-2160p", "allowed": false },
     {
       "name": "WEB 2160p",
@@ -20,6 +27,7 @@
     },
     { "name": "Bluray-2160p", "allowed": false },
     { "name": "Remux-2160p", "allowed": false },
+    { "name": "BR-DISK", "allowed": false },
     { "name": "Raw-HD", "allowed": false },
     { "name": "SDTV", "allowed": true },
     { "name": "DVD", "allowed": true },

--- a/docs/json/sonarr/quality-profiles/anime-remux-1080p.json
+++ b/docs/json/sonarr/quality-profiles/anime-remux-1080p.json
@@ -10,6 +10,10 @@
   "cutoffFormatScore": 10000,
   "minUpgradeFormatScore": 1,
   "items": [
+    { "name": "Unknown", "allowed": false },
+    { "name": "Bluray-576p", "allowed": false },
+    { "name": "HDTV-720p", "allowed": false },
+    { "name": "Raw-HD", "allowed": false },
     { "name": "HDTV-2160p", "allowed": false },
     {
       "name": "WEB 2160p",
@@ -18,9 +22,6 @@
     },
     { "name": "Bluray-2160p", "allowed": false },
     { "name": "Bluray-2160p Remux", "allowed": false },
-    { "name": "Unknown", "allowed": false },
-    { "name": "Bluray-576p", "allowed": false },
-    { "name": "Raw-HD", "allowed": false },
     { "name": "SDTV", "allowed": true },
     { "name": "DVD", "allowed": true },
     {


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->

Add missing quality sources for the new  Anime profiles.

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

Add missing quality sources for the new  Anime profiles.

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [ ] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
