### PR TITLE
feat(starr-anime): Anime LQ Groups should only match HR as an anime group and correct Hitoku typo

### DIFF
--- a/docs/json/radarr/cf/anime-lq-groups.json
+++ b/docs/json/radarr/cf/anime-lq-groups.json
@@ -444,7 +444,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "\\[Hitoku\\]|-Hitoki\\b"
+        "value": "\\[Hitoku\\]|-Hitoku\\b"
       }
     },
     {

--- a/docs/json/radarr/cf/anime-lq-groups.json
+++ b/docs/json/radarr/cf/anime-lq-groups.json
@@ -462,7 +462,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "\\b(HR)\\b"
+        "value": "\\[HR\\]|-HR\\b"
       }
     },
     {

--- a/docs/json/sonarr/cf/anime-lq-groups.json
+++ b/docs/json/sonarr/cf/anime-lq-groups.json
@@ -444,7 +444,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "\\[Hitoku\\]|-Hitoki\\b"
+        "value": "\\[Hitoku\\]|-Hitoku\\b"
       }
     },
     {

--- a/docs/json/sonarr/cf/anime-lq-groups.json
+++ b/docs/json/sonarr/cf/anime-lq-groups.json
@@ -462,7 +462,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "\\b(HR)\\b"
+        "value": "\\[HR\\]|-HR\\b"
       }
     },
     {


### PR DESCRIPTION
# Pull Request

## Purpose
Currently, Anime LQ groups includes the term `HR` which can match a language code. I made it more precise. Also fixed a typo in the Hitoku regex that I noticed
<!-- Please provide a detailed description of why you created this pull request. -->

## Approach
Used the anime-specific group regex we use for more common words
<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->


## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
