### PR TITLE
feat(radarr): Add `CORE` matching to the  `BCORE` streaming services custom format

### DIFF
--- a/docs/json/radarr/cf/bcore.json
+++ b/docs/json/radarr/cf/bcore.json
@@ -16,7 +16,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\b(BCORE)\\b"
+        "value": "\\b((B)?CORE)\\b"
       }
     },
     {


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->

Some release groups use CORE as the name of streaming services and not BCORE.

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

Add `Core` matching to the  `BCORE` streaming services custom format.

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

New Features:
- Support CORE as an alias for BCORE in Radarr's streaming services custom format