### PR TITLE
feat(radarr): Add DRX to LQ

### DIFF
--- a/docs/json/radarr/cf/lq.json
+++ b/docs/json/radarr/cf/lq.json
@@ -233,6 +233,15 @@
       }
     },
     {
+      "name": "DRX",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(DRX)$"
+      }
+    },
+    {
       "name": "E",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,


### PR DESCRIPTION
# Pull Request

## Purpose

Add the DRX group to LQ. They use non-retail audio.

## Approach

Update the LQ CF json with `DRX`

## Open Questions and Pre-Merge TODOs

None

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

New Features:
- Add 'DRX' entry to LQ Cloudflare JSON configuration