### PR TITLE
fix(sonarr): update webrip and webdl CF references

### DIFF
--- a/docs/json/sonarr/cf/atv.json
+++ b/docs/json/sonarr/cf/atv.json
@@ -21,7 +21,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": 7
+        "value": 3
       }
     },
     {
@@ -30,7 +30,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": 8
+        "value": 4
       }
     }
   ]

--- a/docs/json/sonarr/cf/roku.json
+++ b/docs/json/sonarr/cf/roku.json
@@ -21,7 +21,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": 7
+        "value": 3
       }
     },
     {
@@ -30,7 +30,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": 8
+        "value": 4
       }
     }
   ]


### PR DESCRIPTION
# Pull Request

## Purpose

As per 0c29d8accb04ea519499afe253845d9fdb7924a9 some SourceSpecification definitions use a wrong ID for WEBDL and WEBRIP. I figured this out because the build started failing for [my Profilarr Trash Guides database](https://github.com/johman10/profilarr-trash-guides).

It appears to be a mixup between IDs with Radarr. Probably a copy paste error.

It resolves https://github.com/johman10/profilarr-trash-guides/issues/1

## Approach

Update the values to the correct ID for Sonarr. Which also aligns with the [CF specs](https://github.com/TRaSH-Guides/Guides/blob/dc45e4ede66b7760ec786d227f4cb65d2a76373b/docs/json/sonarr/cf/cr.json#L9-L26) [for other](https://github.com/TRaSH-Guides/Guides/blob/dc45e4ede66b7760ec786d227f4cb65d2a76373b/docs/json/sonarr/cf/syfy.json#L9-L26) [files](https://github.com/TRaSH-Guides/Guides/blob/dc45e4ede66b7760ec786d227f4cb65d2a76373b/docs/json/sonarr/cf/funi.json#L9-L26).

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Fix Sonarr custom format references by correcting the WEBDL and WEBRIP specification IDs

Bug Fixes:
- Correct the SourceSpecification IDs for WEBDL and WEBRIP in Sonarr JSON definitions

Documentation:
- Update docs/json/sonarr custom format files with the proper Sonarr specification IDs