### PR TITLE
refactor(starr): remove unnecessary HDR regex

### DIFF
--- a/docs/json/radarr/cf/dv-boost.json
+++ b/docs/json/radarr/cf/dv-boost.json
@@ -14,24 +14,6 @@
       "fields": {
         "value": "\\b(dv|dovi|dolby[ .]?v(ision)?)\\b"
       }
-    },
-    {
-      "name": "DV HLG",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "\\b(DV[ .]HLG)\\b"
-      }
-    },
-    {
-      "name": "DV SDR",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "\\b(DV[ .]SDR)\\b"
-      }
     }
   ]
 }

--- a/docs/json/radarr/cf/hdr.json
+++ b/docs/json/radarr/cf/hdr.json
@@ -12,7 +12,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "^(?=.*\\b(?:(dv|dovi|dolby[ .]?v(ision)?)\\b))(?!(?=.*\\b(WEB)\\b)(?!.*\\b(hulu)\\b))"
+        "value": "^(?=.*\\b(dv|dovi|dolby[ .]?v(ision)?)\\b)(?!(?=.*\\b(WEB)\\b)(?!.*\\b(hulu)\\b))"
       }
     },
     {
@@ -66,7 +66,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "^(?=.*\\b(?:FraMeSToR|HQMUX|SiCFoI)\\b)(?=.*\\b2160p\\b)(?!.*\\b(HDR10([+]|P(lus)?)))(?!.*\\bSDR\\b).*"
+        "value": "^(?=.*\\b(FraMeSToR|HQMUX|SiCFoI)\\b)(?=.*\\b(2160p)\\b)(?!.*\\b(HDR10([+]|P(lus)?)))(?!.*\\b(SDR)\\b).*"
       }
     }
   ]

--- a/docs/json/sonarr/cf/dv-boost.json
+++ b/docs/json/sonarr/cf/dv-boost.json
@@ -14,24 +14,6 @@
       "fields": {
         "value": "\\b(dv|dovi|dolby[ .]?v(ision)?)\\b"
       }
-    },
-    {
-      "name": "DV HLG",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "\\b(DV[ .]HLG)\\b"
-      }
-    },
-    {
-      "name": "DV SDR",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "\\b(DV[ .]SDR)\\b"
-      }
     }
   ]
 }

--- a/docs/json/sonarr/cf/hdr.json
+++ b/docs/json/sonarr/cf/hdr.json
@@ -12,7 +12,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "^(?=.*\\b(?:(dv|dovi|dolby[ .]?v(ision)?)\\b))(?!(?=.*\\b(WEB)\\b)(?!.*\\b(hulu)\\b))"
+        "value": "^(?=.*\\b(dv|dovi|dolby[ .]?v(ision)?)\\b)(?!(?=.*\\b(WEB)\\b)(?!.*\\b(hulu)\\b))"
       }
     },
     {
@@ -66,7 +66,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "^(?=.*\\b(?:FraMeSToR|HQMUX|SiCFoI)\\b)(?=.*\\b2160p\\b)(?!.*\\b(HDR10([+]|P(lus)?)))(?!.*\\bSDR\\b).*"
+        "value": "^(?=.*\\b(FraMeSToR|HQMUX|SiCFoI)\\b)(?=.*\\b(2160p)\\b)(?!.*\\b(HDR10([+]|P(lus)?)))(?!.*\\b(SDR)\\b).*"
       }
     }
   ]


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->
Remove unnecessary `HDR` regex.

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->
Don't use non-capturing group as it does nothing for CFs and remove `DV HLG` and `DV SDR` conditions as those are redundant.

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Refactor content filter JSON configurations for Radarr and Sonarr by cleaning up the HDR regex and dropping unused DV HLG/SDR conditions.

Enhancements:
- Simplify HDR regex in Radarr and Sonarr content filter configs by removing the non-capturing group
- Remove redundant DV HLG and DV SDR conditions from cf/dv-boost and cf/hdr JSON files