### PR TITLE
feat(radarr): Do not match RlsGrp `PiRaTeS` when it is a WEB-DL

### DIFF
--- a/docs/json/radarr/cf/lq-release-title.json
+++ b/docs/json/radarr/cf/lq-release-title.json
@@ -53,6 +53,15 @@
       }
     },
     {
+      "name": "PiRaTeS (no WEBDL)",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "(?<=\\b[12]\\d{3}\\b.*?)(?<!([ ._-]web[ ._-]?(dl|rip)?).*?)\\b(PiRaTeS)\\b"
+      }
+    },
+    {
       "name": "SWTYBLZ",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,

--- a/docs/json/radarr/cf/lq.json
+++ b/docs/json/radarr/cf/lq.json
@@ -611,15 +611,6 @@
       }
     },
     {
-      "name": "PiRaTeS",
-      "implementation": "ReleaseGroupSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "^(PiRaTeS)$"
-      }
-    },
-    {
       "name": "PRODJi",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->

After conducting some research, we did not find any issues with their WEBDL, so we decided to remove them from the `LQ` and move them to the `LQ (Release Title)` while excluding them from matching on WEBDL.

The reason they are in `LQ (Release Title)` is that we received several reports indicating that their non-WEBDL versions do not use the best sources (R5) or they use custom discs, resulting in issues such as artifacting in dark scenes, etc.

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

Removed RlsGrp `PiRaTeS` from the CF `LQ` and moved them to the `LQ (Release Title)` while excluding them from matching on WEBDL.

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
