### PR TITLE
fix(radarr): PiRaTeS & EVO LQ (Release Title) regex

### DIFF
--- a/docs/json/radarr/cf/lq-release-title.json
+++ b/docs/json/radarr/cf/lq-release-title.json
@@ -4,6 +4,7 @@
     "default": -10000,
     "german": -35000
   },
+  "trash_regex": "https://regex101.com/r/8TIqc2/latest",
   "name": "LQ (Release Title)",
   "includeCustomFormatWhenRenaming": false,
   "specifications": [
@@ -31,7 +32,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "(?<=\\b[12]\\d{3}\\b.*?)(?<!([ ._-]web[ ._-]?(dl|rip)?).*?)\\b(EVO)\\b"
+        "value": "(?<=\\b[12]\\d{3}\\b.*?)(?<!\\b(web[ ._-]?(dl|rip)?).*?)\\b(EVO)\\b"
       }
     },
     {
@@ -67,7 +68,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "(?<=\\b[12]\\d{3}\\b.*?)(?<!([ ._-]web[ ._-]?(dl|rip)?).*?)\\b(PiRaTeS)\\b"
+        "value": "(?<=\\b[12]\\d{3}\\b.*?)(?<!\\b(web[ ._-]?(dl|rip)?).*?)\\b(PiRaTeS)\\b"
       }
     },
     {


### PR DESCRIPTION
# Pull Request

## Purpose

Fix false positives for files on disk for `PiRaTeS` & `EVO` releases that are not a WEB-DL.

## Approach

Change the regex to look for a word boundary in front of `WEB`.

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
