### PR TITLE
feat(starr-anime): Add B00BA to Anime Tier 03

### DIFF
--- a/docs/json/radarr/cf/anime-bd-tier-03-seadex-muxers.json
+++ b/docs/json/radarr/cf/anime-bd-tier-03-seadex-muxers.json
@@ -61,6 +61,15 @@
       }
     },
     {
+      "name": "B00BA",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(B00BA)\\b"
+      }
+    },
+    {
       "name": "CBT",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,

--- a/docs/json/sonarr/cf/anime-bd-tier-03-seadex-muxers.json
+++ b/docs/json/sonarr/cf/anime-bd-tier-03-seadex-muxers.json
@@ -70,6 +70,15 @@
       }
     },
     {
+      "name": "B00BA",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(B00BA)\\b"
+      }
+    },
+    {
       "name": "CBT",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,


### PR DESCRIPTION
# Pull Request

## Purpose
B00BA now has 37+ best releases on SeaDex and is a remux group, so adding to the tier with other remux groups with a higher number of best releases
<!-- Please provide a detailed description of why you created this pull request. -->

## Approach
Same anime regex
<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

## Requirements

- [ ] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
