### PR TITLE
feat(starr): Move RlsGrp RAWR from WEB Tier 02 to WEB Tier 01

### DIFF
--- a/docs/json/radarr/cf/web-tier-01.json
+++ b/docs/json/radarr/cf/web-tier-01.json
@@ -162,6 +162,15 @@
       }
     },
     {
+      "name": "RAWR",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(RAWR)$"
+      }
+    },
+    {
       "name": "SiC",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,

--- a/docs/json/radarr/cf/web-tier-02.json
+++ b/docs/json/radarr/cf/web-tier-02.json
@@ -99,15 +99,6 @@
       }
     },
     {
-      "name": "RAWR",
-      "implementation": "ReleaseGroupSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "^(RAWR)$"
-      }
-    },
-    {
       "name": "SbR",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,

--- a/docs/json/sonarr/cf/web-tier-01.json
+++ b/docs/json/sonarr/cf/web-tier-01.json
@@ -144,6 +144,15 @@
       }
     },
     {
+      "name": "RAWR",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(RAWR)$"
+      }
+    },
+    {
       "name": "RTN",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,

--- a/docs/json/sonarr/cf/web-tier-02.json
+++ b/docs/json/sonarr/cf/web-tier-02.json
@@ -288,15 +288,6 @@
       }
     },
     {
-      "name": "RAWR",
-      "implementation": "ReleaseGroupSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "^(RAWR)$"
-      }
-    },
-    {
       "name": "ROCCaT",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->

Moved RlsGrp RAWR from WEB Tier 02 to WEB Tier 01. They fill the gaps that other Tier 1 doesn't cover.

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

Moved RlsGrp RAWR from WEB Tier 02 to WEB Tier 01

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Reclassify RlsGrp RAWR WEB releases from Tier 02 to Tier 01 across Radarr and Sonarr custom format definitions.

Documentation:
- Update Radarr WEB Tier 01 and Tier 02 custom format JSON to move RlsGrp RAWR into Tier 01.
- Update Sonarr WEB Tier 01 and Tier 02 custom format JSON to move RlsGrp RAWR into Tier 01.