### PR TITLE
feat(radarr): Add RlsGrp `TheFarm` to `WEB Tier 01`

### DIFF
--- a/docs/json/radarr/cf/thefarm.json
+++ b/docs/json/radarr/cf/thefarm.json
@@ -1,0 +1,19 @@
+{
+  "trash_id": "d66d26d37c32b0137cd26f42abaa7c2e",
+  "trash_scores": {
+    "default": 231
+  },
+  "name": "TheFarm",
+  "includeCustomFormatWhenRenaming": false,
+  "specifications": [
+    {
+      "name": "TheFarm",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": true,
+      "fields": {
+        "value": "^(TheFarm)$"
+      }
+    }
+  ]
+}

--- a/docs/json/radarr/cf/web-tier-01.json
+++ b/docs/json/radarr/cf/web-tier-01.json
@@ -180,6 +180,15 @@
       }
     },
     {
+      "name": "TheFarm",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(TheFarm)$"
+      }
+    },
+    {
       "name": "ZoroSenpai",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->

This release group is composed of members from another Tier 1 release group. They will be focusing on Movies Anywhere (MA) WEB-DL releases with lossless audio sourced from Blu-ray and UHD discs, along with SRT subtitles.

**Why this approach?** (Based on provided information)

The MA WEB-DL releases are superior to UHD remuxes because they're approximately one-third the file size while maintaining equal or better picture quality in most comparison tests. The encoding team (from MA) working from the master files is achieving exceptional results—it's unclear how they're managing to pull off such impressive compression without quality loss.

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

Added RlsGrp `TheFarm` to `WEB Tier 01`

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Add TheFarm release group to the WEB Tier 01 Radarr custom format to support Movies Anywhere WEB-DL releases with lossless audio and SRT subtitles

New Features:
- Add TheFarm as a new release group for WEB Tier 01

Documentation:
- Introduce thefarm.json to define TheFarm release group in docs/json/radarr/cf