### PR TITLE
feat(sonarr-anime): add KHFR to french anime fansub

### DIFF
--- a/docs/json/sonarr/cf/french-anime-fansub.json
+++ b/docs/json/sonarr/cf/french-anime-fansub.json
@@ -106,6 +106,15 @@
       "fields": {
         "value": "\\b(Yangire[ .-]?Raws)\\b"
       }
+    },
+    {
+      "name": "Kaoru Hana FR (KHFR)",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(KHFR)\\b"
+      }
     }
   ]
 }


### PR DESCRIPTION
# Pull Request

## Purpose

add team 'KHFR' to french anime fansub teams

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Enhancements:
- Include KHFR in the list of French anime fansub teams for Sonarr