### PR TITLE
feat(starr-anime): Add CRUCiBLE to Anime Tier 03

### DIFF
--- a/docs/json/radarr/cf/anime-bd-tier-03-seadex-muxers.json
+++ b/docs/json/radarr/cf/anime-bd-tier-03-seadex-muxers.json
@@ -88,6 +88,15 @@
       }
     },
     {
+      "name": "CRUCiBLE",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[CRUCiBLE\\]|-CRUCiBLE\\b"
+      }
+    },
+    {
       "name": "CyC",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,

--- a/docs/json/sonarr/cf/anime-bd-tier-03-seadex-muxers.json
+++ b/docs/json/sonarr/cf/anime-bd-tier-03-seadex-muxers.json
@@ -88,6 +88,15 @@
       }
     },
     {
+      "name": "CRUCiBLE",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[CRUCiBLE\\]|-CRUCiBLE\\b"
+      }
+    },
+    {
       "name": "CTR",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,


### PR DESCRIPTION
# Pull Request

## Purpose
This PR is to re-add CRUCiBLE to the guide tiers. This has been discussed between Trash guides staff and approved.

## Approach

    Add CRUCiBLE to docs/json/radarr/cf/anime-bd-tier-03-seadex-muxers.json
    Add CRUCiBLE to docs/json/sonarr/cf/anime-bd-tier-03-seadex-muxers.json


## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [X] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [X] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

New Features:
- Re-add the CRUCiBLE custom format to the Anime BD Tier 03 seadex-muxers configuration for Radarr and Sonarr