### PR TITLE
fix(guide-sync): Remove the exclude from the `DV HDR10+/HDR10+ Boost` group.

### DIFF
--- a/docs/json/radarr/cf-groups/dv-hdr10-and-hdr10-boost.json
+++ b/docs/json/radarr/cf-groups/dv-hdr10-and-hdr10-boost.json
@@ -24,8 +24,6 @@
       "[French MULTi.VO] HD Remux (1080p)": "c6460a102b312200c095a2d0982e0461",
       "SQP-1 (1080p)": "0896c29d74de619df168d23b98104b22",
       "SQP-1 WEB (1080p)": "90a3370d2d30cbaf08d9c23b856a12c8",
-      "SQP-1 (2160p)": "5128baeb2b081b72126bc8482b2a86a0",
-      "SQP-1 WEB (2160p)": "e91c9adaca0231493f4af0d571b907f9",
       "[Anime] Remux-1080p": "722b624f9af1e492284c4bc842153a38"
     }
   }


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->

A certain profile wasn't able to enable the `DV HDR10+/HDR10+ Boost groups`  because it was excluded.

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

Remove the exclude from the `DV HDR10+/HDR10+ Boost` group.

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
