### PR TITLE
feat(starr): Add RlsGrp `FMD` to `LQ`

### DIFF
--- a/docs/json/radarr/cf/lq.json
+++ b/docs/json/radarr/cf/lq.json
@@ -242,6 +242,15 @@
       }
     },
     {
+      "name": "Feranki1980",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(Feranki1980)$"
+      }
+    },
+    {
       "name": "FGT",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,
@@ -251,12 +260,12 @@
       }
     },
     {
-      "name": "Feranki1980",
+      "name": "FMD",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,
       "required": false,
       "fields": {
-        "value": "^(Feranki1980)$"
+        "value": "\\b(FMD)\\b"
       }
     },
     {

--- a/docs/json/radarr/cf/lq.json
+++ b/docs/json/radarr/cf/lq.json
@@ -265,7 +265,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "\\b(FMD)\\b"
+        "value": "^(FMD)$"
       }
     },
     {

--- a/docs/json/sonarr/cf/lq.json
+++ b/docs/json/sonarr/cf/lq.json
@@ -80,6 +80,15 @@
       }
     },
     {
+      "name": "FMD",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(FMD)$"
+      }
+    },
+    {
       "name": "GHOSTS",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->

Add RlsGrp `FMD` to `LQ`

Does NF mobile 480p releases and mess it up with non-standard resolutions like 396p

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

Added RlsGrp `FMD` to `LQ` for Radarr and Sonarr

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
