### PR TITLE
feat(guide): Streaming Services Update

### DIFF
--- a/docs/Radarr/Radarr-collection-of-custom-formats.md
+++ b/docs/Radarr/Radarr-collection-of-custom-formats.md
@@ -74,11 +74,12 @@ We've made 3 guides related to this.
 | General Streaming Services | Asian Streaming Services | Dutch Streaming Services |
 | -------------------------- | ------------------------ | ------------------------ |
 | [Amazon](#amzn)            | [FOD](#fod)              | [Pathe Thuis](#pathe)    |
-| [Apple TV+](#atvp)         | [Disney+ Hotstar](#htsr) | [Videoland](#vdl)        |
-| [Bravia Core](#bcore)      | [TVer](#tver)            |                          |
-| [Criterion Channel](#crit) | [TVING](#tving)          |                          |
-| [Disney+](#dsnp)           | [U-NEXT](#u-next)        |                          |
-| [HBO](#hbo)                | [VIU](#viu)              |                          |
+| [Apple TV](#atv)           | [Disney+ Hotstar](#htsr) | [Videoland](#vdl)        |
+| [Apple TV+](#atvp)         | [TVer](#tver)            |                          |
+| [Bravia Core](#bcore)      | [TVING](#tving)          |                          |
+| [Criterion Channel](#crit) | [U-NEXT](#u-next)        |                          |
+| [Disney+](#dsnp)           | [VIU](#viu)              |                          |
+| [HBO](#hbo)                |                          |                          |
 | [HBO Max](#hmax)           |                          |                          |
 | [Hulu](#hulu)              |                          |                          |
 | [iTunes](#it)              |                          |                          |
@@ -87,6 +88,7 @@ We've made 3 guides related to this.
 | [Netflix](#nf)             |                          |                          |
 | [Peacock TV](#pcok)        |                          |                          |
 | [Paramount+](#pmtp)        |                          |                          |
+| [ROKU](#roku)              |                          |                          |
 | [Stan](#stan)              |                          |                          |
 
 | UK Streaming Services | Misc Streaming Services | Anime Streaming Services |
@@ -1596,6 +1598,24 @@ We've made 3 guides related to this.
 
 ---
 
+#### ATV
+
+<sub>Apple TV</sub>
+
+??? question "Description - [Click to show/hide]"
+
+    {! include-markdown "../../includes/cf-descriptions/atv.md" !}
+
+??? example "JSON - [Click to show/hide]"
+
+    ```json
+    [[% filter indent(width=4) %]][[% include 'json/radarr/cf/atv.json' %]][[% endfilter %]]
+    ```
+
+<sub><sup>[TOP](#index)</sup></sub>
+
+---
+
 #### ATVP
 
 <sub>Apple TV+</sub>
@@ -1824,6 +1844,24 @@ We've made 3 guides related to this.
 
     ```json
     [[% filter indent(width=4) %]][[% include 'json/radarr/cf/pmtp.json' %]][[% endfilter %]]
+    ```
+
+<sub><sup>[TOP](#index)</sup></sub>
+
+---
+
+#### ROKU
+
+<sub>ROKU</sub>
+
+??? question "Description - [Click to show/hide]"
+
+    {! include-markdown "../../includes/cf-descriptions/roku.md" !}
+
+??? example "JSON - [Click to show/hide]"
+
+    ```json
+    [[% filter indent(width=4) %]][[% include 'json/radarr/cf/roku.json' %]][[% endfilter %]]
     ```
 
 <sub><sup>[TOP](#index)</sup></sub>

--- a/docs/Sonarr/sonarr-collection-of-custom-formats.md
+++ b/docs/Sonarr/sonarr-collection-of-custom-formats.md
@@ -66,11 +66,12 @@ Special thanks to everyone who has helped in the creation and testing of these C
 | General Streaming Services | French Streaming Services | Asian Streaming Services | Dutch Streaming Services |
 | -------------------------- | ------------------------- | ------------------------ | ------------------------ |
 | [Amazon](#amzn)            | [AUViO](#auvio)           | [FOD](#fod)              | [NLZiet](#nlz)           |
-| [Apple TV+](#atvp)         | [MyCANAL](#mycanal)       | [Disney+ Hotstar](#htsr) | [Videoland](#vdl)        |
-| [Comedy Central](#cc)      | [SALTO](#salto)           | [TVer](#tver)            |                          |
-| [DC Universe](#dcu)        |                           | [TVING](#tving)          |                          |
-| [Disney+](#dsnp)           |                           | [U-NEXT](#u-next)        |                          |
-| [HBO Max](#hmax)           |                           | [VIU](#viu)              |                          |
+| [Apple TV](#atv)           | [MyCANAL](#mycanal)       | [Disney+ Hotstar](#htsr) | [Videoland](#vdl)        |
+| [Apple TV+](#atvp)         | [SALTO](#salto)           | [TVer](#tver)            |                          |
+| [Comedy Central](#cc)      |                           | [TVING](#tving)          |                          |
+| [DC Universe](#dcu)        |                           | [U-NEXT](#u-next)        |                          |
+| [Disney+](#dsnp)           |                           | [VIU](#viu)              |                          |
+| [HBO Max](#hmax)           |                           |                          |                          |
 | [HBO](#hbo)                |                           |                          |                          |
 | [Hulu](#hulu)              |                           |                          |                          |
 | [iTunes](#it)              |                           |                          |                          |
@@ -78,6 +79,7 @@ Special thanks to everyone who has helped in the creation and testing of these C
 | [Netflix](#nf)             |                           |                          |                          |
 | [Paramount+](#pmtp)        |                           |                          |                          |
 | [Peacock TV](#pcok)        |                           |                          |                          |
+| [ROKU](#roku)              |                           |                          |                          |
 | [SHOWTIME](#sho)           |                           |                          |                          |
 | [Stan](#stan)              |                           |                          |                          |
 | [Syfy](#syfy)              |                           |                          |                          |
@@ -85,7 +87,7 @@ Special thanks to everyone who has helped in the creation and testing of these C
 | UK Streaming Services | Misc Streaming Services | Anime Streaming Services | Optional Streaming Services                 |
 | --------------------- | ----------------------- | ------------------------ | ------------------------------------------- |
 | [4OD](#4od)           | [AUBC](#aubc)           | [ABEMA](#abema)          | [UHD Streaming Boost](#uhd-streaming-boost) |
-| [ALL4](#all4)         | [CBC](#cbc)             | [ADN](#adn)              | [UHD Streaming Cut](#uhd-streaming-cut)     |
+| [ALL4](#all4)         | [CBC](#cbc)             | [ADN](#adn)              | [HD Streaming Boost](#hd-streaming-boost)   |
 | [BBC iPlayer](#ip)    | [Crave](#crav)          | [B-Global](#b-global)    |                                             |
 | [ITVX](#itvx)         | [Discovery+](#dscp)     | [Bilibili](#bilibili)    |                                             |
 | [MY5](#my5)           | [OViD](#ovid)           | [Crunchyroll](#cr)       |                                             |
@@ -1332,6 +1334,24 @@ Special thanks to everyone who has helped in the creation and testing of these C
 
 ---
 
+#### ATV
+
+<sub>Apple TV</sub>
+
+??? question "Description - [Click to show/hide]"
+
+    {! include-markdown "../../includes/cf-descriptions/atv.md" !}
+
+??? example "JSON - [Click to show/hide]"
+
+    ```json
+    [[% filter indent(width=4) %]][[% include 'json/sonarr/cf/atv.json' %]][[% endfilter %]]
+    ```
+
+<sub><sup>[TOP](#index)</sup></sub>
+
+---
+
 #### ATVP
 
 <sub>Apple TV+</sub>
@@ -1542,6 +1562,24 @@ Special thanks to everyone who has helped in the creation and testing of these C
 
     ```json
     [[% filter indent(width=4) %]][[% include 'json/sonarr/cf/pcok.json' %]][[% endfilter %]]
+    ```
+
+<sub><sup>[TOP](#index)</sup></sub>
+
+---
+
+#### ROKU
+
+<sub>ROKU</sub>
+
+??? question "Description - [Click to show/hide]"
+
+    {! include-markdown "../../includes/cf-descriptions/roku.md" !}
+
+??? example "JSON - [Click to show/hide]"
+
+    ```json
+    [[% filter indent(width=4) %]][[% include 'json/sonarr/cf/roku.json' %]][[% endfilter %]]
     ```
 
 <sub><sup>[TOP](#index)</sup></sub>
@@ -2248,16 +2286,16 @@ Special thanks to everyone who has helped in the creation and testing of these C
 
 ---
 
-#### UHD Streaming Cut
+#### HD Streaming Boost
 
 ??? question "Description - [Click to show/hide]"
 
-    {! include-markdown "../../includes/cf-descriptions/uhd-streaming-cut.md" !}
+    {! include-markdown "../../includes/cf-descriptions/hd-streaming-boost.md" !}
 
 ??? example "JSON - [Click to show/hide]"
 
     ```json
-    [[% filter indent(width=4) %]][[% include 'json/sonarr/cf/uhd-streaming-cut.json' %]][[% endfilter %]]
+    [[% filter indent(width=4) %]][[% include 'json/sonarr/cf/hd-streaming-boost.json' %]][[% endfilter %]]
     ```
 
 <sub><sup>[TOP](#index)</sup></sub>

--- a/docs/json/radarr/cf-groups/streaming-services-general.json
+++ b/docs/json/radarr/cf-groups/streaming-services-general.json
@@ -10,6 +10,11 @@
       "required": true
     },
     {
+      "name": "ATV",
+      "trash_id": "df13ed57843877b21ad969184ab6888f",
+      "required": true
+    },
+    {
       "name": "ATVP",
       "trash_id": "40e9380490e748672c2522eaaeb692f7",
       "required": true
@@ -72,6 +77,11 @@
     {
       "name": "PMTP",
       "trash_id": "e36a0ba1bc902b26ee40818a1d59b8bd",
+      "required": true
+    },
+    {
+      "name": "ROKU",
+      "trash_id": "44c2b54d7c81c1a442a8b2cabeaef54f",
       "required": true
     },
     {

--- a/docs/json/radarr/cf/atv.json
+++ b/docs/json/radarr/cf/atv.json
@@ -1,19 +1,15 @@
 {
-  "trash_id": "0e99e7cc719a8a73b2668c3a0c3fe10c",
-  "trash_scores": {
-    "default": 75
-  },
-  "trash_regex": "https://regex101.com/r/eQuNMO/1",
-  "name": "U-NEXT",
+  "trash_id": "df13ed57843877b21ad969184ab6888f",
+  "name": "ATV",
   "includeCustomFormatWhenRenaming": true,
   "specifications": [
     {
-      "name": "U-NEXT",
+      "name": "Apple TV",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\b(u-next)\\b"
+        "value": "\\b(atv)\\b"
       }
     },
     {
@@ -22,7 +18,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": 3
+        "value": 7
       }
     },
     {
@@ -31,7 +27,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": 4
+        "value": 8
       }
     }
   ]

--- a/docs/json/radarr/cf/roku.json
+++ b/docs/json/radarr/cf/roku.json
@@ -1,19 +1,15 @@
 {
-  "trash_id": "0e99e7cc719a8a73b2668c3a0c3fe10c",
-  "trash_scores": {
-    "default": 75
-  },
-  "trash_regex": "https://regex101.com/r/eQuNMO/1",
-  "name": "U-NEXT",
+  "trash_id": "44c2b54d7c81c1a442a8b2cabeaef54f",
+  "name": "ROKU",
   "includeCustomFormatWhenRenaming": true,
   "specifications": [
     {
-      "name": "U-NEXT",
+      "name": "ROKU",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\b(u-next)\\b"
+        "value": "\\b(ROKU)\\b"
       }
     },
     {
@@ -22,7 +18,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": 3
+        "value": 7
       }
     },
     {
@@ -31,7 +27,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": 4
+        "value": 8
       }
     }
   ]

--- a/docs/json/sonarr/cf-groups/streaming-services-general.json
+++ b/docs/json/sonarr/cf-groups/streaming-services-general.json
@@ -10,6 +10,11 @@
       "required": true
     },
     {
+      "name": "ATV",
+      "trash_id": "d9e511921c8cedc7282e291b0209cdc5",
+      "required": true
+    },
+    {
       "name": "ATVP",
       "trash_id": "f67c9ca88f463a48346062e8ad07713f",
       "required": true
@@ -67,6 +72,11 @@
     {
       "name": "PMTP",
       "trash_id": "c67a75ae4a1715f2bb4d492755ba4195",
+      "required": true
+    },
+    {
+      "name": "ROKU",
+      "trash_id": "da393fd4e2c0cce7c9dc2669c43e0593",
       "required": true
     },
     {

--- a/docs/json/sonarr/cf/4od.json
+++ b/docs/json/sonarr/cf/4od.json
@@ -1,7 +1,7 @@
 {
   "trash_id": "bbcaf03147de0f73be2be4a9078dfa03",
   "trash_scores": {
-    "default": 50
+    "default": 75
   },
   "trash_regex": "https://regex101.com/r/pa5TPZ/1",
   "name": "4OD",

--- a/docs/json/sonarr/cf/all4.json
+++ b/docs/json/sonarr/cf/all4.json
@@ -1,7 +1,7 @@
 {
   "trash_id": "fcc09418f67ccaddcf3b641a22c5cfd7",
   "trash_scores": {
-    "default": 50
+    "default": 75
   },
   "trash_regex": "https://regex101.com/r/pUDbbp/1",
   "name": "ALL4",

--- a/docs/json/sonarr/cf/amzn.json
+++ b/docs/json/sonarr/cf/amzn.json
@@ -1,7 +1,7 @@
 {
   "trash_id": "d660701077794679fd59e8bdf4ce3a29",
   "trash_scores": {
-    "default": 70,
+    "default": 75,
     "anime-sonarr": 3,
     "french-anime-multi": 3,
     "french-anime-vostfr": 3

--- a/docs/json/sonarr/cf/atv.json
+++ b/docs/json/sonarr/cf/atv.json
@@ -1,0 +1,37 @@
+{
+    "trash_id": "d9e511921c8cedc7282e291b0209cdc5",
+    "trash_scores": {
+        "default": 75
+    },
+    "name": "ATV",
+    "includeCustomFormatWhenRenaming": true,
+    "specifications": [
+        {
+            "name": "Apple TV",
+            "implementation": "ReleaseTitleSpecification",
+            "negate": false,
+            "required": true,
+            "fields": {
+                "value": "\\b(atv)\\b"
+            }
+        },
+        {
+            "name": "WEBDL",
+            "implementation": "SourceSpecification",
+            "negate": false,
+            "required": false,
+            "fields": {
+                "value": 7
+            }
+        },
+        {
+            "name": "WEBRIP",
+            "implementation": "SourceSpecification",
+            "negate": false,
+            "required": false,
+            "fields": {
+                "value": 8
+            }
+        }
+    ]
+}

--- a/docs/json/sonarr/cf/atvp.json
+++ b/docs/json/sonarr/cf/atvp.json
@@ -1,7 +1,7 @@
 {
   "trash_id": "f67c9ca88f463a48346062e8ad07713f",
   "trash_scores": {
-    "default": 100
+    "default": 75
   },
   "name": "ATVP",
   "includeCustomFormatWhenRenaming": true,

--- a/docs/json/sonarr/cf/aubc.json
+++ b/docs/json/sonarr/cf/aubc.json
@@ -1,7 +1,7 @@
 {
   "trash_id": "e6e299075e22ac8f541f722254c8350a",
   "trash_scores": {
-    "default": 50
+    "default": 75
   },
   "name": "AUBC",
   "includeCustomFormatWhenRenaming": true,

--- a/docs/json/sonarr/cf/cbc.json
+++ b/docs/json/sonarr/cf/cbc.json
@@ -1,7 +1,7 @@
 {
   "trash_id": "defb0b4c8b3f6a15927c0f14c6e69c94",
   "trash_scores": {
-    "default": 50
+    "default": 75
   },
   "name": "CBC",
   "includeCustomFormatWhenRenaming": true,

--- a/docs/json/sonarr/cf/cc.json
+++ b/docs/json/sonarr/cf/cc.json
@@ -1,7 +1,7 @@
 {
   "trash_id": "77a7b25585c18af08f60b1547bb9b4fb",
   "trash_scores": {
-    "default": 50
+    "default": 75
   },
   "trash_regex": "https://regex101.com/r/A3TRwE/1",
   "name": "CC",

--- a/docs/json/sonarr/cf/crav.json
+++ b/docs/json/sonarr/cf/crav.json
@@ -1,7 +1,7 @@
 {
   "trash_id": "4e9a630db98d5391aec1368a0256e2fe",
   "trash_scores": {
-    "default": 50
+    "default": 75
   },
   "trash_regex": "https://regex101.com/r/eymcie/1",
   "name": "CRAV",

--- a/docs/json/sonarr/cf/dcu.json
+++ b/docs/json/sonarr/cf/dcu.json
@@ -1,7 +1,7 @@
 {
   "trash_id": "36b72f59f4ea20aad9316f475f2d9fbb",
   "trash_scores": {
-    "default": 50
+    "default": 75
   },
   "name": "DCU",
   "includeCustomFormatWhenRenaming": true,

--- a/docs/json/sonarr/cf/dscp.json
+++ b/docs/json/sonarr/cf/dscp.json
@@ -1,7 +1,7 @@
 {
   "trash_id": "dc5f2bb0e0262155b5fedd0f6c5d2b55",
   "trash_scores": {
-    "default": 50
+    "default": 75
   },
   "trash_regex": "https://regex101.com/r/i0x6OX/latest",
   "name": "DSCP",

--- a/docs/json/sonarr/cf/dsnp.json
+++ b/docs/json/sonarr/cf/dsnp.json
@@ -1,7 +1,7 @@
 {
   "trash_id": "89358767a60cc28783cdc3d0be9388a4",
   "trash_scores": {
-    "default": 100,
+    "default": 75,
     "anime-sonarr": 5,
     "french-anime-multi": 5,
     "french-anime-vostfr": 5

--- a/docs/json/sonarr/cf/fod.json
+++ b/docs/json/sonarr/cf/fod.json
@@ -1,7 +1,7 @@
 {
   "trash_id": "7be9c0572d8cd4f81785dacf7e85985e",
   "trash_scores": {
-    "default": 50
+    "default": 75
   },
   "trash_regex": "https://regex101.com/r/CbFoaJ/1",
   "name": "FOD",

--- a/docs/json/sonarr/cf/hbo.json
+++ b/docs/json/sonarr/cf/hbo.json
@@ -1,7 +1,7 @@
 {
   "trash_id": "7a235133c87f7da4c8cccceca7e3c7a6",
   "trash_scores": {
-    "default": 50
+    "default": 75
   },
   "name": "HBO",
   "includeCustomFormatWhenRenaming": true,

--- a/docs/json/sonarr/cf/hd-streaming-boost.json
+++ b/docs/json/sonarr/cf/hd-streaming-boost.json
@@ -1,36 +1,18 @@
 {
-  "trash_id": "d2d299244a92b8a52d4921ce3897a256",
+  "trash_id": "218e93e5702f44a68ad9e3c6ba87d2f0",
   "trash_scores": {
-    "default": -20
+    "default": 75
   },
-  "name": "UHD Streaming Cut",
+  "name": "HD Streaming Boost",
   "includeCustomFormatWhenRenaming": false,
   "specifications": [
     {
-      "name": "Amazon",
+      "name": "Disney+",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,
-      "required": false,
+      "required": true,
       "fields": {
-        "value": "\\b(amzn|amazon)\\b"
-      }
-    },
-    {
-      "name": "HBO Max",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "\\b(hmax|hbom|hbo[ ._-]?max)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)"
-      }
-    },
-    {
-      "name": "Stan",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "\\b(stan)\\b[ ._-]web[ ._-]?(dl|rip)?\\b"
+        "value": "\\b(dsnp|dsny|disney|Disney\\+)\\b"
       }
     },
     {
@@ -52,12 +34,12 @@
       }
     },
     {
-      "name": "2160p",
+      "name": "1080p",
       "implementation": "ResolutionSpecification",
       "negate": false,
       "required": true,
       "fields": {
-        "value": 2160
+        "value": 1080
       }
     }
   ]

--- a/docs/json/sonarr/cf/hmax.json
+++ b/docs/json/sonarr/cf/hmax.json
@@ -1,7 +1,7 @@
 {
   "trash_id": "a880d6abc21e7c16884f3ae393f84179",
   "trash_scores": {
-    "default": 80
+    "default": 75
   },
   "name": "HMAX",
   "includeCustomFormatWhenRenaming": true,

--- a/docs/json/sonarr/cf/ip.json
+++ b/docs/json/sonarr/cf/ip.json
@@ -1,7 +1,7 @@
 {
   "trash_id": "dc503e2425126fa1d0a9ad6168c83b3f",
   "trash_scores": {
-    "default": 50
+    "default": 75
   },
   "name": "IP",
   "includeCustomFormatWhenRenaming": true,

--- a/docs/json/sonarr/cf/it.json
+++ b/docs/json/sonarr/cf/it.json
@@ -1,7 +1,7 @@
 {
   "trash_id": "0ac24a2a68a9700bcb7eeca8e5cd644c",
   "trash_scores": {
-    "default": 50
+    "default": 75
   },
   "name": "iT",
   "includeCustomFormatWhenRenaming": true,

--- a/docs/json/sonarr/cf/itvx.json
+++ b/docs/json/sonarr/cf/itvx.json
@@ -1,7 +1,7 @@
 {
   "trash_id": "fa5a16b951004c23e980d2913694a137",
   "trash_scores": {
-    "default": 50
+    "default": 75
   },
   "trash_regex": "https://regex101.com/r/Nw3FiP/1",
   "name": "ITVX",

--- a/docs/json/sonarr/cf/max.json
+++ b/docs/json/sonarr/cf/max.json
@@ -1,7 +1,7 @@
 {
   "trash_id": "81d1fbf600e2540cee87f3a23f9d3c1c",
   "trash_scores": {
-    "default": 90
+    "default": 75
   },
   "trash_regex": "https://regex101.com/r/fa649l/1",
   "name": "MAX",

--- a/docs/json/sonarr/cf/my5.json
+++ b/docs/json/sonarr/cf/my5.json
@@ -1,7 +1,7 @@
 {
   "trash_id": "9f72dc1059a6b277c21cee6a1f15f13f",
   "trash_scores": {
-    "default": 50
+    "default": 75
   },
   "name": "MY5",
   "includeCustomFormatWhenRenaming": true,

--- a/docs/json/sonarr/cf/nf.json
+++ b/docs/json/sonarr/cf/nf.json
@@ -1,7 +1,7 @@
 {
   "trash_id": "d34870697c9db575f17700212167be23",
   "trash_scores": {
-    "default": 60,
+    "default": 75,
     "anime-sonarr": 4,
     "french-anime-multi": 4,
     "french-anime-vostfr": 4

--- a/docs/json/sonarr/cf/nlz.json
+++ b/docs/json/sonarr/cf/nlz.json
@@ -1,7 +1,7 @@
 {
   "trash_id": "b2b980877494b560443631eb1f473867",
   "trash_scores": {
-    "default": 50
+    "default": 75
   },
   "name": "NLZ",
   "includeCustomFormatWhenRenaming": true,

--- a/docs/json/sonarr/cf/ovid.json
+++ b/docs/json/sonarr/cf/ovid.json
@@ -1,7 +1,7 @@
 {
   "trash_id": "fb1a91cdc0f26f7ca0696e0e95274645",
   "trash_scores": {
-    "default": 50
+    "default": 75
   },
   "trash_regex": "https://regex101.com/r/hWHpjV/1",
   "name": "OViD",

--- a/docs/json/sonarr/cf/pcok.json
+++ b/docs/json/sonarr/cf/pcok.json
@@ -1,7 +1,7 @@
 {
   "trash_id": "1656adc6d7bb2c8cca6acfb6592db421",
   "trash_scores": {
-    "default": 60
+    "default": 75
   },
   "name": "PCOK",
   "includeCustomFormatWhenRenaming": true,

--- a/docs/json/sonarr/cf/pmtp.json
+++ b/docs/json/sonarr/cf/pmtp.json
@@ -1,7 +1,7 @@
 {
   "trash_id": "c67a75ae4a1715f2bb4d492755ba4195",
   "trash_scores": {
-    "default": 60
+    "default": 75
   },
   "name": "PMTP",
   "includeCustomFormatWhenRenaming": true,

--- a/docs/json/sonarr/cf/qibi.json
+++ b/docs/json/sonarr/cf/qibi.json
@@ -1,7 +1,7 @@
 {
   "trash_id": "3ac5d84fce98bab1b531393e9c82f467",
   "trash_scores": {
-    "default": 80
+    "default": 75
   },
   "name": "QIBI",
   "includeCustomFormatWhenRenaming": true,

--- a/docs/json/sonarr/cf/red.json
+++ b/docs/json/sonarr/cf/red.json
@@ -1,7 +1,7 @@
 {
   "trash_id": "c30d2958827d1867c73318a5a2957eb1",
   "trash_scores": {
-    "default": 50
+    "default": 75
   },
   "trash_regex": "https://regex101.com/r/GfOSFe/1",
   "name": "RED",

--- a/docs/json/sonarr/cf/roku.json
+++ b/docs/json/sonarr/cf/roku.json
@@ -1,0 +1,37 @@
+{
+    "trash_id": "da393fd4e2c0cce7c9dc2669c43e0593",
+    "trash_scores": {
+        "default": 75
+    },
+    "name": "ROKU",
+    "includeCustomFormatWhenRenaming": true,
+    "specifications": [
+        {
+            "name": "ROKU",
+            "implementation": "ReleaseTitleSpecification",
+            "negate": false,
+            "required": true,
+            "fields": {
+                "value": "\\b(roku)\\b"
+            }
+        },
+        {
+            "name": "WEBDL",
+            "implementation": "SourceSpecification",
+            "negate": false,
+            "required": false,
+            "fields": {
+                "value": 7
+            }
+        },
+        {
+            "name": "WEBRIP",
+            "implementation": "SourceSpecification",
+            "negate": false,
+            "required": false,
+            "fields": {
+                "value": 8
+            }
+        }
+    ]
+}

--- a/docs/json/sonarr/cf/sho.json
+++ b/docs/json/sonarr/cf/sho.json
@@ -1,7 +1,7 @@
 {
   "trash_id": "ae58039e1319178e6be73caab5c42166",
   "trash_scores": {
-    "default": 50
+    "default": 75
   },
   "trash_regex": "https://regex101.com/r/kjPPbG/1",
   "name": "SHO",

--- a/docs/json/sonarr/cf/stan.json
+++ b/docs/json/sonarr/cf/stan.json
@@ -1,7 +1,7 @@
 {
   "trash_id": "1efe8da11bfd74fbbcd4d8117ddb9213",
   "trash_scores": {
-    "default": 60
+    "default": 75
   },
   "trash_regex": "https://regex101.com/r/IMS7Or/1",
   "name": "STAN",

--- a/docs/json/sonarr/cf/strp.json
+++ b/docs/json/sonarr/cf/strp.json
@@ -1,7 +1,7 @@
 {
   "trash_id": "fe4062eac43d4ea75955f8ae48adcf1e",
   "trash_scores": {
-    "default": 50
+    "default": 75
   },
   "name": "STRP",
   "includeCustomFormatWhenRenaming": true,

--- a/docs/json/sonarr/cf/syfy.json
+++ b/docs/json/sonarr/cf/syfy.json
@@ -1,7 +1,7 @@
 {
   "trash_id": "9623c5c9cac8e939c1b9aedd32f640bf",
   "trash_scores": {
-    "default": 50
+    "default": 75
   },
   "name": "SYFY",
   "includeCustomFormatWhenRenaming": true,

--- a/docs/json/sonarr/cf/tver.json
+++ b/docs/json/sonarr/cf/tver.json
@@ -1,7 +1,7 @@
 {
   "trash_id": "d100ea972d1af2150b65b1cffb80f6b5",
   "trash_scores": {
-    "default": 50
+    "default": 75
   },
   "trash_regex": "https://regex101.com/r/o9YVOG/1",
   "name": "TVer",

--- a/docs/json/sonarr/cf/tving.json
+++ b/docs/json/sonarr/cf/tving.json
@@ -1,7 +1,7 @@
 {
   "trash_id": "86f8d3b8761de651aa355d46d5d8db3e",
   "trash_scores": {
-    "default": 50
+    "default": 75
   },
   "name": "TVING",
   "includeCustomFormatWhenRenaming": true,

--- a/docs/json/sonarr/cf/uhd-streaming-boost.json
+++ b/docs/json/sonarr/cf/uhd-streaming-boost.json
@@ -1,36 +1,45 @@
 {
   "trash_id": "43b3cf48cb385cd3eac608ee6bca7f09",
   "trash_scores": {
-    "default": 20
+    "default": 75
   },
   "name": "UHD Streaming Boost",
   "includeCustomFormatWhenRenaming": false,
   "specifications": [
     {
-      "name": "Peacock TV",
+      "name": "Disney+",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,
-      "required": false,
+      "required": true,
       "fields": {
-        "value": "\\b(pcok|Peacock TV)\\b"
+        "value": "\\b(dsnp|dsny|disney|Disney\\+)\\b"
       }
     },
     {
-      "name": "Paramount+",
+      "name": "HBO Max",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,
       "required": false,
       "fields": {
-        "value": "\\b(pmtp|Paramount\\+)\\b"
+        "value": "\\b(hmax|hbom|hbo[ ._-]?max)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)"
       }
     },
     {
-      "name": "Hulu",
+      "name": "HMAX Rename",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,
       "required": false,
       "fields": {
-        "value": "\\b(hulu)\\b"
+        "value": "\\[(HMAX)\\b|\\b(HMAX)\\]"
+      }
+    },
+    {
+      "name": "Netflix",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": true,
+      "fields": {
+        "value": "\\b(nf|netflix(u?hd)?)\\b"
       }
     },
     {

--- a/docs/json/sonarr/cf/vdl.json
+++ b/docs/json/sonarr/cf/vdl.json
@@ -1,7 +1,7 @@
 {
   "trash_id": "5d2317d99af813b6529c7ebf01c83533",
   "trash_scores": {
-    "default": 50
+    "default": 75
   },
   "name": "VDL",
   "includeCustomFormatWhenRenaming": true,

--- a/docs/json/sonarr/cf/viu.json
+++ b/docs/json/sonarr/cf/viu.json
@@ -1,7 +1,7 @@
 {
   "trash_id": "93c9d1e566dca8b34d57f5efbbf85f28",
   "trash_scores": {
-    "default": 50
+    "default": 75
   },
   "name": "VIU",
   "includeCustomFormatWhenRenaming": true,

--- a/docs/json/sonarr/dummy-files/sonarr-dummy-quality-profiles.json
+++ b/docs/json/sonarr/dummy-files/sonarr-dummy-quality-profiles.json
@@ -74,7 +74,7 @@
     "STAN": "1efe8da11bfd74fbbcd4d8117ddb9213",
     "SYFY": "9623c5c9cac8e939c1b9aedd32f640bf",
     "UHD Streaming Boost": "43b3cf48cb385cd3eac608ee6bca7f09",
-    "UHD Streaming Cut": "d2d299244a92b8a52d4921ce3897a256",
+    "HD Streaming Boost": "218e93e5702f44a68ad9e3c6ba87d2f0",
     "WEB Tier 01": "e6258996055b9fbab7e9cb2f75819294",
     "WEB Tier 02": "58790d4e2fdcd9733aa7ae68ba2bb503",
     "WEB Tier 03": "d84935abd3f8556dcd51d4f27e22d0a6",

--- a/docs/json/sonarr/quality-profiles/french-multi-vo-bluray-web-2160p.json
+++ b/docs/json/sonarr/quality-profiles/french-multi-vo-bluray-web-2160p.json
@@ -87,7 +87,7 @@
     "Repack v2": "eb3d5cc0a2be0db205fb823640db6a3c",
     "Repack v3": "44e7c4de10ae50265753082e5dc76047",
     "UHD Streaming Boost": "43b3cf48cb385cd3eac608ee6bca7f09",
-    "UHD Streaming Cut": "d2d299244a92b8a52d4921ce3897a256",
+    "HD Streaming Boost": "218e93e5702f44a68ad9e3c6ba87d2f0",
     "AUViO": "b0d6195c23ae254932da00512db7e8a8",
     "MyCanal": "f27d46a831e6b16fa3fee2c4e5d10984",
     "SALTO": "0455d6519a550dbf648c97b56e7231d2",

--- a/docs/json/sonarr/quality-profiles/web-2160p-alternative.json
+++ b/docs/json/sonarr/quality-profiles/web-2160p-alternative.json
@@ -71,7 +71,7 @@
     "STAN": "1efe8da11bfd74fbbcd4d8117ddb9213",
     "SYFY": "9623c5c9cac8e939c1b9aedd32f640bf",
     "UHD Streaming Boost": "43b3cf48cb385cd3eac608ee6bca7f09",
-    "UHD Streaming Cut": "d2d299244a92b8a52d4921ce3897a256",
+    "HD Streaming Boost": "218e93e5702f44a68ad9e3c6ba87d2f0",
     "WEB Tier 01": "e6258996055b9fbab7e9cb2f75819294",
     "WEB Tier 02": "58790d4e2fdcd9733aa7ae68ba2bb503",
     "WEB Tier 03": "d84935abd3f8556dcd51d4f27e22d0a6",

--- a/docs/json/sonarr/quality-profiles/web-2160p-combined.json
+++ b/docs/json/sonarr/quality-profiles/web-2160p-combined.json
@@ -71,7 +71,7 @@
     "STAN": "1efe8da11bfd74fbbcd4d8117ddb9213",
     "SYFY": "9623c5c9cac8e939c1b9aedd32f640bf",
     "UHD Streaming Boost": "43b3cf48cb385cd3eac608ee6bca7f09",
-    "UHD Streaming Cut": "d2d299244a92b8a52d4921ce3897a256",
+    "HD Streaming Boost": "218e93e5702f44a68ad9e3c6ba87d2f0",
     "WEB Tier 01": "e6258996055b9fbab7e9cb2f75819294",
     "WEB Tier 02": "58790d4e2fdcd9733aa7ae68ba2bb503",
     "WEB Tier 03": "d84935abd3f8556dcd51d4f27e22d0a6",

--- a/docs/json/sonarr/quality-profiles/web-2160p.json
+++ b/docs/json/sonarr/quality-profiles/web-2160p.json
@@ -71,7 +71,7 @@
     "STAN": "1efe8da11bfd74fbbcd4d8117ddb9213",
     "SYFY": "9623c5c9cac8e939c1b9aedd32f640bf",
     "UHD Streaming Boost": "43b3cf48cb385cd3eac608ee6bca7f09",
-    "UHD Streaming Cut": "d2d299244a92b8a52d4921ce3897a256",
+    "HD Streaming Boost": "218e93e5702f44a68ad9e3c6ba87d2f0",
     "WEB Tier 01": "e6258996055b9fbab7e9cb2f75819294",
     "WEB Tier 02": "58790d4e2fdcd9733aa7ae68ba2bb503",
     "WEB Tier 03": "d84935abd3f8556dcd51d4f27e22d0a6",

--- a/includes/cf-descriptions/atv.md
+++ b/includes/cf-descriptions/atv.md
@@ -1,0 +1,7 @@
+<!-- markdownlint-disable MD041-->
+**Apple TV**<br>
+
+[From Wikipedia, the free encyclopedia](https://en.wikipedia.org/wiki/Apple_TV%2B){:target="\_blank" rel="noopener noreferrer"}
+
+Apple TV is Apple Inc's video on demand service, offering movies and TV shows that are not Apple Originals.
+<!-- markdownlint-enable MD041-->

--- a/includes/cf-descriptions/hd-streaming-boost.md
+++ b/includes/cf-descriptions/hd-streaming-boost.md
@@ -1,0 +1,5 @@
+<!-- markdownlint-disable MD041-->
+**HD Streaming Boost**<br>
+
+Some streaming services have HD releases that are generally better than their UHD counterparts. The UHD Streaming Boost custom format increases those streaming services' scores appropriately for HD releases. Use this in conjunction with the regular streaming service custom formats.
+<!-- markdownlint-enable MD041-->

--- a/includes/cf-descriptions/roku.md
+++ b/includes/cf-descriptions/roku.md
@@ -1,0 +1,7 @@
+<!-- markdownlint-disable MD041-->
+**ROKU**<br>
+
+[From Wikipedia, the free encyclopedia](https://en.wikipedia.org/wiki/The_Roku_Channel){:target="\_blank" rel="noopener noreferrer"}
+
+The Roku Channel is an over-the-top streaming television service available in the United States, Canada, Mexico and the United Kingdom. The service was launched in 2017, and is owned and operated by Roku, Inc. It is the most popular free ad-supported streaming television (FAST) service in the United States, reportedly reaching 145 million people, as of 2024.
+<!-- markdownlint-enable MD041-->

--- a/includes/cf-descriptions/uhd-streaming-cut.md
+++ b/includes/cf-descriptions/uhd-streaming-cut.md
@@ -1,5 +1,0 @@
-<!-- markdownlint-disable MD041-->
-**UHD Streaming Cut**<br>
-
-Some streaming services have UHD releases that are generally worse than their HD counterparts. The UHD Streaming Cut custom format decreases those streaming services' scores appropriately for UHD releases. Use this in conjunction with the regular streaming service custom formats.
-<!-- markdownlint-enable MD041-->

--- a/includes/cf/radarr-streaming-services.md
+++ b/includes/cf/radarr-streaming-services.md
@@ -4,6 +4,7 @@
     | Custom Format                                                                             |                         Score                          | Trash ID                                |
     | ----------------------------------------------------------------------------------------- | :----------------------------------------------------: | --------------------------------------- |
     | [{{ radarr['cf']['amzn']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#amzn)   |                           0                            | {{ radarr['cf']['amzn']['trash_id'] }}  |
+    | [{{ radarr['cf']['atv']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#atv)   |                           0                            | {{ radarr['cf']['atv']['trash_id'] }}  |
     | [{{ radarr['cf']['atvp']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#atvp)   |                           0                            | {{ radarr['cf']['atvp']['trash_id'] }}  |
     | [{{ radarr['cf']['bcore']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#bcore) | {{ radarr['cf']['bcore']['trash_scores']['default'] }} | {{ radarr['cf']['bcore']['trash_id'] }} |
     | [{{ radarr['cf']['crit']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#crit)   | {{ radarr['cf']['crit']['trash_scores']['default'] }}  | {{ radarr['cf']['crit']['trash_id'] }}  |
@@ -17,6 +18,7 @@
     | [{{ radarr['cf']['nf']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#nf)       |                           0                            | {{ radarr['cf']['nf']['trash_id'] }}    |
     | [{{ radarr['cf']['pmtp']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#pmtp)   |                           0                            | {{ radarr['cf']['pmtp']['trash_id'] }}  |
     | [{{ radarr['cf']['pcok']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#pcok)   |                           0                            | {{ radarr['cf']['pcok']['trash_id'] }}  |
+    | [{{ radarr['cf']['roku']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#roku)   |                           0                            | {{ radarr['cf']['roku']['trash_id'] }}  |
     | [{{ radarr['cf']['stan']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#stan)   |                           0                            | {{ radarr['cf']['stan']['trash_id'] }}  |
 
     ---

--- a/includes/cf/sonarr-streaming-services.md
+++ b/includes/cf/sonarr-streaming-services.md
@@ -19,4 +19,11 @@
     | [{{ sonarr['cf']['sho']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#sho)       |  {{ sonarr['cf']['sho']['trash_scores']['default'] }}   | {{ sonarr['cf']['sho']['trash_id'] }}    |
     | [{{ sonarr['cf']['stan']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#stan)     |  {{ sonarr['cf']['stan']['trash_scores']['default'] }}  | {{ sonarr['cf']['stan']['trash_id'] }}   |
     | [{{ sonarr['cf']['syfy']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#syfy)     |  {{ sonarr['cf']['syfy']['trash_scores']['default'] }}  | {{ sonarr['cf']['syfy']['trash_id'] }}   |
+    | :warning: [{{ sonarr['cf']['hd-streaming-boost']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#hd-streaming-boost)     |  {{ sonarr['cf']['hd-streaming-boost']['trash_scores']['default'] }}  | {{ sonarr['cf']['hd-streaming-boost']['trash_id'] }}   |
+
+    !!! warning "HD Streaming Boost Custom Format"
+
+    The HD Streaming Boost custom format increases the score of some streaming services' HD releases when those are known to have better quality compared to other streaming services.
+
+    This custom format must be included in your profile for streaming service releases to be scored correctly.
 <!-- markdownlint-enable MD041-->

--- a/includes/cf/sonarr-uhd-streaming-services.md
+++ b/includes/cf/sonarr-uhd-streaming-services.md
@@ -20,11 +20,11 @@
     | [{{ sonarr['cf']['stan']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#stan)                                         |        {{ sonarr['cf']['stan']['trash_scores']['default'] }}         | {{ sonarr['cf']['stan']['trash_id'] }}                |
     | [{{ sonarr['cf']['syfy']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#syfy)                                         |  {{ sonarr['cf']['syfy']['trash_scores']['default'] }}         | {{ sonarr['cf']['syfy']['trash_id'] }}                |
     | :warning: [{{ sonarr['cf']['uhd-streaming-boost']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#uhd-streaming-boost) | {{ sonarr['cf']['uhd-streaming-boost']['trash_scores']['default'] }} | {{ sonarr['cf']['uhd-streaming-boost']['trash_id'] }} |
-    | :warning: [{{ sonarr['cf']['uhd-streaming-cut']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#uhd-streaming-cut)     |  {{ sonarr['cf']['uhd-streaming-cut']['trash_scores']['default'] }}  | {{ sonarr['cf']['uhd-streaming-cut']['trash_id'] }}   |
+    | :warning: [{{ sonarr['cf']['hd-streaming-boost']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#hd-streaming-boost)     |  {{ sonarr['cf']['hd-streaming-boost']['trash_scores']['default'] }}  | {{ sonarr['cf']['hd-streaming-boost']['trash_id'] }}   |
 
-    !!! warning "UHD Streaming Boost and UHD Streaming Cut Custom Formats"
+    !!! warning "UHD Streaming Boost and HD Streaming Boost Custom Formats"
 
-    Some streaming services have UHD releases that are generally better or worse than their HD counterparts. The UHD Streaming Boost and UHD Streaming Cut custom formats adjust those streaming services' scores appropriately for UHD releases.
+    The UHD Streaming Boost and HD Streaming Boost custom formats increase the scores of streaming services' UHD or HD releases (or both), when those services are known to have better quality compared to other streaming services.
 
-    These two custom formats must be included in your profile for UHD releases to be scored correctly.
+    These two custom formats must be included in your profile for streaming service releases to be scored correctly.
 <!-- markdownlint-enable MD041-->


### PR DESCRIPTION
# Pull Request

## Purpose

Update Streaming Services management to a more streamlined approach, and add new streaming services.
Resolve #2461 and #2424 

## Approach

- Add ATV for Sonarr and Radarr
- Add Roku for Sonarr and Radarr
- Replace UHD Streaming Cut to HD Streaming Boost for Sonarr
- Replace streaming services in Streaming Boost custom formats for Sonarr
- Change all streaming service scores to 75 for Sonarr
- Change Streaming Boost custom format scores to 75 for Sonarr
- Add descriptions for ATV and Roku
- Update Collection of Custom Formats docs for Sonarr and Radarr

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
