### PR TITLE
chore(guide-sync): Remove Recyclarr config templates

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -22,9 +22,6 @@
             "docs/json/radarr/naming/**",
             "docs/Radarr/**",
           ]
-"Area: Recyclarr":
-  - changed-files:
-      - any-glob-to-any-file: ["docs/recyclarr-configs/**"]
 "Area: Sonarr":
   - changed-files:
       - any-glob-to-any-file:
@@ -65,6 +62,5 @@
             "!docs/Plex/**",
             "!docs/Prowlarr/**",
             "!docs/Radarr/**",
-            "!docs/recyclarr-configs/**",
             "!docs/Sonarr/**",
           ]

--- a/docs/recyclarr-configs/README.md
+++ b/docs/recyclarr-configs/README.md
@@ -1,3 +1,0 @@
-# Relocated
-
-The pre-built Recyclarr config files have been relocated here: [Recyclarr config-templates GitHub Repository](https://github.com/recyclarr/config-templates)

--- a/metadata.json
+++ b/metadata.json
@@ -15,8 +15,5 @@
       "quality_profiles": ["docs/json/sonarr/quality-profiles"],
       "custom_format_groups": ["docs/json/sonarr/cf-groups"]
     }
-  },
-  "recyclarr": {
-    "templates": "docs/recyclarr-configs"
   }
 }

--- a/metadata.schema.json
+++ b/metadata.schema.json
@@ -12,8 +12,7 @@
         "radarr": { "$ref": "#/$defs/radarr" },
         "sonarr": { "$ref": "#/$defs/sonarr" }
       }
-    },
-    "recyclarr": { "$ref": "#/$defs/recyclarr" }
+    }
   },
   "$defs": {
     "paths_object": {
@@ -40,13 +39,6 @@
         "naming": { "$ref": "#/$defs/paths_object" },
         "quality_profiles": { "$ref": "#/$defs/paths_object" },
         "custom_format_groups": { "$ref": "#/$defs/paths_object" }
-      }
-    },
-    "recyclarr": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "templates": { "type": "string" }
       }
     }
   }


### PR DESCRIPTION
Enough time has passed that I think we don't need these anymore. 

- Remove the "Area: Recyclarr" label from labeler.yml
- Delete the docs/recyclarr-configs/README.md file
- Remove recyclarr-related properties from metadata.json and its schema
