### PR TITLE
feat(guide-sync): Added more groups as optionals

### DIFF
--- a/docs/json/radarr/cf-groups/release-groups-german.json
+++ b/docs/json/radarr/cf-groups/release-groups-german.json
@@ -1,6 +1,6 @@
 {
-  "name": "Release Groups German",
-  "trash_id": "cb735fc0e7717a836188214d62368ad3",
+  "name": "[Release Groups] German",
+  "trash_id": "bc85e56ee3bd0f01467866d5f1261543",
   "trash_description": "A collection of German release groups.",
   "custom_formats": [
     {

--- a/docs/json/radarr/cf-groups/release-groups-hd-bluray.json
+++ b/docs/json/radarr/cf-groups/release-groups-hd-bluray.json
@@ -1,52 +1,22 @@
 {
-  "name": "[Release Groups] French",
-  "trash_id": "12a919c8a5e2342db6e9c0b4e3c0756e",
-  "trash_description": "A collection of French release groups.",
+  "name": "[Release Groups] HD Bluray",
+  "trash_id": "d320a1dd070108739722e518604bcd68",
+  "trash_description": "Collection of HD Bluray Tiered Groups for Radarr",
   "custom_formats": [
     {
-      "name": "FR Remux Tier 01",
-      "trash_id": "5583260016e0b9f683f53af41fb42e4a",
-      "required": false
+      "name": "HD Bluray Tier 01",
+      "trash_id": "ed27ebfef2f323e964fb1f61391bcb35",
+      "required": true
     },
     {
-      "name": "FR Remux Tier 02",
-      "trash_id": "9019d81307e68cd4a7eb06a567e833b8",
-      "required": false
+      "name": "HD Bluray Tier 02",
+      "trash_id": "c20c8647f2746a1f4c4262b0fbbeeeae",
+      "required": true
     },
     {
-      "name": "FR UHD Bluray Tier 01",
-      "trash_id": "64f8f12bbf7472a6ccf838bfd6b5e3e8",
-      "required": false
-    },
-    {
-      "name": "FR UHD Bluray Tier 02",
-      "trash_id": "0dcf0c8a386d82e3f2d424189af14065",
-      "required": false
-    },
-    {
-      "name": "FR HD Bluray Tier 01",
-      "trash_id": "5322da05b19d857acc1e75be3edf47b3",
-      "required": false
-    },
-    {
-      "name": "FR HD Bluray Tier 02",
-      "trash_id": "57f34251344be2e283fc30e00e458be6",
-      "required": false
-    },
-    {
-      "name": "FR WEB Tier 01",
-      "trash_id": "9790a618cec1aeac8ce75601a17ea40d",
-      "required": false
-    },
-    {
-      "name": "FR WEB Tier 02",
-      "trash_id": "3c83a765f84239716bd5fd2d7af188f9",
-      "required": false
-    },
-    {
-      "name": "FR Scene Groups",
-      "trash_id": "0d94489c0d5828cd3bf9409d309fb32b",
-      "required": false
+      "name": "HD Bluray Tier 03",
+      "trash_id": "5608c71bcebba0a5e666223bae8c9227",
+      "required": true
     }
   ],
   "quality_profiles": {

--- a/docs/json/radarr/cf-groups/release-groups-remuxes.json
+++ b/docs/json/radarr/cf-groups/release-groups-remuxes.json
@@ -1,52 +1,22 @@
 {
-  "name": "[Release Groups] French",
-  "trash_id": "12a919c8a5e2342db6e9c0b4e3c0756e",
-  "trash_description": "A collection of French release groups.",
+  "name": "[Release Groups] Remuxes",
+  "trash_id": "ea814e6881c4c9d3537e692b8157208e",
+  "trash_description": "Collection of Remux Tiered Groups for Radarr",
   "custom_formats": [
     {
-      "name": "FR Remux Tier 01",
-      "trash_id": "5583260016e0b9f683f53af41fb42e4a",
-      "required": false
+      "name": "Remux Tier 01",
+      "trash_id": "3a3ff47579026e76d6504ebea39390de",
+      "required": true
     },
     {
-      "name": "FR Remux Tier 02",
-      "trash_id": "9019d81307e68cd4a7eb06a567e833b8",
-      "required": false
+      "name": "Remux Tier 02",
+      "trash_id": "9f98181fe5a3fbeb0cc29340da2a468a",
+      "required": true
     },
     {
-      "name": "FR UHD Bluray Tier 01",
-      "trash_id": "64f8f12bbf7472a6ccf838bfd6b5e3e8",
-      "required": false
-    },
-    {
-      "name": "FR UHD Bluray Tier 02",
-      "trash_id": "0dcf0c8a386d82e3f2d424189af14065",
-      "required": false
-    },
-    {
-      "name": "FR HD Bluray Tier 01",
-      "trash_id": "5322da05b19d857acc1e75be3edf47b3",
-      "required": false
-    },
-    {
-      "name": "FR HD Bluray Tier 02",
-      "trash_id": "57f34251344be2e283fc30e00e458be6",
-      "required": false
-    },
-    {
-      "name": "FR WEB Tier 01",
-      "trash_id": "9790a618cec1aeac8ce75601a17ea40d",
-      "required": false
-    },
-    {
-      "name": "FR WEB Tier 02",
-      "trash_id": "3c83a765f84239716bd5fd2d7af188f9",
-      "required": false
-    },
-    {
-      "name": "FR Scene Groups",
-      "trash_id": "0d94489c0d5828cd3bf9409d309fb32b",
-      "required": false
+      "name": "Remux Tier 03",
+      "trash_id": "8baaf0b3142bf4d94c42a724f034e27a",
+      "required": true
     }
   ],
   "quality_profiles": {

--- a/docs/json/radarr/cf-groups/release-groups-uhd-bluray.json
+++ b/docs/json/radarr/cf-groups/release-groups-uhd-bluray.json
@@ -1,72 +1,22 @@
 {
-  "name": "Release Groups",
-  "trash_id": "0891e90b7edea483b30a69ba66c8693e",
-  "trash_description": "A collection of English/International release groups.",
+  "name": "[Release Groups] UHD Bluray",
+  "trash_id": "ea858f7b13df9456f3ea41d47fabc735",
+  "trash_description": "Collection of UHD Bluray Tiered Groups for Radarr",
   "custom_formats": [
-    {
-      "name": "Remux Tier 01",
-      "trash_id": "3a3ff47579026e76d6504ebea39390de",
-      "required": false
-    },
-    {
-      "name": "Remux Tier 02",
-      "trash_id": "9f98181fe5a3fbeb0cc29340da2a468a",
-      "required": false
-    },
-    {
-      "name": "Remux Tier 03",
-      "trash_id": "8baaf0b3142bf4d94c42a724f034e27a",
-      "required": false
-    },
     {
       "name": "UHD Bluray Tier 01",
       "trash_id": "4d74ac4c4db0b64bff6ce0cffef99bf0",
-      "required": false
+      "required": true
     },
     {
       "name": "UHD Bluray Tier 02",
       "trash_id": "a58f517a70193f8e578056642178419d",
-      "required": false
+      "required": true
     },
     {
       "name": "UHD Bluray Tier 03",
       "trash_id": "e71939fae578037e7aed3ee219bbe7c1",
-      "required": false
-    },
-    {
-      "name": "HD Bluray Tier 01",
-      "trash_id": "ed27ebfef2f323e964fb1f61391bcb35",
-      "required": false
-    },
-    {
-      "name": "HD Bluray Tier 02",
-      "trash_id": "c20c8647f2746a1f4c4262b0fbbeeeae",
-      "required": false
-    },
-    {
-      "name": "HD Bluray Tier 03",
-      "trash_id": "5608c71bcebba0a5e666223bae8c9227",
-      "required": false
-    },
-    {
-      "name": "UHD Bluray Tier 03",
-      "trash_id": "e71939fae578037e7aed3ee219bbe7c1",
-      "required": false
-    },
-    {
-      "name": "WEB Tier 01",
-      "trash_id": "c20f169ef63c5f40c2def54abaf4438e",
-      "required": false
-    },
-    {
-      "name": "WEB Tier 02",
-      "trash_id": "403816d65392c79236dcb6dd591aeda4",
-      "required": false
-    },
-    {
-      "name": "WEB Tier 03",
-      "trash_id": "af94e0fe497124d1f9ce732069ec8c3b",
-      "required": false
+      "required": true
     }
   ],
   "quality_profiles": {

--- a/docs/json/radarr/cf-groups/release-groups-web.json
+++ b/docs/json/radarr/cf-groups/release-groups-web.json
@@ -1,52 +1,23 @@
 {
-  "name": "[Release Groups] French",
-  "trash_id": "12a919c8a5e2342db6e9c0b4e3c0756e",
-  "trash_description": "A collection of French release groups.",
+  "name": "[Release Groups] WEB",
+  "trash_id": "2e8ede48948e8fe5e4c68a1e09e843e8",
+  "trash_description": "Collection of WEB Tiered Groups for Radarr",
+  "default": "true",
   "custom_formats": [
     {
-      "name": "FR Remux Tier 01",
-      "trash_id": "5583260016e0b9f683f53af41fb42e4a",
-      "required": false
+      "name": "WEB Tier 01",
+      "trash_id": "c20f169ef63c5f40c2def54abaf4438e",
+      "required": true
     },
     {
-      "name": "FR Remux Tier 02",
-      "trash_id": "9019d81307e68cd4a7eb06a567e833b8",
-      "required": false
+      "name": "WEB Tier 02",
+      "trash_id": "403816d65392c79236dcb6dd591aeda4",
+      "required": true
     },
     {
-      "name": "FR UHD Bluray Tier 01",
-      "trash_id": "64f8f12bbf7472a6ccf838bfd6b5e3e8",
-      "required": false
-    },
-    {
-      "name": "FR UHD Bluray Tier 02",
-      "trash_id": "0dcf0c8a386d82e3f2d424189af14065",
-      "required": false
-    },
-    {
-      "name": "FR HD Bluray Tier 01",
-      "trash_id": "5322da05b19d857acc1e75be3edf47b3",
-      "required": false
-    },
-    {
-      "name": "FR HD Bluray Tier 02",
-      "trash_id": "57f34251344be2e283fc30e00e458be6",
-      "required": false
-    },
-    {
-      "name": "FR WEB Tier 01",
-      "trash_id": "9790a618cec1aeac8ce75601a17ea40d",
-      "required": false
-    },
-    {
-      "name": "FR WEB Tier 02",
-      "trash_id": "3c83a765f84239716bd5fd2d7af188f9",
-      "required": false
-    },
-    {
-      "name": "FR Scene Groups",
-      "trash_id": "0d94489c0d5828cd3bf9409d309fb32b",
-      "required": false
+      "name": "WEB Tier 03",
+      "trash_id": "af94e0fe497124d1f9ce732069ec8c3b",
+      "required": true
     }
   ],
   "quality_profiles": {

--- a/docs/json/radarr/cf-groups/streaming-services-general.json
+++ b/docs/json/radarr/cf-groups/streaming-services-general.json
@@ -1,52 +1,83 @@
 {
-  "name": "[Release Groups] French",
-  "trash_id": "12a919c8a5e2342db6e9c0b4e3c0756e",
-  "trash_description": "A collection of French release groups.",
+  "name": "[Streaming Services] General",
+  "trash_id": "d9cc9a504e5ede6294c8b973aad4f028",
+  "trash_description": "Collection of General Streaming Services for Radarr",
+  "default": "true",
   "custom_formats": [
     {
-      "name": "FR Remux Tier 01",
-      "trash_id": "5583260016e0b9f683f53af41fb42e4a",
-      "required": false
+      "name": "AMZN",
+      "trash_id": "b3b3a6ac74ecbd56bcdbefa4799fb9df",
+      "required": true
     },
     {
-      "name": "FR Remux Tier 02",
-      "trash_id": "9019d81307e68cd4a7eb06a567e833b8",
-      "required": false
+      "name": "ATVP",
+      "trash_id": "40e9380490e748672c2522eaaeb692f7",
+      "required": true
     },
     {
-      "name": "FR UHD Bluray Tier 01",
-      "trash_id": "64f8f12bbf7472a6ccf838bfd6b5e3e8",
-      "required": false
+      "name": "BCORE",
+      "trash_id": "cc5e51a9e85a6296ceefe097a77f12f4",
+      "required": true
     },
     {
-      "name": "FR UHD Bluray Tier 02",
-      "trash_id": "0dcf0c8a386d82e3f2d424189af14065",
-      "required": false
+      "name": "CRiT",
+      "trash_id": "16622a6911d1ab5d5b8b713d5b0036d4",
+      "required": true
     },
     {
-      "name": "FR HD Bluray Tier 01",
-      "trash_id": "5322da05b19d857acc1e75be3edf47b3",
-      "required": false
+      "name": "DSNP",
+      "trash_id": "84272245b2988854bfb76a16e60baea5",
+      "required": true
     },
     {
-      "name": "FR HD Bluray Tier 02",
-      "trash_id": "57f34251344be2e283fc30e00e458be6",
-      "required": false
+      "name": "HBO",
+      "trash_id": "509e5f41146e278f9eab1ddaceb34515",
+      "required": true
     },
     {
-      "name": "FR WEB Tier 01",
-      "trash_id": "9790a618cec1aeac8ce75601a17ea40d",
-      "required": false
+      "name": "HMAX",
+      "trash_id": "5763d1b0ce84aff3b21038eea8e9b8ad",
+      "required": true
     },
     {
-      "name": "FR WEB Tier 02",
-      "trash_id": "3c83a765f84239716bd5fd2d7af188f9",
-      "required": false
+      "name": "Hulu",
+      "trash_id": "526d445d4c16214309f0fd2b3be18a89",
+      "required": true
     },
     {
-      "name": "FR Scene Groups",
-      "trash_id": "0d94489c0d5828cd3bf9409d309fb32b",
-      "required": false
+      "name": "iT",
+      "trash_id": "e0ec9672be6cac914ffad34a6b077209",
+      "required": true
+    },
+    {
+      "name": "MA",
+      "trash_id": "2a6039655313bf5dab1e43523b62c374",
+      "required": true
+    },
+    {
+      "name": "MAX",
+      "trash_id": "6a061313d22e51e0f25b7cd4dc065233",
+      "required": true
+    },
+    {
+      "name": "NF",
+      "trash_id": "170b1d363bd8516fbf3a3eb05d4faff6",
+      "required": true
+    },
+    {
+      "name": "PCOK",
+      "trash_id": "c9fd353f8f5f1baf56dc601c4cb29920",
+      "required": true
+    },
+    {
+      "name": "PMTP",
+      "trash_id": "e36a0ba1bc902b26ee40818a1d59b8bd",
+      "required": true
+    },
+    {
+      "name": "STAN",
+      "trash_id": "c2863d2a50c9acad1fb50e53ece60817",
+      "required": true
     }
   ],
   "quality_profiles": {

--- a/docs/json/sonarr/cf-groups/optional-sdr.json
+++ b/docs/json/sonarr/cf-groups/optional-sdr.json
@@ -16,12 +16,10 @@
   ],
   "quality_profiles": {
     "exclude": {
-      "WEB-2160p": "d1498e7d189fbe6c7110ceaabb7473e6",
-      "WEB-2160p (Alternative)": "dfa5eaae7894077ad6449169b6eb03e0",
-      "WEB-2160p (Combined)": "c4cadd6b35b95f62c3d47a408e53e2f7",
-      "[German] UHD Bluray + WEB (Alternative)": "7324309a7d1e10dc0dc2cea6c70ed852",
-      "[German] UHD Bluray + WEB": "3b0fa37fddaaefc931b75f2889d4b4f5",
-      "[German] UHD Remux + WEB": "08cececf1840290f6fd490b7d79e8642",
+      "WEB-1080p (Alternative)": "9d142234e45d6143785ac55f5a9e8dc9",
+      "WEB-1080p": "72dae194fc92bf828f32cde7744e51a1",
+      "[German] HD Bluray + WEB": "dca7e5e9e99c703bcbdaaa471dd40e98",
+      "[German] HD Remux + WEB": "0dd5f085ed61a1e01f6d347779dfa1bc",
       "[French MULTi.VO] HD Bluray + WEB (1080p)": "4c48f506c1116a3a57ae33f12346bd15",
       "[Anime] Remux-1080p": "20e0fc959f1f1704bed501f23bdae76f"
     }

--- a/docs/json/sonarr/cf-groups/release-groups-hd-bluray.json
+++ b/docs/json/sonarr/cf-groups/release-groups-hd-bluray.json
@@ -1,0 +1,34 @@
+{
+  "name": "[Release Groups] HD Bluray",
+  "trash_id": "c7ac01c8b3d633f5b911f9dcdf7cfeb4",
+  "trash_description": "Collection of HD Bluray Tiered Groups for Sonarr",
+  "custom_formats": [
+    {
+      "name": "HD Bluray Tier 01",
+      "trash_id": "d6819cba26b1a6508138d25fb5e32293",
+      "required": true
+    },
+    {
+      "name": "HD Bluray Tier 02",
+      "trash_id": "c2216b7b8aa545dc1ce8388c618f8d57",
+      "required": true
+    }
+  ],
+  "quality_profiles": {
+    "exclude": {
+      "WEB-1080p": "72dae194fc92bf828f32cde7744e51a1",
+      "WEB-1080p (Alternative)": "9d142234e45d6143785ac55f5a9e8dc9",
+      "WEB-2160p": "d1498e7d189fbe6c7110ceaabb7473e6",
+      "WEB-2160p (Alternative)": "dfa5eaae7894077ad6449169b6eb03e0",
+      "WEB-2160p (Combined)": "c4cadd6b35b95f62c3d47a408e53e2f7",
+      "[German] HD Bluray + WEB": "dca7e5e9e99c703bcbdaaa471dd40e98",
+      "[German] HD Remux + WEB": "0dd5f085ed61a1e01f6d347779dfa1bc",
+      "[German] UHD Bluray + WEB (Alternative)": "7324309a7d1e10dc0dc2cea6c70ed852",
+      "[German] UHD Bluray + WEB": "3b0fa37fddaaefc931b75f2889d4b4f5",
+      "[German] UHD Remux + WEB": "08cececf1840290f6fd490b7d79e8642",
+      "[French MULTi.VO] HD Bluray + WEB (1080p)": "4c48f506c1116a3a57ae33f12346bd15",
+      "[French MULTi.VO] UHD Bluray + WEB (2160p)": "6fa7364373e8f06206871d9c20a4fb3e",
+      "[Anime] Remux-1080p": "20e0fc959f1f1704bed501f23bdae76f"
+    }
+  }
+}

--- a/docs/json/sonarr/cf-groups/release-groups-remuxes.json
+++ b/docs/json/sonarr/cf-groups/release-groups-remuxes.json
@@ -1,0 +1,34 @@
+{
+  "name": "[Release Groups] Remuxes",
+  "trash_id": "e9ffafa2a431a51639b4d00272a0e915",
+  "trash_description": "Collection of Remux Tiered Groups for Sonarr",
+  "custom_formats": [
+    {
+      "name": "Remux Tier 01",
+      "trash_id": "9965a052eb87b0d10313b1cea89eb451",
+      "required": true
+    },
+    {
+      "name": "Remux Tier 02",
+      "trash_id": "8a1d0c3d7497e741736761a1da866a2e",
+      "required": true
+    }
+  ],
+  "quality_profiles": {
+    "exclude": {
+      "WEB-1080p": "72dae194fc92bf828f32cde7744e51a1",
+      "WEB-1080p (Alternative)": "9d142234e45d6143785ac55f5a9e8dc9",
+      "WEB-2160p": "d1498e7d189fbe6c7110ceaabb7473e6",
+      "WEB-2160p (Alternative)": "dfa5eaae7894077ad6449169b6eb03e0",
+      "WEB-2160p (Combined)": "c4cadd6b35b95f62c3d47a408e53e2f7",
+      "[German] HD Bluray + WEB": "dca7e5e9e99c703bcbdaaa471dd40e98",
+      "[German] HD Remux + WEB": "0dd5f085ed61a1e01f6d347779dfa1bc",
+      "[German] UHD Bluray + WEB (Alternative)": "7324309a7d1e10dc0dc2cea6c70ed852",
+      "[German] UHD Bluray + WEB": "3b0fa37fddaaefc931b75f2889d4b4f5",
+      "[German] UHD Remux + WEB": "08cececf1840290f6fd490b7d79e8642",
+      "[French MULTi.VO] HD Bluray + WEB (1080p)": "4c48f506c1116a3a57ae33f12346bd15",
+      "[French MULTi.VO] UHD Bluray + WEB (2160p)": "6fa7364373e8f06206871d9c20a4fb3e",
+      "[Anime] Remux-1080p": "20e0fc959f1f1704bed501f23bdae76f"
+    }
+  }
+}

--- a/docs/json/sonarr/cf-groups/release-groups-web.json
+++ b/docs/json/sonarr/cf-groups/release-groups-web.json
@@ -1,0 +1,45 @@
+{
+  "name": "[Release Groups] WEB",
+  "trash_id": "2e8ede48948e8fe5e4c68a1e09e843e8",
+  "trash_description": "Collection of WEB Tiered Groups for Sonarr",
+  "default": "true",
+  "custom_formats": [
+    {
+      "name": "WEB Tier 01",
+      "trash_id": "e6258996055b9fbab7e9cb2f75819294",
+      "required": true
+    },
+    {
+      "name": "WEB Tier 02",
+      "trash_id": "58790d4e2fdcd9733aa7ae68ba2bb503",
+      "required": true
+    },
+    {
+      "name": "WEB Tier 03",
+      "trash_id": "d84935abd3f8556dcd51d4f27e22d0a6",
+      "required": true
+    },
+    {
+      "name": "WEB Scene",
+      "trash_id": "d0c516558625b04b363fa6c5c2c7cfd4",
+      "required": false
+    }
+  ],
+  "quality_profiles": {
+    "exclude": {
+      "WEB-1080p": "72dae194fc92bf828f32cde7744e51a1",
+      "WEB-1080p (Alternative)": "9d142234e45d6143785ac55f5a9e8dc9",
+      "WEB-2160p": "d1498e7d189fbe6c7110ceaabb7473e6",
+      "WEB-2160p (Alternative)": "dfa5eaae7894077ad6449169b6eb03e0",
+      "WEB-2160p (Combined)": "c4cadd6b35b95f62c3d47a408e53e2f7",
+      "[German] HD Bluray + WEB": "dca7e5e9e99c703bcbdaaa471dd40e98",
+      "[German] HD Remux + WEB": "0dd5f085ed61a1e01f6d347779dfa1bc",
+      "[German] UHD Bluray + WEB (Alternative)": "7324309a7d1e10dc0dc2cea6c70ed852",
+      "[German] UHD Bluray + WEB": "3b0fa37fddaaefc931b75f2889d4b4f5",
+      "[German] UHD Remux + WEB": "08cececf1840290f6fd490b7d79e8642",
+      "[French MULTi.VO] HD Bluray + WEB (1080p)": "4c48f506c1116a3a57ae33f12346bd15",
+      "[French MULTi.VO] UHD Bluray + WEB (2160p)": "6fa7364373e8f06206871d9c20a4fb3e",
+      "[Anime] Remux-1080p": "20e0fc959f1f1704bed501f23bdae76f"
+    }
+  }
+}

--- a/docs/json/sonarr/cf-groups/streaming-services-general.json
+++ b/docs/json/sonarr/cf-groups/streaming-services-general.json
@@ -1,0 +1,106 @@
+{
+  "name": "[Streaming Services] General",
+  "trash_id": "abe720fab2d27682adc2a735136cec02",
+  "trash_description": "Collection of General Streaming Services for Sonarr",
+  "default": "true",
+  "custom_formats": [
+    {
+      "name": "AMZN",
+      "trash_id": "d660701077794679fd59e8bdf4ce3a29",
+      "required": true
+    },
+    {
+      "name": "ATVP",
+      "trash_id": "f67c9ca88f463a48346062e8ad07713f",
+      "required": true
+    },
+    {
+      "name": "CC",
+      "trash_id": "77a7b25585c18af08f60b1547bb9b4fb",
+      "required": true
+    },
+    {
+      "name": "DCU",
+      "trash_id": "36b72f59f4ea20aad9316f475f2d9fbb",
+      "required": true
+    },
+    {
+      "name": "DSNP",
+      "trash_id": "89358767a60cc28783cdc3d0be9388a4",
+      "required": true
+    },
+    {
+      "name": "HBO",
+      "trash_id": "7a235133c87f7da4c8cccceca7e3c7a6",
+      "required": true
+    },
+    {
+      "name": "HMAX",
+      "trash_id": "a880d6abc21e7c16884f3ae393f84179",
+      "required": true
+    },
+    {
+      "name": "Hulu",
+      "trash_id": "f6cce30f1733d5c8194222a7507909bb",
+      "required": true
+    },
+    {
+      "name": "iT",
+      "trash_id": "0ac24a2a68a9700bcb7eeca8e5cd644c",
+      "required": true
+    },
+    {
+      "name": "MAX",
+      "trash_id": "81d1fbf600e2540cee87f3a23f9d3c1c",
+      "required": true
+    },
+    {
+      "name": "NF",
+      "trash_id": "d34870697c9db575f17700212167be23",
+      "required": true
+    },
+    {
+      "name": "PCOK",
+      "trash_id": "1656adc6d7bb2c8cca6acfb6592db421",
+      "required": true
+    },
+    {
+      "name": "PMTP",
+      "trash_id": "c67a75ae4a1715f2bb4d492755ba4195",
+      "required": true
+    },
+    {
+      "name": "SHO",
+      "trash_id": "ae58039e1319178e6be73caab5c42166",
+      "required": true
+    },
+    {
+      "name": "STAN",
+      "trash_id": "1efe8da11bfd74fbbcd4d8117ddb9213",
+      "required": true
+    },
+    {
+      "name": "SYFY",
+      "trash_id": "9623c5c9cac8e939c1b9aedd32f640bf",
+      "required": true
+    }
+  ],
+  "quality_profiles": {
+    "exclude": {
+      "WEB-1080p": "72dae194fc92bf828f32cde7744e51a1",
+      "WEB-1080p (Alternative)": "9d142234e45d6143785ac55f5a9e8dc9",
+      "WEB-2160p": "d1498e7d189fbe6c7110ceaabb7473e6",
+      "WEB-2160p (Alternative)": "dfa5eaae7894077ad6449169b6eb03e0",
+      "WEB-2160p (Combined)": "c4cadd6b35b95f62c3d47a408e53e2f7",
+      "[German] HD Bluray + WEB": "dca7e5e9e99c703bcbdaaa471dd40e98",
+      "[German] HD Remux + WEB": "0dd5f085ed61a1e01f6d347779dfa1bc",
+      "[German] UHD Bluray + WEB (Alternative)": "7324309a7d1e10dc0dc2cea6c70ed852",
+      "[German] UHD Bluray + WEB": "3b0fa37fddaaefc931b75f2889d4b4f5",
+      "[German] UHD Remux + WEB": "08cececf1840290f6fd490b7d79e8642",
+      "[French MULTi.VO] HD Bluray + WEB (1080p)": "4c48f506c1116a3a57ae33f12346bd15",
+      "[French MULTi.VO] UHD Bluray + WEB (2160p)": "6fa7364373e8f06206871d9c20a4fb3e",
+      "[Anime] Remux-1080p": "20e0fc959f1f1704bed501f23bdae76f"
+    }
+  }
+}
+


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->

Added more groups for the Supported Approved 3rd-party sync tools

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

Added several new and missing groups that can be used for the supported and approved 3rd-party sync tools for Radarr/Sonarr. Also, making preparations to move several CF to the groups and not have them locked into the profiles.

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

- [x] Sonarr- [Optional] SDR

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Introduce new optional group definitions for supported third-party sync tools and adjust existing group files to support dynamic grouping without locking into profiles

New Features:
- Add CF groups for HD Bluray, UHD Bluray, remux releases, web releases, and streaming services for Radarr and Sonarr

Enhancements:
- Update French and German release group lists and reorganize core release-groups into separate language-specific JSON files