### PR TITLE
feat(starr-anime): Assume SubsPlease is from CR

### DIFF
--- a/docs/json/sonarr/cf/cr.json
+++ b/docs/json/sonarr/cf/cr.json
@@ -37,9 +37,18 @@
       "name": "Crunchyroll",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,
-      "required": true,
+      "required": false,
       "fields": {
         "value": "\\b(C(runchy)?[ .-]?R(oll)?)\\b"
+      }
+    },
+    {
+      "name": "SubsPlease",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(SubsPlease)\\b"
       }
     }
   ]


### PR DESCRIPTION
# Pull Request

## Purpose
Right now, SubsPlease does not mark their releases as CR despite only ripping from that source. This means that when people upload these releases onto Usenet or other platforms, they assume it is CR and rename it as such, leading to it matching the CR format. This creates a higher score, leading to unnecessary upgrades. 

<!-- Please provide a detailed description of why you created this pull request. -->

## Approach
By adding SubsPlease into the CR format, we will apply that extra score from the beginning, meaning those renamed releases no longer have that incorrect higher score. 
<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
