### PR TITLE
Update sonarr-naming.json

### DIFF
--- a/docs/json/sonarr/naming/sonarr-naming.json
+++ b/docs/json/sonarr/naming/sonarr-naming.json
@@ -4,8 +4,8 @@
   },
   "series": {
     "default": "{Series TitleYear}",
-    "plex-imdb": "{Series TitleYear} {imdb-{ImdbId}}",
-    "plex-tvdb": "{Series TitleYear} {tvdb-{TvdbId}}",
+    "plex-imdb": "{Series TitleYear} [imdb-{ImdbId}]",
+    "plex-tvdb": "{Series TitleYear} [tvdb-{TvdbId}]",
     "emby-imdb": "{Series TitleYear} [imdb-{ImdbId}]",
     "emby-tvdb": "{Series TitleYear} [tvdb-{TvdbId}]",
     "jellyfin-tvdb": "{Series TitleYear} [tvdbid-{TvdbId}]"


### PR DESCRIPTION
Change {} to [] in Plex recommended folder name

# Pull Request

## Purpose

I'm pretty sure the recommended folder filename format should use square brackets rather than squiggly brackets to denote the IMDB/TMDB ID. This tripped me up for a second.

## Requirements

- [X] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [X] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Documentation:
- Use square brackets instead of curly braces for the Plex recommended folder name in sonarr-naming.json.