### PR TITLE
fix(downloaders): run dos2unix before executing

### DIFF
--- a/docs/Downloaders/NZBGet/scripts/index.md
+++ b/docs/Downloaders/NZBGet/scripts/index.md
@@ -38,6 +38,7 @@ If you have a script you want to share, don't hesitate to create a [PR](https://
 
         1. Copy script to NZBGet's script folder
         1. Run: `sudo chmod +x replace_for.py`
+        1. Run: `dos2unix replace_for.py`
         1. In NZBGet go to `Settings` => `Extension Scripts`
         1. Enable `replace_for.py` in the `Extensions` setting.
 

--- a/docs/Downloaders/NZBGet/scripts/index.md
+++ b/docs/Downloaders/NZBGet/scripts/index.md
@@ -37,10 +37,10 @@ If you have a script you want to share, don't hesitate to create a [PR](https://
     Install Instructions:
 
         1. Copy script to NZBGet's script folder
-        1. Run: `sudo chmod +x replace_for.py`
-        1. Run: `dos2unix replace_for.py`
-        1. In NZBGet go to `Settings` => `Extension Scripts`
-        1. Enable `replace_for.py` in the `Extensions` setting.
+        2. Run: `sudo chmod +x replace_for.py`
+        3. Run: `dos2unix replace_for.py`
+        4. In NZBGet go to `Settings` => `Extension Scripts`
+        5. Enable `replace_for.py` in the `Extensions` setting.
 
 ??? example "Script"
 

--- a/docs/Downloaders/SABnzbd/scripts/index.md
+++ b/docs/Downloaders/SABnzbd/scripts/index.md
@@ -27,11 +27,11 @@ If you have a script you want to share, don't hesitate to create a [PR](https://
     Install Instructions:
 
         1. Copy script to SABnzbd's `scripts` folder
-        1. Use your prefered shell and navigate to the `scripts` folder with the command `cd` (example `cd /mnt/user/appdata/sabnzdb/scripts`).
-        1. Run: `sudo chmod +x Clean.py`
-        1. Run: `dos2unix Clean.py`
-        1. In SABnzbd go to `Settings` => `Switches`
-        1. Change Pre-queue user script and select: `Clean.py`
+        2. Use your prefered shell and navigate to the `scripts` folder with the command `cd` (example `cd /mnt/user/appdata/sabnzdb/scripts`).
+        3. Run: `sudo chmod +x Clean.py`
+        4. Run: `dos2unix Clean.py`
+        5. In SABnzbd go to `Settings` => `Switches`
+        6. Change Pre-queue user script and select: `Clean.py`
 
     ![!Enable Clean.py](/Downloaders/SABnzbd/images/sabnzbd-switches-queue-clean.png)
 
@@ -53,10 +53,10 @@ If you have a script you want to share, don't hesitate to create a [PR](https://
     Install Instructions:
 
         1. Copy script to SABnzbd's script folder
-        1. Run: `sudo chmod +x replace_for.py`
-        1. Run: `dos2unix replace_for.py`
-        1. In SABnzbd go to `Settings` => `Categories`
-        1. Change script for required categories and select: `replace_for.py`
+        2. Run: `sudo chmod +x replace_for.py`
+        3. Run: `dos2unix replace_for.py`
+        4. In SABnzbd go to `Settings` => `Categories`
+        5. Change script for required categories and select: `replace_for.py`
 
     ![!Enable replace_for.py](/Downloaders/SABnzbd/images/sabnzbd-categories-replace_for.png)
 

--- a/docs/Downloaders/SABnzbd/scripts/index.md
+++ b/docs/Downloaders/SABnzbd/scripts/index.md
@@ -10,7 +10,7 @@ If you have a script you want to share, don't hesitate to create a [PR](https://
 
 - You've created folder called `scripts` in the root directory of SABnzbd
 - You've set the `scripts` folder inside the SABnzbd settings under `Folder > User Folders > Scripts Folder`. ([More Infos](https://sabnzbd.org/wiki/configuration/4.3/folders))
-- Your script got sufficient rights to execute. ([More Infos](https://sabnzbd.org/wiki/configuration/4.3/scripts/post-processing-scripts))
+- Your script got sufficient rights to execute. ([More Infos](https://sabnzbd.org/wiki/configuration/4.5/scripts/post-processing-scripts))
 
 ## Clean
 
@@ -27,10 +27,11 @@ If you have a script you want to share, don't hesitate to create a [PR](https://
     Install Instructions:
 
         1. Copy script to SABnzbd's `scripts` folder
-        2. Use your prefered shell and navigate to the `scripts` folder with the command `cd` (example `cd /mnt/user/appdata/sabnzdb/scripts`).
-        3. run: `sudo chmod +x Clean.py`
-        4. in SABnzbd go to `Settings` => `Switches`
-        5. Change Pre-queue user script and select: `Clean.py`
+        1. Use your prefered shell and navigate to the `scripts` folder with the command `cd` (example `cd /mnt/user/appdata/sabnzdb/scripts`).
+        1. Run: `sudo chmod +x Clean.py`
+        1. Run: `dos2unix Clean.py`
+        1. In SABnzbd go to `Settings` => `Switches`
+        1. Change Pre-queue user script and select: `Clean.py`
 
     ![!Enable Clean.py](/Downloaders/SABnzbd/images/sabnzbd-switches-queue-clean.png)
 
@@ -52,8 +53,9 @@ If you have a script you want to share, don't hesitate to create a [PR](https://
     Install Instructions:
 
         1. Copy script to SABnzbd's script folder
-        1. run: `sudo chmod +x replace_for.py`
-        1. in SABnzbd go to `Settings` => `Categories`
+        1. Run: `sudo chmod +x replace_for.py`
+        1. Run: `dos2unix replace_for.py`
+        1. In SABnzbd go to `Settings` => `Categories`
         1. Change script for required categories and select: `replace_for.py`
 
     ![!Enable replace_for.py](/Downloaders/SABnzbd/images/sabnzbd-categories-replace_for.png)


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->
Fix #1976 

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->
Add instruction to run `dos2unix` before executing python scripts in SABnzbd or NZBGet.

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
