### PR TITLE
chore(misc): improve Renovate configuration with PR method and smart dependency grouping

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,7 +3,7 @@
   "extends": [
     "config:best-practices",
     "customManagers:githubActionsVersions",
-    ":automergeBranch",
+    ":automergePr",
     ":automergeDigest",
     ":automergeLinters",
     ":automergeStableNonMajor",

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -20,22 +20,49 @@
   ],
   "packageRules": [
     {
-      "description": "Group Python pip dependencies",
+      "description": "Group Python non-major dependencies",
       "matchManagers": ["pip_requirements"],
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
       "groupName": "Python dependencies",
       "groupSlug": "python-deps"
     },
     {
-      "description": "Group GitHub Actions dependencies",
+      "description": "Group Python major dependencies",
+      "matchManagers": ["pip_requirements"],
+      "matchUpdateTypes": ["major"],
+      "groupName": "Python major dependencies",
+      "groupSlug": "python-major",
+      "automerge": false
+    },
+    {
+      "description": "Group GitHub Actions non-major dependencies",
       "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
       "groupName": "GitHub Actions",
       "groupSlug": "github-actions"
     },
     {
-      "description": "Group Docker dependencies",
+      "description": "Group GitHub Actions major dependencies",
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["major"],
+      "groupName": "GitHub Actions major",
+      "groupSlug": "github-actions-major",
+      "automerge": false
+    },
+    {
+      "description": "Group Docker non-major dependencies",
       "matchManagers": ["docker-compose", "dockerfile"],
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
       "groupName": "Docker dependencies",
       "groupSlug": "docker-deps"
+    },
+    {
+      "description": "Group Docker major dependencies",
+      "matchManagers": ["docker-compose", "dockerfile"],
+      "matchUpdateTypes": ["major"],
+      "groupName": "Docker major dependencies",
+      "groupSlug": "docker-major",
+      "automerge": false
     }
   ]
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -17,5 +17,25 @@
   ],
   "ignorePaths": [
     "includes/docker/docker-compose.yml"
+  ],
+  "packageRules": [
+    {
+      "description": "Group Python pip dependencies",
+      "matchManagers": ["pip_requirements"],
+      "groupName": "Python dependencies",
+      "groupSlug": "python-deps"
+    },
+    {
+      "description": "Group GitHub Actions dependencies",
+      "matchManagers": ["github-actions"],
+      "groupName": "GitHub Actions",
+      "groupSlug": "github-actions"
+    },
+    {
+      "description": "Group Docker dependencies",
+      "matchManagers": ["docker-compose", "dockerfile"],
+      "groupName": "Docker dependencies",
+      "groupSlug": "docker-deps"
+    }
   ]
 }


### PR DESCRIPTION
## Summary
- Switch Renovate configuration from `:automergeBranch` to `:automergePr` 
- Add intelligent dependency grouping that separates major and non-major updates

### Changes Made
1. **PR Method**: Changed from branch method to PR method for automerging
   - No functional change as PR method is Renovate's fallback anyway
   - Helps avoid errors currently added as comments to each PR

2. **Smart Dependency Grouping**: Added `packageRules` to group dependencies by package manager and update type:
   - **Non-major updates** (minor/patch/pin/digest): Grouped by package manager and eligible for automerge
     - Python dependencies
     - GitHub Actions  
     - Docker dependencies
   - **Major updates**: Separated into distinct groups with automerge disabled for manual review
     - Python major dependencies
     - GitHub Actions major
     - Docker major dependencies

This creates fewer, more focused PRs while ensuring major version changes require human oversight and safe updates can be automated via existing presets (`:automergeDigest`, `:automergeLinters`, `:automergeStableNonMajor`).

## Summary by Sourcery

Update Renovate configuration to use the PR-based automerge method and create package rules that group non-major updates for automerge while isolating major version changes for manual review.

Enhancements:
- Switch Renovate automerge method to PR mode to prevent comment-based errors
- Introduce smart dependency grouping to separate and handle major versus non-major updates