### PR TITLE
feat(radarr): Increase SQP quality size for WEBDL/WEBRip-1080p

### DIFF
--- a/docs/json/radarr/quality-size/sqp-streaming.json
+++ b/docs/json/radarr/quality-size/sqp-streaming.json
@@ -17,14 +17,14 @@
     {
       "quality": "WEBDL-1080p",
       "min": 12.5,
-      "preferred": 84.7,
-      "max": 85.7
+      "preferred": 101,
+      "max": 102
     },
     {
       "quality": "WEBRip-1080p",
       "min": 12.5,
-      "preferred": 84.7,
-      "max": 85.7
+      "preferred": 101,
+      "max": 102
     },
     {
       "quality": "Bluray-720p",


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->

Some WEBDL/WEBRip 1080p releases were rejected because they were too large.

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

Increased SQP quality size for WEBDL/WEBRip 1080p from `85.7` => `102`

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Enhancements:
- Increase SQP quality size threshold for WEBDL/WEBRip-1080p from 85.7 to 102 in the streaming configuration