### PR TITLE
feat(guide): Centralize the last descriptions on the Custom Format Collection page

### DIFF
--- a/docs/Radarr/Radarr-collection-of-custom-formats.md
+++ b/docs/Radarr/Radarr-collection-of-custom-formats.md
@@ -3102,9 +3102,7 @@ We've made 3 guides related to this.
 
 ??? question "FR Anime Tier 01 - [Click to show/hide]"
 
-    - WIP
-    - Groups that are known to be active and only doing Anime
-    - Groups whose releases are at least comparable to SeaDex recommended.
+    {! include-markdown "../../includes/cf-descriptions/french-anime-tier-01.md" !}
 
 ??? example "JSON - [Click to show/hide]"
 
@@ -3120,9 +3118,7 @@ We've made 3 guides related to this.
 
 ??? question "FR Anime Tier 02 - [Click to show/hide]"
 
-    - WIP
-    - Groups that are known to be active and only doing Anime, but with few releases per year.
-    - Groups that are known to be active and doing Anime AND other types of releases.
+    {! include-markdown "../../includes/cf-descriptions/french-anime-tier-02.md" !}
 
 ??? example "JSON - [Click to show/hide]"
 
@@ -3138,10 +3134,7 @@ We've made 3 guides related to this.
 
 ??? question "FR Anime Tier 03 - [Click to show/hide]"
 
-    - WIP
-    - Groups with no or little activity that have at some point made an interesting release which is either the only one available (in VOSTFR/MULTi) or still top of its category.
-    - Groups that haven't released much or are not well recognized. (yet)
-    - Groups doing only anime that have retired (or no longer exist) and may not have the best quality by today's standards.
+    {! include-markdown "../../includes/cf-descriptions/french-anime-tier-03.md" !}
 
 ??? example "JSON - [Click to show/hide]"
 
@@ -3157,7 +3150,7 @@ We've made 3 guides related to this.
 
 ??? question "FR Anime FanSub - [Click to show/hide]"
 
-    Known good groups that only do FanSub in good quality.
+    {! include-markdown "../../includes/cf-descriptions/french-anime-fansub.md" !}
 
 ??? example "JSON - [Click to show/hide]"
 
@@ -3487,7 +3480,7 @@ We've made 3 guides related to this.
 
 ??? question "Description - [Click to show/hide]"
 
-    Language Specification Original + French
+    {! include-markdown "../../includes/cf-descriptions/language-original-plus-french.md" !}
 
 ??? example "JSON - [Click to show/hide]"
 

--- a/docs/Sonarr/sonarr-collection-of-custom-formats.md
+++ b/docs/Sonarr/sonarr-collection-of-custom-formats.md
@@ -3489,7 +3489,7 @@ We've made 3 guides related to this.
 
 ??? question "Description - [Click to show/hide]"
 
-    Language Specification Original + French
+    {! include-markdown "../../includes/cf-descriptions/language-original-plus-french.md" !}
 
 ??? example "JSON - [Click to show/hide]"
 

--- a/includes/cf-descriptions/language-original-plus-french.md
+++ b/includes/cf-descriptions/language-original-plus-french.md
@@ -1,0 +1,5 @@
+<!-- markdownlint-disable MD041-->
+**Language: Original + French**<br>
+
+Language Specification Original + French
+<!-- markdownlint-enable MD041-->

--- a/includes/cf-descriptions/special-edition.md
+++ b/includes/cf-descriptions/special-edition.md
@@ -1,7 +1,7 @@
 <!-- markdownlint-disable MD041-->
 **Special Edition**<br>
 
-Custom format for several Special Editions
+Custom format that matches various special editions (non-theatrical edition)
 
 - The Director's Cut is the version edited by the Director, usually for additional home media releases.
 - An Extended Cut is usually any version of the film that is longer than the theatrical cut (though in very rare cases, its shorter).


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->

Centralize the last descriptions on the Custom Format Collection page

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

Centralize the last descriptions on the Custom Format Collection page

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
