### PR TITLE
feat(radarr): Add RlsGrp `PiRAMiDHEAD` to `Remux Tier 01`

### DIFF
--- a/docs/json/radarr/cf/remux-tier-01.json
+++ b/docs/json/radarr/cf/remux-tier-01.json
@@ -72,6 +72,15 @@
       }
     },
     {
+      "name": "PiRAMiDHEAD",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(PiRAMiDHEAD)$"
+      }
+    },
+    {
       "name": "PmP",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->

### RlsGrp Addition: PiRAMiDHEAD

Added RlsGrp `PiRAMiDHEAD` to `Remux Tier 01`.
They are former members of BLURANiUM who are now operating independently.

#### Justification

They follow PTP remuxing standards, only releasing titles where meaningful improvements can be made. In several cases, their work has provided clear quality upgrades over other tier RlsGrps releases.

### Release Quality Information

- Comprehensive video and audio comparisons to ensure the highest quality sources
- Hybrid video/audio implementation when necessary
- In-depth subtitle selection and analysis
- Intertitle replacement and intro studio logo audio replacement
- Triple-checked syncs and chapters, with willingness to repack if improvements are possible

### Level of Group Activity

Maintains a consistent release schedule, regularly producing new remuxes and updates across various titles.

### Availability of Releases

Widely available with clear and consistent naming conventions.

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

Added RlsGrp `PiRAMiDHEAD` to `Remux Tier 01`

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [ ] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
