### PR TITLE
fix(radarr): fix image link

### DIFF
--- a/docs/Radarr/Tips/Radarr-remote-path-mapping.md
+++ b/docs/Radarr/Tips/Radarr-remote-path-mapping.md
@@ -101,7 +101,7 @@ Click on the browse button and browse to the location where the files are access
 
 The final result will look something like this:
 
-![!rpm-final-results]
+![!rpm-final-results](images/rpm-final-results.png)
 
 After these changes, the file should be able to be imported by Radarr.
 


### PR DESCRIPTION
# Pull Request

## Purpose

fix image link

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Documentation:
- Add missing image path to the rpm-final-results image link in the Radarr remote path mapping documentation