### PR TITLE
feat(starr): Collection of Custom Formats pages to explicitly state if you are on the Radarr/Sonarr page.

### DIFF
--- a/docs/Radarr/Radarr-collection-of-custom-formats.md
+++ b/docs/Radarr/Radarr-collection-of-custom-formats.md
@@ -1,4 +1,6 @@
-# Collection of Custom Formats
+# Collection of Custom Formats for Radarr
+
+{! include-markdown "../../includes/starr/cf-not-compatible.md" !}
 
 Below is a collection of what we've come to regard as the most needed and commonly used Custom Formats.
 These CFs have been collected from discussions on Discord or created with help from others.

--- a/docs/Sonarr/sonarr-collection-of-custom-formats.md
+++ b/docs/Sonarr/sonarr-collection-of-custom-formats.md
@@ -1,4 +1,6 @@
-# Collection of Custom Formats
+# Collection of Custom Formats for Sonarr
+
+{! include-markdown "../../includes/starr/cf-not-compatible.md" !}
 
 Below is a collection of what we've come to regard as the most needed and commonly used Custom Formats.
 These CFs have been collected from discussions on Discord or created with help from others.

--- a/includes/starr/cf-not-compatible.md
+++ b/includes/starr/cf-not-compatible.md
@@ -1,0 +1,3 @@
+<!-- markdownlint-disable MD041-->
+!!! danger "Keep in mind that custom formats in Radarr and Sonarr are not always compatible :bangbang:"
+<!-- markdownlint-enable MD041-->

--- a/includes/starr/move-quality-to-top.md
+++ b/includes/starr/move-quality-to-top.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD041-->
 !!! info
 
     The order listed in the profile matters even if a quality is not checked, for example if you have a 1080p version but wanted the SD version, Radarr will reject all SD results because 1080p is listed higher than SD even though 1080p was not checked.
@@ -11,3 +12,4 @@
     This is why it's recommended to move the selected quality to the top of the list.
 
     [Source: Wiki Servarr](https://wiki.servarr.com/en/radarr/settings#quality-profiles){:target="_blank" rel="noopener noreferrer"}
+<!-- markdownlint-enable MD041-->


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->

fix: #2373 

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

- [x] Added Radarr/Sonarr to the header title.
- [x] Added Warning message that `custom formats in Radarr and Sonarr are not always compatible`

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [ ] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
