### PR TITLE
fix(radarr): Add missing Custom Format `Repack3` to all applicable guide profiles

### DIFF
--- a/includes/sqp/1-4k-merge-qualities-sqp1.md
+++ b/includes/sqp/1-4k-merge-qualities-sqp1.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD041-->
 ##### Merge the following Qualities together
 
 - Bluray-1080p
@@ -18,3 +19,4 @@ and merge the following 2160p ones in a new group
 and name it: `WEB-2160p`
 
 ![!Merge the following Qualities together](/SQP/images/1-4k-merge-qualities-sqp1.png)
+<!-- markdownlint-enable MD041-->

--- a/includes/sqp/1-4k-newqp-sqp1.md
+++ b/includes/sqp/1-4k-newqp-sqp1.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD041-->
 ### SQP-1 (2160p)
 
 #### Create a new Quality Profile
@@ -7,3 +8,4 @@
 Create a new profile and name it what ever you want, we used: `SQP-1 (2160p)`
 
 ![!Create a new Quality Profile](/SQP/images/1-4k-newqp-sqp1.png)
+<!-- markdownlint-enable MD041-->

--- a/includes/sqp/1-4k-qp-settings-sqp1.md
+++ b/includes/sqp/1-4k-qp-settings-sqp1.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD041-->
 #### Quality Profile Settings
 
 - **Enable:** `Upgrades Allowed`
@@ -17,3 +18,4 @@
 
         - Always follow the data described in the guide.
         - If you got any questions or aren't sure just click the chat badge to join the Discord Channel where you can ask your questions directly.
+<!-- markdownlint-enable MD041-->

--- a/includes/sqp/1-4k-quality-size.md
+++ b/includes/sqp/1-4k-quality-size.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD041-->
 ### Quality Size
 
 `Settings` => `Quality`
@@ -19,3 +20,4 @@ The reason why you don't see the `Preferred` score in the table above is because
 The highest preferred quality you can manually enter is 1 less than the Maximum quality. If you use the slider, the preferred quality can be up to 5 lesser than the Maximum quality.
 
 Make sure you have enabled `Show Advanced` in Radarr, if you don't see a provision to enter the scores, under the Quality settings.
+<!-- markdownlint-enable MD041-->

--- a/includes/sqp/1-4k-select-qualities-sqp1.md
+++ b/includes/sqp/1-4k-select-qualities-sqp1.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD041-->
 ##### Select the following qualities
 
 - `Bluray-2160p`
@@ -20,3 +21,4 @@
 
     - `Bluray-2160p`
     - The merged quality group: `WEB-2160p`
+<!-- markdownlint-enable MD041-->

--- a/includes/sqp/1-4k-streaming-services.md
+++ b/includes/sqp/1-4k-streaming-services.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD041-->
 ??? abstract "Streaming Services - [Click to show/hide]"
 
     | Custom Format                                                                             |                                     Score                                      | Trash ID                                |
@@ -26,3 +27,4 @@
 
     - The reason why these Custom Formats have a score of `0` is because they are mainly used for the naming scheme and other variables should decide for movies if a certain release if preferred.
     - `CRiT` and `MA` are the only ones with a positive score because of their better source material, or higher bitrate and quality compared to other streaming services. `BCore` has a negative score as these releases have a very high bitrate so can cause transcoding.
+<!-- markdownlint-enable MD041-->

--- a/includes/sqp/1-cf-scoring.md
+++ b/includes/sqp/1-cf-scoring.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD041-->
 #### Custom Formats and scores
 
 **The following Custom Formats are required:**
@@ -69,3 +70,4 @@
         - The reason why we don't add [{{ radarr['cf']['imax']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#imax) is because BHDStudio didn't add IMAX to their filename before 2023-07-27.
 
         !!! danger "Adding `IMAX`/`IMAX Enhanced` will replace the BHDStudio release in most cases :warning:"
+<!-- markdownlint-enable MD041-->

--- a/includes/sqp/1-newqp.md
+++ b/includes/sqp/1-newqp.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD041-->
 ### Create a new Quality Profile
 
 `Settings` => `Profiles`
@@ -5,3 +6,4 @@
 Create a new profile and name it: `SQP-1 (1080p)`
 
 ![!Create a new Quality Profile](/SQP/images/1-newqp.png)
+<!-- markdownlint-enable MD041-->

--- a/includes/sqp/1-qp-settings.md
+++ b/includes/sqp/1-qp-settings.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD041-->
 #### Quality Profile Settings
 
 - **Enable:** `Upgrades Allowed`
@@ -17,3 +18,4 @@
 
         - Always follow the data described in the guide.
         - If you got any questions or aren't sure just click the chat badge to join the Discord Channel where you can ask your questions directly.
+<!-- markdownlint-enable MD041-->

--- a/includes/sqp/1-quality-size.md
+++ b/includes/sqp/1-quality-size.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD041-->
 ### Quality Size
 
 `Settings` => `Quality`
@@ -16,3 +17,4 @@ The reason why you don't see the `Preferred` score in the table above is because
 The highest preferred quality you can manually enter is 1 less than the Maximum quality. If you use the slider, the preferred quality can be up to 5 lesser than the Maximum quality.
 
 Make sure you have enabled `Show Advanced` in Radarr, if you don't see a provision to enter the scores, under the Quality settings.
+<!-- markdownlint-enable MD041-->

--- a/includes/sqp/1-select-qualities.md
+++ b/includes/sqp/1-select-qualities.md
@@ -1,6 +1,8 @@
+<!-- markdownlint-disable MD041-->
 ##### Select the following qualities
 
 - The merged quality profile: `Bluray|WEB-1080p`
 - Bluray-720p
 
 ![!Select the following qualities](/SQP/images/1-select-qualities.png)
+<!-- markdownlint-enable MD041-->

--- a/includes/sqp/1-streaming-services.md
+++ b/includes/sqp/1-streaming-services.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD041-->
 ??? abstract "Streaming Services - [Click to show/hide]"
 
     | Custom Format                                                                             |                                     Score                                      | Trash ID                                |
@@ -26,3 +27,4 @@
 
     - The reason why these Custom Formats have a score of `0` is because they are mainly used for the naming scheme and other variables should decide for movies if a certain release if preferred.
     - `CRiT` and `MA` are the only ones with a positive score because of their better source material, or higher bitrate and quality compared to other streaming services. `BCore` has a negative score as these releases have a very high bitrate so can cause transcoding.
+<!-- markdownlint-enable MD041-->

--- a/includes/sqp/2-cf-scoring.md
+++ b/includes/sqp/2-cf-scoring.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD041-->
 #### Custom Formats and scores
 
 **The following Custom Formats are required:**
@@ -37,3 +38,4 @@
 {! include-markdown "../../includes/cf/radarr-misc-uhd-optional.md" !}
 
 {! include-markdown "../../includes/cf/radarr-movie-versions-imaxe.md" !}
+<!-- markdownlint-enable MD041-->

--- a/includes/sqp/2-merge-qualities.md
+++ b/includes/sqp/2-merge-qualities.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD041-->
 ##### Merge the following Qualities together
 
 - WEBDL-2160p
@@ -12,3 +13,4 @@ and name it what ever you want, we used: `WEB|Remux|Bluray|2160p`
 !!! info "If you're only running 1 Radarr, You might want to merge the HD Qualities together (WEB+Remux) and <ins>NOT</ins> with the UHD ones so you will also get the HD release if there is no UHD release."
 
 ![!Merge the following Qualities together](/SQP/images/2-merge-qualities.png)
+<!-- markdownlint-enable MD041-->

--- a/includes/sqp/2-newqp.md
+++ b/includes/sqp/2-newqp.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD041-->
 ### Create a new Quality Profile
 
 `Settings` => `Profiles`
@@ -5,3 +6,4 @@
 Create a new profile and name it what ever you want, we used: `Remux|Bluray|IMAX-E|2160p`
 
 ![!Create a new Quality Profile](/SQP/images/2-newqp.png)
+<!-- markdownlint-enable MD041-->

--- a/includes/sqp/2-qp-settings.md
+++ b/includes/sqp/2-qp-settings.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD041-->
 #### Quality Profile Settings
 
 - **Enable:** `Upgrades Allowed`
@@ -15,3 +16,4 @@
 
         - Always follow the data described in the guide.
         - If you got any questions or aren't sure just click the chat badge to join the Discord Channel where you can ask your questions directly.
+<!-- markdownlint-enable MD041-->

--- a/includes/sqp/2-quality-size.md
+++ b/includes/sqp/2-quality-size.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD041-->
 ### Quality Size
 
 `Settings` => `Quality`
@@ -17,3 +18,4 @@ The reason why you don't see the `Preferred` score in the table above is because
 The highest preferred quality you can manually enter is 1 less than the Maximum quality. If you use the slider, the preferred quality can be up to 5 lesser than the Maximum quality.
 
 Make sure you have enabled `Show Advanced` in Radarr, if you don't see a provision to enter the scores, under the Quality settings.
+<!-- markdownlint-enable MD041-->

--- a/includes/sqp/2-select-qualities.md
+++ b/includes/sqp/2-select-qualities.md
@@ -1,6 +1,8 @@
+<!-- markdownlint-disable MD041-->
 #### Select the following qualities
 
 - The merged quality profile: `WEB|Remux|Bluray|2160p`
 - `Remux-1080p`
 
 ![!Select the following qualities](/SQP/images/2-select-qualities.png)
+<!-- markdownlint-enable MD041-->

--- a/includes/sqp/2-why.md
+++ b/includes/sqp/2-why.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD041-->
 ## Why choose this quality profile
 
 ??? question "Why choose this quality profile? - [Click to show/hide]"
@@ -6,3 +7,4 @@
     - You have a TV that supports enhanced HDR formats, (DV and/or HDR10+).
     - You want the highest possible quality to watch but want to also save space for archiving without giving up video and audio quality.
     - You don't want to wait longer for the HQ Encodes to be released.
+<!-- markdownlint-enable MD041-->

--- a/includes/sqp/2-workflow.md
+++ b/includes/sqp/2-workflow.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD041-->
 ## Workflow Logic
 
 ??? abstract "Workflow Logic - [Click to show/hide]"
@@ -19,3 +20,4 @@
     - 1080p Remux
 
     !!! info "[*Optional*] IMAX Enhanced (IMAX-E)<br>- When an IMAX Enhanced exists, it will upgrade/downgrade to IMAX Enhanced.<br>- IMAX Enhanced will **ONLY** be chosen if it has the same **AUDIO** and **HDR Metadata**<br>- It won't downgrade from a `TrueHD Atmos` to a `DD+ Atmos` or from a `DV` to an `HDR`."
+<!-- markdownlint-enable MD041-->

--- a/includes/sqp/3-cf-scoring.md
+++ b/includes/sqp/3-cf-scoring.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD041-->
 #### Custom Formats and scores
 
 **The following Custom Formats are required:**
@@ -23,3 +24,4 @@
 {! include-markdown "../../includes/cf/radarr-misc-uhd-optional.md" !}
 
 {! include-markdown "../../includes/cf/radarr-movie-versions-imaxe.md" !}
+<!-- markdownlint-enable MD041-->

--- a/includes/sqp/3-merge-qualities.md
+++ b/includes/sqp/3-merge-qualities.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD041-->
 ##### Merge the following Qualities together
 
 - WEBDL-2160p
@@ -11,3 +12,4 @@ and name it what ever you want I used: `WEB|Remux|2160p`
 !!! info "If you're only running 1 Radarr, You might want to merge the HD Qualities together (WEB+Remux) and <ins>NOT</ins> with the UHD ones so you will also get the HD release if there is no UHD release."
 
 ![!Merge the following Qualities together](/SQP/images/3-merge-qualities.png)
+<!-- markdownlint-enable MD041-->

--- a/includes/sqp/3-newqp.md
+++ b/includes/sqp/3-newqp.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD041-->
 ### Create a new Quality Profile
 
 `Settings` => `Profiles`
@@ -5,3 +6,4 @@
 Create a new profile and name it what ever you want, we used: `Remux|IMAX-E|2160p`
 
 ![!Create a new Quality Profile](/SQP/images/3-newqp.png)
+<!-- markdownlint-enable MD041-->

--- a/includes/sqp/3-qp-settings.md
+++ b/includes/sqp/3-qp-settings.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD041-->
 #### Quality Profile Settings
 
 - **Enable:** `Upgrades Allowed`
@@ -15,3 +16,4 @@
 
         - Always follow the data described in the guide.
         - If you got any questions or aren't sure just click the chat badge to join the Discord Channel where you can ask your questions directly.
+<!-- markdownlint-enable MD041-->

--- a/includes/sqp/3-quality-size.md
+++ b/includes/sqp/3-quality-size.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD041-->
 ### Quality Size
 
 `Settings` => `Quality`
@@ -16,3 +17,4 @@ The reason why you don't see the `Preferred` score in the table above is because
 The highest preferred quality you can manually enter is 1 less than the Maximum quality. If you use the slider, the preferred quality can be up to 5 lesser than the Maximum quality.
 
 Make sure you have enabled `Show Advanced` in Radarr, if you don't see a provision to enter the scores, under the Quality settings.
+<!-- markdownlint-enable MD041-->

--- a/includes/sqp/3-select-qualities.md
+++ b/includes/sqp/3-select-qualities.md
@@ -1,6 +1,8 @@
+<!-- markdownlint-disable MD041-->
 #### Select the following qualities
 
 - The merged quality profile: `WEB|Remux|2160p`
 - `Remux-1080p`
 
 ![!Select the following qualities](/SQP/images/3-select-qualities.png)
+<!-- markdownlint-enable MD041-->

--- a/includes/sqp/3-why.md
+++ b/includes/sqp/3-why.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD041-->
 ## Why choose this quality profile
 
 ??? question "Why choose this quality profile? - [Click to show/hide]"
@@ -7,3 +8,4 @@
     - HDR/DoVi (Depending what's offered and often both)
     - HD Audio (Atmos, TrueHD etc...)
     - You want the highest quality possible, with the option to upgrade to IMAX Enhanced.
+<!-- markdownlint-enable MD041-->

--- a/includes/sqp/3-workflow.md
+++ b/includes/sqp/3-workflow.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD041-->
 ## Workflow Logic
 
 ??? abstract "Workflow Logic - [Click to show/hide]"
@@ -18,3 +19,4 @@
     - 1080p Remux
 
     !!! info "[*Optional*] IMAX Enhanced (IMAX-E)<br>- When an IMAX Enhanced exists it will upgrade/downgrade to IMAX Enhanced.<br>- IMAX Enhanced will **ONLY** be chosen if it has the same **AUDIO** and **HDR Metadata**<br>- It won't downgrade from a `TrueHD Atmos` to a `DD+ Atmos` or from a `DV` to a `HDR`."
+<!-- markdownlint-enable MD041-->

--- a/includes/sqp/4-cf-scoring.md
+++ b/includes/sqp/4-cf-scoring.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD041-->
 #### Custom Formats and scores
 
 **The following Custom Formats are required:**
@@ -23,3 +24,4 @@
 {! include-markdown "../../includes/cf/radarr-misc-uhd-optional.md" !}
 
 {! include-markdown "../../includes/cf/radarr-movie-versions-imaxe.md" !}
+<!-- markdownlint-enable MD041-->

--- a/includes/sqp/4-merge-qualities.md
+++ b/includes/sqp/4-merge-qualities.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD041-->
 ##### Merge the following Qualities together
 
 - WEBDL-2160p
@@ -10,3 +11,4 @@ and name it what ever you want I used: `WEB|2160p`
 !!! info "If you're only running 1 Radarr, You might want to merge the HD Qualities together (WEB+Remux) and <ins>NOT</ins> with the UHD ones so you will also get the HD release if there is no UHD release."
 
 ![!Merge the following Qualities together](/SQP/images/4-merge-qualities.png)
+<!-- markdownlint-enable MD041-->

--- a/includes/sqp/4-newqp.md
+++ b/includes/sqp/4-newqp.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD041-->
 ### Create a new Quality Profile
 
 `Settings` => `Profiles`
@@ -5,3 +6,4 @@
 Create a new profile and name it what ever you want, we used: `WEBDL|IMAX-E|2160p`
 
 ![!Create a new Quality Profile](/SQP/images/4-newqp.png)
+<!-- markdownlint-enable MD041-->

--- a/includes/sqp/4-qp-settings.md
+++ b/includes/sqp/4-qp-settings.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD041-->
 #### Quality Profile Settings
 
 - **Enable:** `Upgrades Allowed`
@@ -15,3 +16,4 @@
 
         - Always follow the data described in the guide.
         - If you got any questions or aren't sure just click the chat badge to join the Discord Channel where you can ask your questions directly.
+<!-- markdownlint-enable MD041-->

--- a/includes/sqp/4-quality-size.md
+++ b/includes/sqp/4-quality-size.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD041-->
 ### Quality Size
 
 `Settings` => `Quality`
@@ -15,3 +16,4 @@ The reason why you don't see the `Preferred` score in the table above is because
 The highest preferred quality you can manually enter is 1 less than the Maximum quality. If you use the slider, the preferred quality can be up to 5 lesser than the Maximum quality.
 
 Make sure you have enabled `Show Advanced` in Radarr, if you don't see a provision to enter the scores, under the Quality settings.
+<!-- markdownlint-enable MD041-->

--- a/includes/sqp/4-select-qualities.md
+++ b/includes/sqp/4-select-qualities.md
@@ -1,6 +1,8 @@
+<!-- markdownlint-disable MD041-->
 #### Select the following qualities
 
 - The merged quality profile: `WEBDL|2160p`
 - `Remux-1080p`
 
 ![!Select the following qualities](/SQP/images/4-select-qualities.png)
+<!-- markdownlint-enable MD041-->

--- a/includes/sqp/4-why.md
+++ b/includes/sqp/4-why.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD041-->
 ## Why choose this quality profile
 
 ??? question "Why choose this quality profile? - [Click to show/hide]"
@@ -8,3 +9,4 @@
     - You're okay with WEB-DL, with the option to upgrade to IMAX Enhanced.
     - You don't need the huge Remuxes or UHD Bluray Encodes but still want HDR Formats.
     - You want smaller files for your kid's movies (Disney/Pixar etc)
+<!-- markdownlint-enable MD041-->

--- a/includes/sqp/4-workflow.md
+++ b/includes/sqp/4-workflow.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD041-->
 ## Workflow Logic
 
 ??? abstract "Workflow Logic - [Click to show/hide]"
@@ -17,3 +18,4 @@
     - 1080p Remux
 
     !!! info "[*Optional*] IMAX Enhanced (IMAX-E)<br>- When an IMAX Enhanced exists, it will upgrade/downgrade to IMAX Enhanced.<br>- IMAX Enhanced will **ONLY** be chosen if it has the same **AUDIO** and **HDR Metadata**<br>- It won't downgrade from a `TrueHD Atmos` to a `DD+ Atmos` or from a `DV` to an `HDR`."
+<!-- markdownlint-enable MD041-->

--- a/includes/sqp/5-cf-scoring.md
+++ b/includes/sqp/5-cf-scoring.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD041-->
 #### Custom Formats and scores
 
 **The following Custom Formats are required:**
@@ -37,3 +38,4 @@
 {! include-markdown "../../includes/cf/radarr-misc-uhd-optional.md" !}
 
 {! include-markdown "../../includes/cf/radarr-movie-versions-imaxe.md" !}
+<!-- markdownlint-enable MD041-->

--- a/includes/sqp/5-merge-qualities.md
+++ b/includes/sqp/5-merge-qualities.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD041-->
 ##### Merge the following Qualities together
 
 - WEBDL-2160p
@@ -11,3 +12,4 @@ and name it what ever you want I used: `WEB|Bluray|2160p`
 !!! info "If you're only running 1 Radarr, You might want to merge the HD Qualities together (WEB+Remux) and <ins>NOT</ins> with the UHD ones so you will also get the HD release if there is no UHD release."
 
 ![!Merge the following Qualities together](/SQP/images/5-merge-qualities.png)
+<!-- markdownlint-enable MD041-->

--- a/includes/sqp/5-newqp.md
+++ b/includes/sqp/5-newqp.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD041-->
 ### Create a new Quality Profile
 
 `Settings` => `Profiles`
@@ -5,3 +6,4 @@
 Create a new profile and name it what ever you want, we used: `Bluray|IMAX-E|2160p`
 
 ![!Create a new Quality Profile](/SQP/images/5-newqp.png)
+<!-- markdownlint-enable MD041-->

--- a/includes/sqp/5-qp-settings.md
+++ b/includes/sqp/5-qp-settings.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD041-->
 #### Quality Profile Settings
 
 - **Enable:** `Upgrades Allowed`
@@ -15,3 +16,4 @@
 
         - Always follow the data described in the guide.
         - If you got any questions or aren't sure just click the chat badge to join the Discord Channel where you can ask your questions directly.
+<!-- markdownlint-enable MD041-->

--- a/includes/sqp/5-quality-size.md
+++ b/includes/sqp/5-quality-size.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD041-->
 ### Quality Size
 
 `Settings` => `Quality`
@@ -16,3 +17,4 @@ The reason why you don't see the `Preferred` score in the table above is because
 The highest preferred quality you can manually enter is 1 less than the Maximum quality. If you use the slider, the preferred quality can be up to 5 lesser than the Maximum quality.
 
 Make sure you have enabled `Show Advanced` in Radarr, if you don't see a provision to enter the scores, under the Quality settings.
+<!-- markdownlint-enable MD041-->

--- a/includes/sqp/5-select-qualities.md
+++ b/includes/sqp/5-select-qualities.md
@@ -1,6 +1,8 @@
+<!-- markdownlint-disable MD041-->
 #### Select the following qualities
 
 - The merged quality profile: `WEB|Bluray|2160p`
 - `Remux-1080p`
 
 ![!Select the following qualities](/SQP/images/5-select-qualities.png)
+<!-- markdownlint-enable MD041-->

--- a/includes/sqp/5-why.md
+++ b/includes/sqp/5-why.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD041-->
 ## Why choose this quality profile
 
 ??? question "Why choose this quality profile? - [Click to show/hide]"
@@ -7,3 +8,4 @@
     - You do want the highest quality as possible to watch but want to save space for archiving without losing video and audio quality.
     - HDR/DoVi (Depending what's offered and often both)
     - HD Audio (Atmos, TrueHD etc...)
+<!-- markdownlint-enable MD041-->

--- a/includes/sqp/5-workflow.md
+++ b/includes/sqp/5-workflow.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD041-->
 ## Workflow Logic
 
 ??? abstract "Workflow Logic - [Click to show/hide]"
@@ -20,3 +21,4 @@
     - 1080p Remux
 
     !!! info "[*Optional*] IMAX Enhanced (IMAX-E)<br>- When an IMAX Enhanced exists, it will upgrade/downgrade to IMAX Enhanced.<br>- IMAX Enhanced will **ONLY** be chosen if it has the same **AUDIO** and **HDR Metadata**<br>- It won't downgrade from a `TrueHD Atmos` to a `DD+ Atmos` or from a `DV` to an `HDR`."
+<!-- markdownlint-enable MD041-->

--- a/includes/sqp/hd-radarr-misc-optional.md
+++ b/includes/sqp/hd-radarr-misc-optional.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD041-->
 ??? abstract "Miscellaneous (Optional) - [Click to show/hide]"
 
     | Custom Format                                                                                                                   |                                   Score                                   | Trash ID                                                   |
@@ -22,3 +23,4 @@
     - **{{ radarr['cf']['obfuscated']['name'] }}:** [*Optional*] (use these only if you dislike renamed releases)
     - **{{ radarr['cf']['retags']['name'] }}:** [*Optional*] (use these only if you dislike retagged releases)
     - **{{ radarr['cf']['scene']['name'] }}:** [*Optional*] (use these only if you dislike scene releases)
+<!-- markdownlint-enable MD041-->

--- a/includes/sqp/radarr-unwanted-sqp1.md
+++ b/includes/sqp/radarr-unwanted-sqp1.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD041-->
 ??? abstract "Unwanted - [Click to show/hide]"
 
     | Custom Format                                                                                                             |                                 Score                                  | Trash ID                                                |
@@ -32,3 +33,4 @@
     - **{{ radarr['cf']['av1']['name'] }}:** This blocks all releases encoded in AV1.
 
         {! include-markdown "../../includes/cf-descriptions/av1.md" !}
+<!-- markdownlint-enable MD041-->

--- a/includes/sqp/radarr-unwanted-uhd-sqp1.md
+++ b/includes/sqp/radarr-unwanted-uhd-sqp1.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD041-->
 ??? abstract "Unwanted - [Click to show/hide]"
 
     | Custom Format                                                                                                             |                                 Score                                  | Trash ID                                                |
@@ -34,3 +35,4 @@
     - **{{ radarr['cf']['av1']['name'] }}:** This blocks all releases encoded in AV1.
 
         {! include-markdown "../../includes/cf-descriptions/av1.md" !}
+<!-- markdownlint-enable MD041-->

--- a/includes/sqp/uhd-radarr-misc-required.md
+++ b/includes/sqp/uhd-radarr-misc-required.md
@@ -1,9 +1,11 @@
+<!-- markdownlint-disable MD041-->
 ??? abstract "Miscellaneous (Required) - [Click to show/hide]"
 
     | Custom Format                                                                                            |                                  Score                                  | Trash ID                                        |
     | -------------------------------------------------------------------------------------------------------- | :---------------------------------------------------------------------: | ----------------------------------------------- |
     | [{{ radarr['cf']['repack-proper']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#repackproper) |     {{ radarr['cf']['repack-proper']['trash_scores']['default'] }}      | {{ radarr['cf']['repack-proper']['trash_id'] }} |
     | [{{ radarr['cf']['repack2']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#repack2)            |        {{ radarr['cf']['repack2']['trash_scores']['default'] }}         | {{ radarr['cf']['repack2']['trash_id'] }}       |
+    | [{{ radarr['cf']['repack3']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#repack3)            |        {{ radarr['cf']['repack3']['trash_scores']['default'] }}         | {{ radarr['cf']['repack3']['trash_id'] }}       |
     | [{{ radarr['cf']['x264']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#x264)                  | :warning: {{ radarr['cf']['x264']['trash_scores']['sqp-2'] }} :warning: | {{ radarr['cf']['x264']['trash_id'] }}          |
 
     !!! warning "Scores marked with a :warning: warning :warning: are different to those used in the main guide"
@@ -24,3 +26,4 @@
         ![!cf-mm-propers-repacks-disable](/Radarr/images/cf-mm-propers-repacks-disable.png)
 
         This way you make sure the Custom Formats preferences will be used and not ignored.
+<!-- markdownlint-enable MD041-->

--- a/includes/sqp/wip.md
+++ b/includes/sqp/wip.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD041-->
 !!! info
 
     Keep in mind this SQP is a WIP, Changes are done when needed.
@@ -5,3 +6,4 @@
     It uses Custom Formats and specific needed settings that probably will never make it to the guide, being the guide is used by the masses and what's used here is made for specific needs.
 
     This also means some Custom Formats needs manual updating or you can use one of the 3rd party automation tools.
+<!-- markdownlint-enable MD041-->


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->

Add missing Custom Format `Repack3` to all applicable guide profiles.

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

- [x] Added missing Custom Format `Repack3` to all applicable guide profiles
- [x] Added MD041 exclusion.

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [ ] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
