### PR TITLE
feat(starr): Add RlsGrp `RAWR` to `WEB Tier 02`

### DIFF
--- a/docs/json/radarr/cf/web-tier-02.json
+++ b/docs/json/radarr/cf/web-tier-02.json
@@ -90,6 +90,15 @@
       }
     },
     {
+      "name": "RAWR",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(RAWR)$"
+      }
+    },
+    {
       "name": "SbR",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,

--- a/docs/json/sonarr/cf/web-tier-02.json
+++ b/docs/json/sonarr/cf/web-tier-02.json
@@ -279,6 +279,15 @@
       }
     },
     {
+      "name": "RAWR",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(RAWR)$"
+      }
+    },
+    {
       "name": "ROCCaT",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->

RAWR signed up for the gentleman's list on certain private trackers and currently covers 260 shows (1733 episodes) and a handful of movies.
For now, we have placed them in Tier 02. Depending on reports, we may reconsider moving them up or down if necessary.

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

Added RlsGrp `RAWR` to `WEB Tier 02` to Radarr/Sonarr

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

- [x] Sonarr - Add RlsGrp `RAWR` to `WEB Tier 02`
- [x] Radarr - Add RlsGrp `RAWR` to `WEB Tier 02`

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
