### PR TITLE
feat(starr-anime): Add KawaSubs to Anime Web Tier 06

### DIFF
--- a/docs/json/radarr/cf/anime-web-tier-06-fansubs.json
+++ b/docs/json/radarr/cf/anime-web-tier-06-fansubs.json
@@ -70,6 +70,15 @@
       }
     },
     {
+      "name": "KawaSubs",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(KawaSubs)\\b"
+      }
+    },
+    {
       "name": "Tsundere",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,

--- a/docs/json/sonarr/cf/anime-web-tier-06-fansubs.json
+++ b/docs/json/sonarr/cf/anime-web-tier-06-fansubs.json
@@ -79,6 +79,15 @@
       }
     },
     {
+      "name": "KawaSubs",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(KawaSubs)\\b"
+      }
+    },
+    {
       "name": "Tsundere",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,


### PR DESCRIPTION
# Pull Request

## Purpose
Add KawaSubs to Anime Web Tier 06. Fansubs group from the people over at ToonsHub (well known raws/rips releaser)
NF and CR video rips
<!-- Please provide a detailed description of why you created this pull request. -->

## Approach
Simple regex
<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Include KawaSubs as a recognized fansub source in the Anime Web Tier 06 JSON configurations for both Radarr and Sonarr.

New Features:
- Add KawaSubs fansub group to the Anime Web Tier 06 configuration for Radarr
- Add KawaSubs fansub group to the Anime Web Tier 06 configuration for Sonarr