### PR TITLE
ci(changelog): filter out more backend commits

### DIFF
--- a/.github/workflows/automatic-changelog.yml
+++ b/.github/workflows/automatic-changelog.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Run git log
         run: |
-          git log --no-merges --perl-regexp --author='^(?!.*(\[bot\]|actions@github\.com)).*$' --grep='^(feat|fix|chore|docs|style|refactor|perf|test|build|ci|revert|update)(\(.*?\))?:' --since="${{ env.LAST_EDIT_TIME }}" --pretty="%s" > log_output.txt
+          git log --no-merges --perl-regexp --author='^(?!.*(\[bot\]|actions@github\.com)).*$' --grep='^(feat|fix|chore|docs|style|refactor|perf|test|build|revert|update)(\(.*?\))?:(?! Update CONTRIBUTORS.md)' --since="${{ env.LAST_EDIT_TIME }}" --pretty="%s" > log_output.txt
 
       - name: Check if there are new commits
         run: |


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->
Update the changelog workflow to exclude more backend changes like CI or contributor updates.

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->
Update the regex used to match specific commit messages.

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

CI:
- Refine the automatic changelog workflow regex to exclude CI-generated commits and contributor file updates