### PR TITLE
feat(guide): Add `E` to Radarr `LQ` custom format

### DIFF
--- a/docs/json/radarr/cf/lq.json
+++ b/docs/json/radarr/cf/lq.json
@@ -233,6 +233,15 @@
       }
     },
     {
+      "name": "E",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(E)$"
+      }
+    },
+    {
       "name": "EPiC",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,


### PR DESCRIPTION
# Pull Request

## Purpose

Identify the release group `E` as LQ:
- User-generated Atmos
- Non-standard filenames causing import issues
- Upmixed audio tracks

## Approach

Add `E` to Radarr `LQ` custom format

## Open Questions and Pre-Merge TODOs

None

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

New Features:
- Recognize 'E' as a low-quality (LQ) release group in Radarr's custom format.