### PR TITLE
feat(starr): Move RlsGrp `BYNDR` to `WEB Tier 02`

### DIFF
--- a/docs/json/radarr/cf/web-tier-02.json
+++ b/docs/json/radarr/cf/web-tier-02.json
@@ -27,6 +27,15 @@
       }
     },
     {
+      "name": "BYNDR",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(BYNDR)$"
+      }
+    },
+    {
       "name": "dB",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,

--- a/docs/json/radarr/cf/web-tier-03.json
+++ b/docs/json/radarr/cf/web-tier-03.json
@@ -27,15 +27,6 @@
       }
     },
     {
-      "name": "BYNDR",
-      "implementation": "ReleaseGroupSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "^(BYNDR)$"
-      }
-    },
-    {
       "name": "GNOMiSSiON",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,

--- a/docs/json/sonarr/cf/web-tier-02.json
+++ b/docs/json/sonarr/cf/web-tier-02.json
@@ -36,6 +36,15 @@
       }
     },
     {
+      "name": "BYNDR",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(BYNDR)$"
+      }
+    },
+    {
       "name": "Chotab",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,

--- a/docs/json/sonarr/cf/web-tier-03.json
+++ b/docs/json/sonarr/cf/web-tier-03.json
@@ -9,15 +9,6 @@
   "includeCustomFormatWhenRenaming": false,
   "specifications": [
     {
-      "name": "BYNDR",
-      "implementation": "ReleaseGroupSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "^(BYNDR)$"
-      }
-    },
-    {
       "name": "DRACULA",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->

Move RlsGrp `BYNDR` from `WEB Tier 03` to `WEB Tier 02`

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

Moved RlsGrp `BYNDR` from `WEB Tier 03` to `WEB Tier 02`

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Enhancements:
- Move the BYNDR release group from WEB Tier 03 to WEB Tier 02 in Radarr and Sonarr custom format configurations