### PR TITLE
fix(radarr-french): incorrect quality group name in CF

### DIFF
--- a/docs/json/radarr/quality-profiles/french-multi-vo-uhd-remux-web.json
+++ b/docs/json/radarr/quality-profiles/french-multi-vo-uhd-remux-web.json
@@ -47,7 +47,7 @@
     { "name": "BR-DISK", "allowed": false },
     { "name": "Raw-HD", "allowed": false },
     {
-      "name": "Bluray|WEB 1080p",
+      "name": "Bluray|WEB 2160p",
       "allowed": true,
       "items": [
         "WEBDL-2160p",


### PR DESCRIPTION
# Pull Request

## Purpose

Small naming fix: 1080p to 2160p

<!-- Please provide a detailed description of why you created this pull request. -->

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [X] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [X] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Bug Fixes:
- Correct UHD quality group name from 1080p to 2160p in the French Radarr quality profile