### PR TITLE
fix(guide-sync): corrected duplicate trash_id with two groups

### DIFF
--- a/docs/json/radarr/cf-groups/dv-hdr10-and-hdr10-boost.json
+++ b/docs/json/radarr/cf-groups/dv-hdr10-and-hdr10-boost.json
@@ -1,6 +1,6 @@
 {
   "name": "[HDR Formats] DV HDR10+ and HDR10+ Boost",
-  "trash_id": "d9acca37ab4ab8f6428b68125fc0cacb",
+  "trash_id": "d4cfd16fa73c59a980d36f42bb26d8a0",
   "trash_description": "You have a (Samsung) TV and Media Player Device that supports HDR10+",
   "custom_formats": [
     {


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->

It appeared that both [DV HDR10+ and HDR10+ Boost](https://github.com/TRaSH-Guides/Guides/blob/master/docs/json/radarr/cf-groups/dv-hdr10-and-hdr10-boost.json) and [HDR Formats](https://github.com/TRaSH-Guides/Guides/blob/master/docs/json/radarr/cf-groups/hdr-formats.json) had the same trash_id

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

Created a new unique trash_id for the `DV HDR10+ and HDR10+ Boost` group

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
