### PR TITLE
fix(guide-sync): Add group exclusion for the anime profiles

### DIFF
--- a/docs/json/radarr/cf-groups/optional-movie-versions.json
+++ b/docs/json/radarr/cf-groups/optional-movie-versions.json
@@ -43,5 +43,10 @@
       "trash_id": "9f6cbff8cfe4ebbc1bde14c7b7bec0de",
       "required": false
     }
-  ]
+  ],
+  "quality_profiles": {
+    "exclude": {
+      "[Anime] Remux-1080p": "722b624f9af1e492284c4bc842153a38"
+    }
+  }
 }

--- a/docs/json/radarr/quality-profiles/anime-remux-1080p.json
+++ b/docs/json/radarr/quality-profiles/anime-remux-1080p.json
@@ -50,7 +50,7 @@
       "items": ["WEBDL-1080p", "WEBRip-1080p", "HDTV-1080p"]
     },
     {
-      "name": "Remux-1080p",
+      "name": "Remux 1080p",
       "allowed": true,
       "items": ["Bluray-1080p", "Remux-1080p"]
     }

--- a/docs/json/sonarr/quality-profiles/anime-remux-1080p.json
+++ b/docs/json/sonarr/quality-profiles/anime-remux-1080p.json
@@ -41,7 +41,7 @@
       "items": ["WEBDL-1080p", "WEBRip-1080p", "HDTV-1080p"]
     },
     {
-      "name": "Bluray-1080p",
+      "name": "Bluray 1080p",
       "allowed": true,
       "items": ["Bluray-1080p", "Bluray-1080p Remux"]
     }


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->

Add group exclusion for the anime profiles.

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

Add group exclusion for the anime profiles.

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
