### PR TITLE
fix(downloaders): updated mover-tuning-start and mover-tuning-end script to v20251112

### DIFF
--- a/includes/downloaders/mover-tuning-end.sh
+++ b/includes/downloaders/mover-tuning-end.sh
@@ -3,7 +3,7 @@ set -euo pipefail # Exit on error, undefined variables, and pipe failures
 
 # =====================================
 # Script: qBittorrent Cache Mover - End
-# Updated: 20251102
+# Updated: 20251112
 # =====================================
 
 # Get the directory where the script is located
@@ -11,6 +11,9 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # Source the config from the same directory
 source "$SCRIPT_DIR/mover-tuning.cfg"
+
+# Notification delay in seconds (helps ensure all notifications appear in Unraid)
+NOTIFICATION_DELAY=2
 
 # ================================
 # UTILITY FUNCTIONS
@@ -31,6 +34,8 @@ notify() {
 
     if [[ -x "$notify_cmd" ]]; then
         "$notify_cmd" -s "$subject" -d "$description"
+        # Add delay after each notification to prevent dropping
+        sleep "$NOTIFICATION_DELAY"
     fi
 }
 
@@ -271,7 +276,6 @@ process_qbit_instance() {
         --host "$host" \
         --user "$user" \
         --password "$password" \
-        --cache-mount "$CACHE_MOUNT" \
         --days_from "$DAYS_FROM" \
         --days_to "$DAYS_TO"; then
         log "✓ Successfully resumed torrents for $name"

--- a/includes/downloaders/mover-tuning-start.sh
+++ b/includes/downloaders/mover-tuning-start.sh
@@ -3,7 +3,7 @@ set -euo pipefail # Exit on error, undefined variables, and pipe failures
 
 # =======================================
 # Script: qBittorrent Cache Mover - Start
-# Updated: 20251102
+# Updated: 20251112
 # =======================================
 
 # Get the directory where the script is located
@@ -15,6 +15,9 @@ source "$SCRIPT_DIR/mover-tuning.cfg"
 readonly VENV_PATH="${QBIT_MOVER_PATH}.venv"
 readonly MOVER_SCRIPT="${QBIT_MOVER_PATH}mover.py"
 readonly MOVER_URL="https://raw.githubusercontent.com/StuffAnThings/qbit_manage/develop/scripts/mover.py"
+
+# Notification delay in seconds (helps ensure all notifications appear in Unraid)
+NOTIFICATION_DELAY=2
 
 # ================================
 # UTILITY FUNCTIONS
@@ -32,7 +35,12 @@ notify() {
     local subject="$1"
     local description="$2"
     local notify_cmd="/usr/local/emhttp/plugins/dynamix/scripts/notify"
-    [[ -x "$notify_cmd" ]] && "$notify_cmd" -s "$subject" -d "$description"
+
+    if [[ -x "$notify_cmd" ]]; then
+        "$notify_cmd" -s "$subject" -d "$description"
+        # Add delay after each notification to prevent dropping
+        sleep "$NOTIFICATION_DELAY"
+    fi
 }
 
 check_command() {


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->

- Added a two-second delay between the different scripts so unRaid can send the notifications.
- Removed the `--cache-mount` option from the mover-tuning-end script, because the files are moved to the array it wouldn't resume the files at the end of the run.

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

- Added a two-second delay between the different scripts so unRaid can send the notifications.
- Removed the `--cache-mount` option from the mover-tuning-end script, because the files are moved to the array it wouldn't resume the files at the end of the run.

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
