### PR TITLE
feat(guide): Remove WEBDL exclusion from Dynamic Generate HDR custom format

### DIFF
--- a/docs/json/radarr/cf/generated-dynamic-hdr.json
+++ b/docs/json/radarr/cf/generated-dynamic-hdr.json
@@ -87,24 +87,6 @@
       "fields": {
         "value": "\\b(dv|dovi|dolby[ .]?v(ision)?)\\b"
       }
-    },
-    {
-      "name": "Not WEBDL",
-      "implementation": "SourceSpecification",
-      "negate": true,
-      "required": true,
-      "fields": {
-        "value": 7
-      }
-    },
-    {
-      "name": "Not WEBRIP",
-      "implementation": "SourceSpecification",
-      "negate": true,
-      "required": true,
-      "fields": {
-        "value": 8
-      }
     }
   ]
 }


### PR DESCRIPTION
# Pull Request

## Purpose

Allow the Dynamic Generated HDR custom format to match WEBDL releases by groups who also use non-retail HDR

## Approach

Remove WEBDL exclusion from Dynamic Generate HDR custom format

## Open Questions and Pre-Merge TODOs
None

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Enhancements:
- Remove WEBDL exclusion from the Dynamic Generate HDR custom format to include group-sourced non-retail HDR releases