### PR TITLE
feat(radarr): Removed include Custom Format When Renaming For IMAX Enhanced

### DIFF
--- a/docs/json/radarr/cf/imax-enhanced.json
+++ b/docs/json/radarr/cf/imax-enhanced.json
@@ -5,7 +5,7 @@
   },
   "trash_regex": "https://regex101.com/r/e7ugxU/1",
   "name": "IMAX Enhanced",
-  "includeCustomFormatWhenRenaming": true,
+  "includeCustomFormatWhenRenaming": false,
   "specifications": [
     {
       "name": "IMAX Enhanced",


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->

Since a PR from a while ago for Radarr Imax Enhanced is recognized by Radarr as an edition, we're getting double-naming of the editions in the filename after import and rename. Our current CF is already set up to pick it up correctly.

Examples of what will change

```diff
- - Movie.2019.IMAX.BCORE.IMAX.Enhanced.WEBDL-2160p.TrueHD.Atmos.7.1.HDR10.HEVC-RlsGrp
+ - Movie.2019.IMAX.BCORE.WEBDL-2160p.TrueHD.Atmos.7.1.HDR10.HEVC-RlsGrp
- - Movie.2022.IMAX.DSNP.IMAX.Enhanced.WEBDL-2160p.TrueHD.Atmos.7.1.HDR10.h265-RlsGrp
+ - Movie.2022.WEBDL-2160p.TrueHD.Atmos.7.1.HDR10.h265-RlsGrp
- - Movie.2019.IMAX.DSNP.IMAX.Enhanced.WEBDL-2160p.TrueHD.Atmos.7.1.DV.HDR10.HEVC-RlsGrp
+ - Movie.2019.IMAX.DSNP.WEBDL-2160p.TrueHD.Atmos.7.1.DV.HDR10.HEVC-RlsGrp
```

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

Removed include Custom Format When Renaming For IMAX Enhanced

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Enhancements:
- Update the IMAX Enhanced custom format configuration so it is no longer included when generating Radarr rename patterns, preventing redundant 'IMAX Enhanced' tags in filenames.