### PR TITLE
chore(sonarr): Fix markdown includes not rendering correctly for some custom formats

### DIFF
--- a/docs/Sonarr/sonarr-collection-of-custom-formats.md
+++ b/docs/Sonarr/sonarr-collection-of-custom-formats.md
@@ -809,7 +809,7 @@ We've made 3 guides related to this.
 
 ??? question "LQ (Release Title)- [Click to show/hide]"
 
-    ! include-markdown "../../includes/cf-descriptions/lq-release-title
+    {! include-markdown "../../includes/cf-descriptions/lq-release-title !}
 
 ??? example "JSON - [Click to show/hide]"
 
@@ -2543,7 +2543,7 @@ We've made 3 guides related to this.
 
 ??? question "Description - [Click to show/hide]"
 
-    ! include-markdown "../../includes/cf-descriptions/anime-bd-tier-07-p2pscene
+    {! include-markdown "../../includes/cf-descriptions/anime-bd-tier-07-p2pscene !}
 
 ??? example "JSON - [Click to show/hide]"
 

--- a/docs/Sonarr/sonarr-collection-of-custom-formats.md
+++ b/docs/Sonarr/sonarr-collection-of-custom-formats.md
@@ -809,7 +809,7 @@ We've made 3 guides related to this.
 
 ??? question "LQ (Release Title)- [Click to show/hide]"
 
-    {! include-markdown "../../includes/cf-descriptions/lq-release-title !}
+    {! include-markdown "../../includes/cf-descriptions/lq-release-title.md" !}
 
 ??? example "JSON - [Click to show/hide]"
 
@@ -2543,7 +2543,7 @@ We've made 3 guides related to this.
 
 ??? question "Description - [Click to show/hide]"
 
-    {! include-markdown "../../includes/cf-descriptions/anime-bd-tier-07-p2pscene !}
+    {! include-markdown "../../includes/cf-descriptions/anime-bd-tier-07-p2pscene.md" !}
 
 ??? example "JSON - [Click to show/hide]"
 


### PR DESCRIPTION
# Pull Request

## Purpose

- Fixing markdown includes that are not rendering properly in the documentation.
- Ensuring that included content is embedded correctly rather than appearing as plain text.

## Approach

- Adjusted include paths to ensure they point to the correct files and are formatted correctly

## Open Questions and Pre-Merge TODOs

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
