### PR TITLE
feat(starr-anime): Add Flugel to Anime BD Tier 03

### DIFF
--- a/docs/json/radarr/cf/anime-bd-tier-03-seadex-muxers.json
+++ b/docs/json/radarr/cf/anime-bd-tier-03-seadex-muxers.json
@@ -115,6 +115,15 @@
       }
     },
     {
+      "name": "Flugel",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Flugel)\\b"
+      }
+    },
+    {
       "name": "Galator",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,

--- a/docs/json/sonarr/cf/anime-bd-tier-03-seadex-muxers.json
+++ b/docs/json/sonarr/cf/anime-bd-tier-03-seadex-muxers.json
@@ -124,6 +124,15 @@
       }
     },
     {
+      "name": "Flugel",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Flugel)\\b"
+      }
+    },
+    {
       "name": "Galator",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,


### PR DESCRIPTION
# Pull Request

## Purpose
Add Flugel to Anime BD Tier 03 due to having almost all of their releases listed on SeaDex
<!-- Please provide a detailed description of why you created this pull request. -->

## Approach
Just add alongside other top tier remux groups in tier 03
<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
