### PR TITLE
fix(starr): iT CF matching italian language code

### DIFF
--- a/docs/json/radarr/cf/it.json
+++ b/docs/json/radarr/cf/it.json
@@ -1,5 +1,6 @@
 {
   "trash_id": "e0ec9672be6cac914ffad34a6b077209",
+  "trash_regex": "https://regex101.com/r/ptwLDS/1",
   "name": "iT",
   "includeCustomFormatWhenRenaming": true,
   "specifications": [
@@ -18,7 +19,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "\\[(iT)\\b|\\b(iT)\\]"
+        "value": "\\[(iT)(?![+])\\b|\\b(?<![+])(iT)\\]"
       }
     },
     {

--- a/docs/json/sonarr/cf/it.json
+++ b/docs/json/sonarr/cf/it.json
@@ -3,6 +3,7 @@
   "trash_scores": {
     "default": 75
   },
+  "trash_regex": "https://regex101.com/r/ptwLDS/1",
   "name": "iT",
   "includeCustomFormatWhenRenaming": true,
   "specifications": [
@@ -21,7 +22,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "\\[(iT)\\b|\\b(iT)\\]"
+        "value": "\\[(iT)(?![+])\\b|\\b(?<![+])(iT)\\]"
       }
     },
     {


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->
Fix `iT` CF matching the Italian ISO language code.

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->
Update the regex in the `iT Rename` condition of the `iT` CF to no longer match for example `[IT+EN]` or `[EN+IT]`.

## Requirements

- [ ] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Bug Fixes:
- Restrict the Italian CF rename regex to match only standalone 'IT' language code, preventing false matches for composite tags like [IT+EN] or [EN+IT]