### PR TITLE
update(anime): remove CRUCiBLE due to retagging

### DIFF
--- a/docs/json/radarr/cf/anime-bd-tier-03-seadex-muxers.json
+++ b/docs/json/radarr/cf/anime-bd-tier-03-seadex-muxers.json
@@ -79,15 +79,6 @@
       }
     },
     {
-      "name": "CRUCiBLE",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "\\[CRUCiBLE\\]|-CRUCiBLE\\b"
-      }
-    },
-    {
       "name": "CTR",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,

--- a/docs/json/sonarr/cf/anime-bd-tier-03-seadex-muxers.json
+++ b/docs/json/sonarr/cf/anime-bd-tier-03-seadex-muxers.json
@@ -88,15 +88,6 @@
       }
     },
     {
-      "name": "CRUCiBLE",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "\\[CRUCiBLE\\]|-CRUCiBLE\\b"
-      }
-    },
-    {
       "name": "CTR",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,


### PR DESCRIPTION
# Pull Request

## Purpose

This PR is to remove CRUCiBLE from the guide tiers due to known retagging. This has been discussed between Trash guides staff and approved

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Remove the CRUCiBLE entry from the anime BD tier-03 custom format lists in Radarr and Sonarr due to known retagging

Chores:
- Delete CRUCiBLE from docs/json/radarr/cf/anime-bd-tier-03-seadex-muxers.json
- Delete CRUCiBLE from docs/json/sonarr/cf/anime-bd-tier-03-seadex-muxers.json