### PR TITLE
feat(starr): add `BiOMA` and `sh4down` to Bad Dual Groups

### DIFF
--- a/docs/json/radarr/cf/bad-dual-groups.json
+++ b/docs/json/radarr/cf/bad-dual-groups.json
@@ -260,6 +260,15 @@
       "fields": {
         "value": "^(ZNM)$"
       }
+    },
+    {
+      "name": "BiOMA",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(BiOMA)$"
+      }
     }
   ]
 }

--- a/docs/json/radarr/cf/bad-dual-groups.json
+++ b/docs/json/radarr/cf/bad-dual-groups.json
@@ -269,6 +269,15 @@
       "fields": {
         "value": "^(BiOMA)$"
       }
+    },
+    {
+      "name": "sh4down",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(sh4down)$"
+      }
     }
   ]
 }

--- a/docs/json/sonarr/cf/bad-dual-groups.json
+++ b/docs/json/sonarr/cf/bad-dual-groups.json
@@ -242,6 +242,15 @@
       "fields": {
         "value": "^(ZNM)$"
       }
+    },
+    {
+      "name": "BiOMA",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(BiOMA)$"
+      }
     }
   ]
 }

--- a/docs/json/sonarr/cf/bad-dual-groups.json
+++ b/docs/json/sonarr/cf/bad-dual-groups.json
@@ -251,6 +251,15 @@
       "fields": {
         "value": "^(BiOMA)$"
       }
+    },
+    {
+      "name": "sh4down",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(sh4down)$"
+      }
     }
   ]
 }


### PR DESCRIPTION
# Pull Request

## Purpose

`BiOMA` is internal from `CapybaraBR`, `sh4down` is not internal but it is their home.

The mentioned tracker is a Brazilian tracker where Portuguese as first audio track is in the rules for DUAL releases. 

These groups meets the [bad dual groups criteria](https://github.com/TRaSH-Guides/Guides/blob/master/includes/cf-descriptions/bad-dual-groups.md)

## Approach

Adds `BiOMA` and `sh4down` to Bad Dual Groups (sonarr and radarr)

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
