### PR TITLE
fix(guide): Updated streaming service scores for Sonarr

### DIFF
--- a/docs/json/sonarr/cf/htsr.json
+++ b/docs/json/sonarr/cf/htsr.json
@@ -2,7 +2,7 @@
   "trash_id": "4404ad44d87ccbb82746e180713112fb",
   "trash_regex": "https://regex101.com/r/PNiRKh/1",
   "trash_scores": {
-    "default": 50
+    "default": 75
   },
   "name": "HTSR",
   "includeCustomFormatWhenRenaming": true,

--- a/docs/json/sonarr/cf/hulu.json
+++ b/docs/json/sonarr/cf/hulu.json
@@ -1,7 +1,7 @@
 {
   "trash_id": "f6cce30f1733d5c8194222a7507909bb",
   "trash_scores": {
-    "default": 50
+    "default": 75
   },
   "name": "HULU",
   "includeCustomFormatWhenRenaming": true,

--- a/docs/json/sonarr/cf/now.json
+++ b/docs/json/sonarr/cf/now.json
@@ -1,7 +1,7 @@
 {
   "trash_id": "b66a699fba6f9df91becab798d7502e5",
   "trash_scores": {
-    "default": 50
+    "default": 75
   },
   "name": "NOW",
   "includeCustomFormatWhenRenaming": true,


### PR DESCRIPTION
# Pull Request

## Purpose

Updated streaming service scores for Sonarr, which were missed in the previous streaming service update.

## Approach

Updated NOW, HTSR, HULU scores to 75

## Open Questions and Pre-Merge TODOs
None

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Enhancements:
- Bump Sonarr custom format scores for NOW, HTSR, and HULU streaming services to 75