### PR TITLE
feat(starr): Add BTM to LQ Custom Formats

### DIFF
--- a/docs/json/radarr/cf/lq.json
+++ b/docs/json/radarr/cf/lq.json
@@ -98,6 +98,15 @@
       }
     },
     {
+      "name": "BTM",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(BTM)$"
+      }
+    },
+    {
       "name": "C1NEM4",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,

--- a/docs/json/sonarr/cf/lq.json
+++ b/docs/json/sonarr/cf/lq.json
@@ -17,6 +17,15 @@
       }
     },
     {
+      "name": "BTM",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(BTM)$"
+      }
+    },
+    {
       "name": "CHX",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,


### PR DESCRIPTION


# Pull Request

## Purpose

BEN THE MEN was already in LQ (Release Title) custom format. This PR adds BTM to LQ custom format as well. 

---

Update the LQ custom formats to add the BEN THE MEN (i.e. BTM) release group, as their release titles don't format the release group name properly, or include the quality of the release (e.g., Bluray, WEBDL etc). This results in the breaking of automation.

## Approach

- Add the rlsgrp BTM to the LQ custom formats for Radarr and Sonarr.

## Open Questions and Pre-Merge TODOs

None

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
