### PR TITLE
feat(radarr): Add `ZoroSenpai` to `HD Bluray Tier 01` and `WEB Tier 01`

### DIFF
--- a/docs/json/radarr/cf/hd-bluray-tier-01.json
+++ b/docs/json/radarr/cf/hd-bluray-tier-01.json
@@ -226,6 +226,15 @@
       "fields": {
         "value": "^(ZQ)$"
       }
+    },
+    {
+      "name": "ZoroSenpai",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(ZoroSenpai)$"
+      }
     }
   ]
 }

--- a/docs/json/radarr/cf/web-tier-01.json
+++ b/docs/json/radarr/cf/web-tier-01.json
@@ -178,6 +178,15 @@
       "fields": {
         "value": "^(TEPES)$"
       }
+    },
+    {
+      "name": "ZoroSenpai",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(ZoroSenpai)$"
+      }
     }
   ]
 }


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->

ZoroSenpai, take a 2160p WEB-DL sourced from a better source, for example, MA 4K, and create/encode a 1080p WEBRip that looks superior to the available Blu-ray 1080p.

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

Add `ZoroSenpai` to `HD Bluray Tier 01` and `WEB Tier 01`

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
