### PR TITLE
fix(radarr): bcore regex could match movie titles

### DIFF
--- a/docs/json/radarr/cf/bcore.json
+++ b/docs/json/radarr/cf/bcore.json
@@ -16,7 +16,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\b((B)?CORE)\\b"
+        "value": "\\b(BCORE)\\b|\\b(\\d{3,4}(p|i))\\b.*\\b(CORE)\\b"
       }
     },
     {


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [ ] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Fix the bcore custom format regex so it no longer matches movie titles in Radarr

Bug Fixes:
- Prevent the bcore regex from matching entire movie titles

Documentation:
- Update bcore.json with the corrected regex pattern