### PR TITLE
feat(starr-german): Add Release Groups to German Tiers

### DIFF
--- a/docs/json/radarr/cf/german-bluray-tier-01.json
+++ b/docs/json/radarr/cf/german-bluray-tier-01.json
@@ -1,7 +1,7 @@
 {
   "trash_id": "54795711b78ea87e56127928c423689b",
   "trash_scores": {
-      "default": 2900
+    "default": 2900
   },
   "name": "German Bluray Tier 01",
   "includeCustomFormatWhenRenaming": false,
@@ -94,6 +94,15 @@
       "required": false,
       "fields": {
         "value": "^(MAMA)$"
+      }
+    },
+    {
+      "name": "WalterBishop",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(WalterBishop)$"
       }
     },
     {

--- a/docs/json/radarr/cf/german-bluray-tier-02.json
+++ b/docs/json/radarr/cf/german-bluray-tier-02.json
@@ -1,7 +1,7 @@
 {
   "trash_id": "1bfc773c53283d47c68e535811da30b7",
   "trash_scores": {
-      "default": 2650
+    "default": 2650
   },
   "name": "German Bluray Tier 02",
   "includeCustomFormatWhenRenaming": false,
@@ -58,6 +58,15 @@
       "required": false,
       "fields": {
         "value": "^(paranoid06)$"
+      }
+    },
+    {
+      "name": "RocketHD",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(RocketHD)$"
       }
     },
     {

--- a/docs/json/radarr/cf/german-bluray-tier-03.json
+++ b/docs/json/radarr/cf/german-bluray-tier-03.json
@@ -1,7 +1,7 @@
 {
   "trash_id": "aee01d40cd1bf4bcded81ee62f0f3659",
   "trash_scores": {
-      "default": 2300
+    "default": 2300
   },
   "name": "German Bluray Tier 03",
   "includeCustomFormatWhenRenaming": false,
@@ -67,6 +67,15 @@
       "required": false,
       "fields": {
         "value": "^(FX)$"
+      }
+    },
+    {
+      "name": "RDR",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(RDR)$"
       }
     },
     {

--- a/docs/json/radarr/cf/german-lq.json
+++ b/docs/json/radarr/cf/german-lq.json
@@ -1,7 +1,7 @@
 {
   "trash_id": "263943bc5d99550c68aad0c4278ba1c7",
   "trash_scores": {
-      "default": -35000
+    "default": -35000
   },
   "name": "German LQ",
   "includeCustomFormatWhenRenaming": false,
@@ -391,6 +391,15 @@
       "required": false,
       "fields": {
         "value": "^(REEL)$"
+      }
+    },
+    {
+      "name": "VideoStar",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(VideoStar)$"
       }
     }
   ]

--- a/docs/json/radarr/cf/german-microsized.json
+++ b/docs/json/radarr/cf/german-microsized.json
@@ -1,7 +1,7 @@
 {
   "trash_id": "03c430f326f10a27a9739b8bc83c30e4",
   "trash_scores": {
-      "default": -35000
+    "default": -35000
   },
   "name": "German Microsized",
   "includeCustomFormatWhenRenaming": false,
@@ -40,6 +40,24 @@
       "required": false,
       "fields": {
         "value": "^(JellyfinPlex)$"
+      }
+    },
+    {
+      "name": "BB",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(BB)$"
+      }
+    },
+    {
+      "name": "266ers",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(266ers)$"
       }
     }
   ]

--- a/docs/json/radarr/cf/german-remux-tier-02.json
+++ b/docs/json/radarr/cf/german-remux-tier-02.json
@@ -1,7 +1,7 @@
 {
   "trash_id": "f9cf598d55ce532d63596b060a6db9ee",
   "trash_scores": {
-      "default": 3900
+    "default": 3900
   },
   "name": "German Remux Tier 02",
   "includeCustomFormatWhenRenaming": false,
@@ -49,6 +49,15 @@
       "required": false,
       "fields": {
         "value": "^(FX)$"
+      }
+    },
+    {
+      "name": "RocketHD",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(RocketHD)$"
       }
     },
     {

--- a/docs/json/radarr/cf/german-scene.json
+++ b/docs/json/radarr/cf/german-scene.json
@@ -1,7 +1,7 @@
 {
   "trash_id": "2d136d4e33082fe573d06b1f237c40dd",
   "trash_scores": {
-      "default": 1700
+    "default": 1700
   },
   "name": "German Scene",
   "includeCustomFormatWhenRenaming": false,
@@ -301,6 +301,51 @@
       "required": false,
       "fields": {
         "value": "^(SAViOURHD)$"
+      }
+    },
+    {
+      "name": "RiLE",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(RiLE)$"
+      }
+    },
+    {
+      "name": "CONTRiBUTiON",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(CONTRiBUTiON)$"
+      }
+    },
+    {
+      "name": "GOREHOUNDS",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(GOREHOUNDS)$"
+      }
+    },
+    {
+      "name": "SPiCY",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(SPiCY)$"
+      }
+    },
+    {
+      "name": "bi0hazard",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(bi0hazard)$"
       }
     }
   ]

--- a/docs/json/radarr/cf/german-web-tier-01.json
+++ b/docs/json/radarr/cf/german-web-tier-01.json
@@ -1,7 +1,7 @@
 {
   "trash_id": "a2ab25194f463f057a5559c03c84a3df",
   "trash_scores": {
-      "default": 2100
+    "default": 2100
   },
   "name": "German Web Tier 01",
   "includeCustomFormatWhenRenaming": false,
@@ -130,6 +130,24 @@
       "required": false,
       "fields": {
         "value": "\\b(TOJ)\\b"
+      }
+    },
+    {
+      "name": "WalterBishop",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(WalterBishop)$"
+      }
+    },
+    {
+      "name": "pmHD",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(pmHD)$"
       }
     },
     {

--- a/docs/json/radarr/cf/german-web-tier-03.json
+++ b/docs/json/radarr/cf/german-web-tier-03.json
@@ -1,7 +1,7 @@
 {
   "trash_id": "439f9d71becaed589058ec949e037ff3",
   "trash_scores": {
-      "default": 1800
+    "default": 1800
   },
   "name": "German Web Tier 03",
   "includeCustomFormatWhenRenaming": false,
@@ -40,6 +40,15 @@
       "required": false,
       "fields": {
         "value": "^(FX)$"
+      }
+    },
+    {
+      "name": "RDR",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(RDR)$"
       }
     },
     {

--- a/docs/json/sonarr/cf/german-bluray-tier-01.json
+++ b/docs/json/sonarr/cf/german-bluray-tier-01.json
@@ -1,7 +1,7 @@
 {
   "trash_id": "7940b2fb0278f27cf4f70187f2be95d6",
   "trash_scores": {
-      "default": 2900
+    "default": 2900
   },
   "name": "German Bluray Tier 01",
   "includeCustomFormatWhenRenaming": false,
@@ -85,6 +85,15 @@
       "required": false,
       "fields": {
         "value": "^(WeebPinn)$"
+      }
+    },
+    {
+      "name": "WalterBishop",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(WalterBishop)$"
       }
     },
     {

--- a/docs/json/sonarr/cf/german-bluray-tier-03.json
+++ b/docs/json/sonarr/cf/german-bluray-tier-03.json
@@ -1,7 +1,7 @@
 {
   "trash_id": "d8f8e1539827967e0e564833e6c08d33",
   "trash_scores": {
-      "default": 2300
+    "default": 2300
   },
   "name": "German Bluray Tier 03",
   "includeCustomFormatWhenRenaming": false,
@@ -22,6 +22,15 @@
       "required": false,
       "fields": {
         "value": "^(HQC)$"
+      }
+    },
+    {
+      "name": "RDR",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(RDR)$"
       }
     },
     {

--- a/docs/json/sonarr/cf/german-microsized.json
+++ b/docs/json/sonarr/cf/german-microsized.json
@@ -1,7 +1,7 @@
 {
   "trash_id": "237eda4ef550a97da2c9d87b437e500b",
   "trash_scores": {
-      "default": -35000
+    "default": -35000
   },
   "name": "German Microsized",
   "includeCustomFormatWhenRenaming": false,
@@ -49,6 +49,24 @@
       "required": false,
       "fields": {
         "value": "^(JellyfinPlex)$"
+      }
+    },
+    {
+      "name": "BB",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(BB)$"
+      }
+    },
+    {
+      "name": "266ers",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(266ers)$"
       }
     }
   ]

--- a/docs/json/sonarr/cf/german-scene.json
+++ b/docs/json/sonarr/cf/german-scene.json
@@ -1,7 +1,7 @@
 {
   "trash_id": "c2eec878fa1989599c226ce4c287d6a7",
   "trash_scores": {
-      "default": 1700
+    "default": 1700
   },
   "name": "German Scene",
   "includeCustomFormatWhenRenaming": false,
@@ -337,6 +337,33 @@
       "required": false,
       "fields": {
         "value": "^(CDD)$"
+      }
+    },
+    {
+      "name": "RiLE",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(RiLE)$"
+      }
+    },
+    {
+      "name": "CONTRiBUTiON",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(CONTRiBUTiON)$"
+      }
+    },
+    {
+      "name": "bi0hazard",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(bi0hazard)$"
       }
     }
   ]

--- a/docs/json/sonarr/cf/german-web-tier-01.json
+++ b/docs/json/sonarr/cf/german-web-tier-01.json
@@ -1,7 +1,7 @@
 {
   "trash_id": "68be37323132b35cf333c81a2ac8fc16",
   "trash_scores": {
-      "default": 2100
+    "default": 2100
   },
   "name": "German Web Tier 01",
   "includeCustomFormatWhenRenaming": false,
@@ -121,6 +121,15 @@
       "required": false,
       "fields": {
         "value": "\\b(TOJ)\\b"
+      }
+    },
+    {
+      "name": "WalterBishop",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(WalterBishop)$"
       }
     },
     {

--- a/docs/json/sonarr/cf/german-web-tier-03.json
+++ b/docs/json/sonarr/cf/german-web-tier-03.json
@@ -1,7 +1,7 @@
 {
   "trash_id": "bda67c2c0aae257308a4723d92475b86",
   "trash_scores": {
-      "default": 1800
+    "default": 1800
   },
   "name": "German Web Tier 03",
   "includeCustomFormatWhenRenaming": false,
@@ -49,6 +49,15 @@
       "required": false,
       "fields": {
         "value": "^(iNCEPTION)$"
+      }
+    },
+    {
+      "name": "RDR",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(RDR)$"
       }
     },
     {


### PR DESCRIPTION
# Pull Request

Added Groups to German Tiers

_Radarr_
* WalterBishop to German Bluray Tier 01
* WalterBishop, pmHD to German Web Tier 01
* RDR to German Bluray Tier 03
* RDR to German Web Tier 03
* VideoStar to German LQ (Reason: Bad encoding settings, broken media)
* BB, 266ers to German Microsized
* RiLE, CONTRiBUTiON, GOREHOUNDS, bi0hazard to German Scene
* RocketHD to German Bluray Tier 02

_Sonarr_
* WalterBishop to German Bluray Tier 01
* WalterBishop to German Web Tier 01
* RDR to German Bluray Tier 03
* RDR to German Web Tier 03
* BB, 266ers to German Microsized
* RiLE, CONTRiBUTiON, bi0hazard to German Scene

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Enhancements:
- Expand German tier definitions in Radarr and Sonarr by adding release groups WalterBishop, RDR, BB, 266ers, RiLE, CONTRiBUTiON, bi0hazard, pmHD, VideoStar, and GOREHOUNDS across bluray, web, low-quality, microsized, and scene categories