### PR TITLE
feat(guide): October 2025 Tier Membership update

### DIFF
--- a/docs/json/radarr/cf/hd-bluray-tier-02.json
+++ b/docs/json/radarr/cf/hd-bluray-tier-02.json
@@ -39,6 +39,15 @@
       }
     },
     {
+      "name": "ATELiER",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(ATELiER)$"
+      }
+    },
+    {
       "name": "EA",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,

--- a/docs/json/radarr/cf/hd-bluray-tier-03.json
+++ b/docs/json/radarr/cf/hd-bluray-tier-03.json
@@ -39,15 +39,6 @@
       }
     },
     {
-      "name": "ATELiER",
-      "implementation": "ReleaseGroupSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "^(ATELiER)$"
-      }
-    },
-    {
       "name": "BHDStudio",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,

--- a/docs/json/radarr/cf/remux-tier-02.json
+++ b/docs/json/radarr/cf/remux-tier-02.json
@@ -18,6 +18,15 @@
       }
     },
     {
+      "name": "ATELiER",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(ATELiER)$"
+      }
+    },
+    {
       "name": "NCmt",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,

--- a/docs/json/radarr/cf/remux-tier-03.json
+++ b/docs/json/radarr/cf/remux-tier-03.json
@@ -18,12 +18,12 @@
       }
     },
     {
-      "name": "ATELiER",
+      "name": "12GaugeShotgun",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,
       "required": false,
       "fields": {
-        "value": "^(ATELiER)$"
+        "value": "^(12GaugeShotgun)$"
       }
     },
     {

--- a/docs/json/radarr/cf/web-tier-03.json
+++ b/docs/json/radarr/cf/web-tier-03.json
@@ -27,6 +27,15 @@
       }
     },
     {
+      "name": "Dooky",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(Dooky)$"
+      }
+    },
+    {
       "name": "GNOMiSSiON",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,

--- a/docs/json/sonarr/cf/remux-tier-02.json
+++ b/docs/json/sonarr/cf/remux-tier-02.json
@@ -18,6 +18,15 @@
       }
     },
     {
+      "name": "12GaugeShotgun",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(12GaugeShotgun)$"
+      }
+    },
+    {
       "name": "decibeL",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,

--- a/docs/json/sonarr/cf/web-tier-03.json
+++ b/docs/json/sonarr/cf/web-tier-03.json
@@ -18,6 +18,15 @@
       }
     },
     {
+      "name": "Dooky",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(Dooky)$"
+      }
+    },
+    {
       "name": "NINJACENTRAL",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,


### PR DESCRIPTION
# Pull Request

## Purpose

Apply the latest team-agreed updates to Tier membership.

## Approach

- Add Dooky to WEB Tier 3 (Radarr & Sonarr)
- Add 12GaugeShotgun to Remux Tier 3 (Radarr) and Tier 2 (Sonarr, tier 3 equivalent)
- Move ATELiER to Remux and HD Bluray Tier 2 (Radarr only)

## Open Questions and Pre-Merge TODOs

None

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Update October 2025 Tier membership assignments across Radarr and Sonarr configurations

New Features:
- Add Dooky to Web Tier 3 for both Radarr and Sonarr
- Add 12GaugeShotgun to Remux Tier 3 in Radarr and Remux Tier 2 in Sonarr
- Relocate ATELiER to Remux Tier 2 and HD Bluray Tier 2 in Radarr