### PR TITLE
fix(guide-sync): cutoff name for the anime profiles

### DIFF
--- a/docs/json/radarr/quality-profiles/anime-remux-1080p.json
+++ b/docs/json/radarr/quality-profiles/anime-remux-1080p.json
@@ -5,7 +5,7 @@
   "group": 81,
   "trash_score_set": "anime-radarr",
   "upgradeAllowed": true,
-  "cutoff": "Remux-1080p",
+  "cutoff": "Remux 1080p",
   "minFormatScore": 100,
   "cutoffFormatScore": 10000,
   "minUpgradeFormatScore": 1,

--- a/docs/json/sonarr/quality-profiles/anime-remux-1080p.json
+++ b/docs/json/sonarr/quality-profiles/anime-remux-1080p.json
@@ -5,7 +5,7 @@
   "group": 81,
   "trash_score_set": "anime-sonarr",
   "upgradeAllowed": true,
-  "cutoff": "Bluray-1080p",
+  "cutoff": "Bluray 1080p",
   "minFormatScore": 100,
   "cutoffFormatScore": 10000,
   "minUpgradeFormatScore": 1,


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->

After fixing the source name, I forgot to edit the cutoff name for the anime profiles.

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

Fixed the cutoff name for the anime profiles.

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
