### PR TITLE
fix(config): allow renovate to migrate its own config

### DIFF
--- a/.github/workflows/pr-naming-check.yml
+++ b/.github/workflows/pr-naming-check.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const titleRegex = /^(Revert \")?(((feat|fix|chore)\((((radarr|sonarr|starr)(-(german|french|anime))?)|(prowlarr|lidarr|bazarr|hardlinks|downloaders|plex|guide(-sync)?|misc|glossary|gha|deps))\))|(docs|style|refactor|perf|test|update|build|ci)(\([\w\/-]+\))?):\s.+$/;
+            const titleRegex = /^(Revert \")?(((feat|fix|chore)\((((radarr|sonarr|starr)(-(german|french|anime))?)|(prowlarr|lidarr|bazarr|hardlinks|downloaders|plex|guide(-sync)?|misc|glossary|gha|deps|config))\))|(docs|style|refactor|perf|test|update|build|ci)(\([\w\/-]+\))?):\s.+$/;
             const title = context.payload.pull_request.title;
             const isValid = titleRegex.test(title);
             if (!isValid) {


### PR DESCRIPTION
# Pull Request

## Purpose

https://github.com/TRaSH-Guides/Guides/pull/2440 failed because of PR title issues.

## Approach

Add `config` to the regex scope for `feat|fix|chore`, allowing `chore(config):`

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Bug Fixes:
- Add 'config' to the allowed scopes in the PR title naming regex so that 'chore(config):' titles are valid.