### PR TITLE
fix(starr-german): add ML to German CF to avoid matching ML

### DIFF
--- a/docs/json/radarr/cf/language-german.json
+++ b/docs/json/radarr/cf/language-german.json
@@ -34,6 +34,15 @@
       }
     },
     {
+      "name": "ML",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": true,
+      "required": true,
+      "fields": {
+        "value": "\\b(ML)\\b"
+      }
+    },
+    {
       "name": "Not Subbed",
       "implementation": "ReleaseTitleSpecification",
       "negate": true,

--- a/docs/json/sonarr/cf/language-german.json
+++ b/docs/json/sonarr/cf/language-german.json
@@ -34,6 +34,15 @@
       }
     },
     {
+      "name": "ML",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": true,
+      "required": true,
+      "fields": {
+        "value": "\\b(ML)\\b"
+      }
+    },
+    {
       "name": "Not Subbed",
       "implementation": "ReleaseTitleSpecification",
       "negate": true,


### PR DESCRIPTION
# Pull Request

## Purpose
When a tracker reports a file as german only and the title contains "German.ML" both the German and German DL (undefined) CF are matching. This should not be the case.
<!-- Please provide a detailed description of why you created this pull request. -->

## Approach
Change German CF to not match ML.
<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
