### PR TITLE
feat(starr): Add Streaming Service ATV (This is NOT ATVP)

### DIFF
--- a/docs/json/radarr/cf/atv.json
+++ b/docs/json/radarr/cf/atv.json
@@ -1,0 +1,34 @@
+{
+  "trash_id": "d9e511921c8cedc7282e291b0209cdc5",
+  "name": "ATV",
+  "includeCustomFormatWhenRenaming": true,
+  "specifications": [
+    {
+      "name": "Apple TV",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": true,
+      "fields": {
+        "value": "\\b(atv)\\b"
+      }
+    },
+    {
+      "name": "WEBDL",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 7
+      }
+    },
+    {
+      "name": "WEBRIP",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 8
+      }
+    }
+  ]
+}

--- a/docs/json/sonarr/cf/atv.json
+++ b/docs/json/sonarr/cf/atv.json
@@ -1,0 +1,37 @@
+{
+  "trash_id": "5399f0ab9f023a9ce164d8bfc9c71356",
+  "trash_scores": {
+    "default": 0
+  },
+  "name": "ATV",
+  "includeCustomFormatWhenRenaming": true,
+  "specifications": [
+    {
+      "name": "Apple TV",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": true,
+      "fields": {
+        "value": "\\b(atv)\\b"
+      }
+    },
+    {
+      "name": "WEBDL",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 3
+      }
+    },
+    {
+      "name": "WEBRIP",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 4
+      }
+    }
+  ]
+}


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->

Added Streaming Service ATV (This is NOT ATVP)

- ATVP is Apple Originals.
- ATV is channels, i.e., non-Apple Originals.

It seems to use the same encoding engine as ATVP, but has DNR applied.

- DNR => (dynamic noise reduction) rather visible, losing details in faces, etc

We still need to decide on which scoring to use.

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

Added Streaming Service ATV (This is NOT ATVP)

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

- [ ] Set ATV scoring for Sonarr

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [ ] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
