### PR TITLE
feat(guides): Add D3US to `lq-release-title.json`

### DIFF
--- a/docs/json/radarr/cf/lq-release-title.json
+++ b/docs/json/radarr/cf/lq-release-title.json
@@ -27,6 +27,15 @@
       }
     },
     {
+      "name": "D3US",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "(-D3US|D3US-)"
+      }
+    },
+    {
       "name": "EVO (no WEBDL)",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,


### PR DESCRIPTION
# Pull Request

## Purpose

Identify the release group D3US as LQ. File and release names do not conform to naming conventions so cattor be effectively parsed.

## Approach

Add `-D3US` and `D3US-` as matches to the LQ (Release Title) custom format. This allows for matching when the usual release group parsing criteria are not met.

## Open Questions and Pre-Merge TODOs

None

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
