### PR TITLE
feat(guide-sync): Added the missing movie versions: Open Matte, Theatrical Cut, and Hybrid

### DIFF
--- a/docs/json/radarr/cf-groups/optional-movie-versions.json
+++ b/docs/json/radarr/cf-groups/optional-movie-versions.json
@@ -24,6 +24,11 @@
       "required": false
     },
     {
+      "name": "Open Matte",
+      "trash_id": "09d9dd29a0fc958f9796e65c2a8864b4",
+      "required": false
+    },
+    {
       "name": "Vinegar Syndrome",
       "trash_id": "db9b4c4b53d312a3ca5f1378f6440fc9",
       "required": false
@@ -31,6 +36,16 @@
     {
       "name": "Special Edition",
       "trash_id": "957d0f44b592285f26449575e8b1167e",
+      "required": false
+    },
+    {
+      "name": "Theatrical Cut",
+      "trash_id": "e9001909a4c88013a359d0b9920d7bea",
+      "required": false
+    },
+    {
+      "name": "Hybrid",
+      "trash_id": "0f12c086e289cf966fa5948eac571f44",
       "required": false
     },
     {


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->

Added the missing movie versions: Open Matte, Theatrical Cut, and Hybrid

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

Added the missing movie versions: Open Matte, Theatrical Cut, and Hybrid

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [ ] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
