### PR TITLE
fix(starr): audio channel CFs consistency

### DIFF
--- a/docs/json/radarr/cf/51-surround.json
+++ b/docs/json/radarr/cf/51-surround.json
@@ -13,7 +13,7 @@
       }
     },
     {
-      "name": "6.1 Surround",
+      "name": "Not 6.1 Surround",
       "implementation": "ReleaseTitleSpecification",
       "negate": true,
       "required": true,

--- a/docs/json/radarr/cf/71-surround.json
+++ b/docs/json/radarr/cf/71-surround.json
@@ -13,7 +13,7 @@
       }
     },
     {
-      "name": "5.1 Surround",
+      "name": "Not 5.1 Surround",
       "implementation": "ReleaseTitleSpecification",
       "negate": true,
       "required": true,
@@ -22,7 +22,7 @@
       }
     },
     {
-      "name": "6.1 Surround",
+      "name": "Not 6.1 Surround",
       "implementation": "ReleaseTitleSpecification",
       "negate": true,
       "required": true,
@@ -36,7 +36,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "(?<!repac)[^0-9][1-4][ .][0-1]|\\b(Stereo|Mono)\\b"
+        "value": "(?<!repac)[^0-9][1-4][ .][0-1]\\b|\\b(Stereo|Mono)\\b"
       }
     }
   ]

--- a/docs/json/sonarr/cf/30-sound.json
+++ b/docs/json/sonarr/cf/30-sound.json
@@ -18,7 +18,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "[^0-9]1[ .]0|\\bMono\\b|\\[PCM \\]"
+        "value": "[^0-9]1[ .]0\\b|\\bMono\\b|\\[PCM \\]"
       }
     },
     {

--- a/docs/json/sonarr/cf/51-surround.json
+++ b/docs/json/sonarr/cf/51-surround.json
@@ -13,6 +13,15 @@
       }
     },
     {
+      "name": "Not 6.1 Surround",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": true,
+      "required": true,
+      "fields": {
+        "value": "[^0-9]6[ .][0-1]\\b"
+      }
+    },
+    {
       "name": "Not 7.1 Surround",
       "implementation": "ReleaseTitleSpecification",
       "negate": true,
@@ -27,7 +36,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "(?<!repac)[^0-9][1-4][ .][0-1]|\\b(Stereo|Mono)\\b"
+        "value": "(?<!repac)[^0-9][1-4][ .][0-1]\\b|\\b(Stereo|Mono)\\b"
       }
     }
   ]

--- a/docs/json/sonarr/cf/61-surround.json
+++ b/docs/json/sonarr/cf/61-surround.json
@@ -36,7 +36,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "(?<!repac)[^0-9][1-4][ .][0-1]|\\b(Stereo|Mono)\\b"
+        "value": "(?<!repac)[^0-9][1-4][ .][0-1]\\b|\\b(Stereo|Mono)\\b"
       }
     }
   ]

--- a/docs/json/sonarr/cf/71-surround.json
+++ b/docs/json/sonarr/cf/71-surround.json
@@ -13,7 +13,7 @@
       }
     },
     {
-      "name": "5.1 Surround",
+      "name": "Not 5.1 Surround",
       "implementation": "ReleaseTitleSpecification",
       "negate": true,
       "required": true,
@@ -22,7 +22,7 @@
       }
     },
     {
-      "name": "6.1 Surround",
+      "name": "Not 6.1 Surround",
       "implementation": "ReleaseTitleSpecification",
       "negate": true,
       "required": true,
@@ -36,7 +36,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "(?<!repac)[^0-9][1-4][ .][0-1]|\\b(Stereo|Mono)\\b"
+        "value": "(?<!repac)[^0-9][1-4][ .][0-1]\\b|\\b(Stereo|Mono)\\b"
       }
     }
   ]


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->
Fix consistency between the Audio Channel CFs for Sonarr and Radarr and fix an issue with missing word boundaries leading to false negatives.

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->
Bring all Audio Channel CFs in line with each other between Sonarr and Radarr and add word boundaries where necessary.

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
