### PR TITLE
feat(starr-anime): Add Headpatter to Anime Tier 03

### DIFF
--- a/docs/json/radarr/cf/anime-bd-tier-03-seadex-muxers.json
+++ b/docs/json/radarr/cf/anime-bd-tier-03-seadex-muxers.json
@@ -151,6 +151,15 @@
       }
     },
     {
+      "name": "Headpatter",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Headpatter\\]|-Headpatter\\b"
+      }
+    },
+    {
       "name": "Holomux",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,

--- a/docs/json/sonarr/cf/anime-bd-tier-03-seadex-muxers.json
+++ b/docs/json/sonarr/cf/anime-bd-tier-03-seadex-muxers.json
@@ -160,6 +160,15 @@
       }
     },
     {
+      "name": "Headpatter",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Headpatter\\]|-Headpatter\\b"
+      }
+    },
+    {
       "name": "Holomux",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,


### PR DESCRIPTION
# Pull Request

## Purpose

Headpatter now has 41+ releases on SeaDex and is a remux group, so adding to the tier with other remux groups with a higher number of best releases

## Approach

Same anime regex

## Requirements

- [X] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [X] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

New Features:
- Add Headpatter to the Anime BD Tier-03 SeaDex remuxer lists for both Sonarr and Radarr