### PR TITLE
fix(starr): HDR CF DV condition

### DIFF
--- a/docs/json/radarr/cf/hdr.json
+++ b/docs/json/radarr/cf/hdr.json
@@ -12,7 +12,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "^(?=.*\\b(dv|dovi|dolby[ .]?v(ision)?)\\b)(?!(?=.*\\b(WEB)\\b)(?!.*\\b(hulu)\\b))"
+        "value": "^(?=.*\\b(dv|dovi|dolby[ .]?v(ision)?)\\b)(?!(?=.*\\b(WEB[ ._-]?(DL|Rip)?)\\b)(?!.*\\b(hulu)\\b))"
       }
     },
     {

--- a/docs/json/sonarr/cf/hdr.json
+++ b/docs/json/sonarr/cf/hdr.json
@@ -12,7 +12,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "^(?=.*\\b(dv|dovi|dolby[ .]?v(ision)?)\\b)(?!(?=.*\\b(WEB)\\b)(?!.*\\b(hulu)\\b))"
+        "value": "^(?=.*\\b(dv|dovi|dolby[ .]?v(ision)?)\\b)(?!(?=.*\\b(WEB[ ._-]?(DL|Rip)?)\\b)(?!.*\\b(hulu)\\b))"
       }
     },
     {


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->
Fix `HDR` CF matching files without HDR fallback after rename.

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->
Adjust `DV` condition to also match on `WEBDL` and `WEBRip` and not only `WEB-DL` or `WEB-Rip`.

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Bug Fixes:
- Update HDR CF DV condition to also match on WEBDL and WEBRip variants in both Radarr and Sonarr configurations