### PR TITLE
chore(misc): enable Renovate management of pre-commit hooks

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -12,6 +12,9 @@
     ":enableVulnerabilityAlerts",
     ":renovatePrefix"
   ],
+  "pre-commit": {
+    "enabled": true
+  },
   "baseBranchPatterns": [
     "$default"
   ],
@@ -62,6 +65,21 @@
       "matchUpdateTypes": ["major"],
       "groupName": "Docker major dependencies",
       "groupSlug": "docker-major",
+      "automerge": false
+    },
+    {
+      "description": "Group pre-commit hook non-major dependencies",
+      "matchManagers": ["pre-commit"],
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "groupName": "Pre-commit hooks",
+      "groupSlug": "pre-commit-hooks"
+    },
+    {
+      "description": "Group pre-commit hook major dependencies",
+      "matchManagers": ["pre-commit"],
+      "matchUpdateTypes": ["major"],
+      "groupName": "Pre-commit hooks major",
+      "groupSlug": "pre-commit-hooks-major",
       "automerge": false
     }
   ]


### PR DESCRIPTION
## Summary
Enable Renovate to manage pre-commit hook dependencies in `.pre-commit-config.yaml`

### Changes Made
1. **Enabled pre-commit manager**: Added `"pre-commit": { "enabled": true }` to allow Renovate to track the `.pre-commit-config.yaml` file
2. **Added smart grouping for pre-commit hooks**:
   - **Non-major updates**: Grouped as "Pre-commit hooks" (eligible for automerge)
   - **Major updates**: Grouped as "Pre-commit hooks major" (requires manual review)

This follows the same grouping pattern used for other package managers and ensures pre-commit hooks stay up-to-date automatically while maintaining safety for breaking changes.

### Current pre-commit hooks that will be managed
- python-jsonschema/check-jsonschema
- adrienverge/yamllint
- igorshubovych/markdownlint-cli
- editorconfig-checker/editorconfig-checker

## Summary by Sourcery

Enable Renovate to automatically manage and group pre-commit hook dependencies in .pre-commit-config.yaml

New Features:
- Enable Renovate to track and update pre-commit hook dependencies

Enhancements:
- Group non-major pre-commit hook updates under “Pre-commit hooks” for automerge
- Group major pre-commit hook updates under “Pre-commit hooks major” for manual review