### PR TITLE
feat(radarr): Re-Tier/Move RlsGRp Flights to Generated Dynamic HDR

### DIFF
--- a/docs/json/radarr/cf/generated-dynamic-hdr.json
+++ b/docs/json/radarr/cf/generated-dynamic-hdr.json
@@ -26,6 +26,15 @@
       }
     },
     {
+      "name": "Flights",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(Flights)$"
+      }
+    },
+    {
       "name": "SasukeducK",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,
@@ -77,6 +86,24 @@
       "required": false,
       "fields": {
         "value": "\\b(dv|dovi|dolby[ .]?v(ision)?)\\b"
+      }
+    },
+    {
+      "name": "Not WEBDL",
+      "implementation": "SourceSpecification",
+      "negate": true,
+      "required": true,
+      "fields": {
+        "value": 7
+      }
+    },
+    {
+      "name": "Not WEBRIP",
+      "implementation": "SourceSpecification",
+      "negate": true,
+      "required": true,
+      "fields": {
+        "value": 8
       }
     }
   ]

--- a/docs/json/radarr/cf/remux-tier-02.json
+++ b/docs/json/radarr/cf/remux-tier-02.json
@@ -18,15 +18,6 @@
       }
     },
     {
-      "name": "Flights",
-      "implementation": "ReleaseGroupSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "^(Flights)$"
-      }
-    },
-    {
       "name": "NCmt",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->

They have been banned on several mid-higher profile trackers recently for fake DV/HDR layers.
Example: `Hybrid Remux: HDR10+ metadata was taken from the WEB-DL, Converted to DV, and injected into the remux`

After conducting further research, we discovered that most of their releases are Generated Dynamic HDR (also known as fake DV/HDR10+).

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

- [x] Removed RlsGrp Flights from the `Remux Tier 02`.
- [x] Added RlsGrp Flights to the `Generated Dynamic HDR`.

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [ ] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
