### PR TITLE
Revert "feat(starr): add `BiOMA` and `sh4down` to Bad Dual Groups

### DIFF
--- a/docs/json/radarr/cf/bad-dual-groups.json
+++ b/docs/json/radarr/cf/bad-dual-groups.json
@@ -260,24 +260,6 @@
       "fields": {
         "value": "^(ZNM)$"
       }
-    },
-    {
-      "name": "BiOMA",
-      "implementation": "ReleaseGroupSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "^(BiOMA)$"
-      }
-    },
-    {
-      "name": "sh4down",
-      "implementation": "ReleaseGroupSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "^(sh4down)$"
-      }
     }
   ]
 }

--- a/docs/json/sonarr/cf/bad-dual-groups.json
+++ b/docs/json/sonarr/cf/bad-dual-groups.json
@@ -242,24 +242,6 @@
       "fields": {
         "value": "^(ZNM)$"
       }
-    },
-    {
-      "name": "BiOMA",
-      "implementation": "ReleaseGroupSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "^(BiOMA)$"
-      }
-    },
-    {
-      "name": "sh4down",
-      "implementation": "ReleaseGroupSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "^(sh4down)$"
-      }
     }
   ]
 }


### PR DESCRIPTION
# Pull Request

## Purpose

This was a mistaken from my part. The groups also does correct "not dual" releases. 

Adding it to "bad dual groups" would harm those releases - since the CF does not filter only dual.

The group does web-dl so quality is not in question.

The group follows trackers rules and the dual releases that does not have "original language" as primary track are not spread, it is not an issue.

Apologies.

## Approach

This reverts commit 21c554b403afe9ff5394e62ef9b2557003d847bb introduced in #2399 

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
