### PR TITLE
feat(radarr): Add RlsGrp `VisionXpert` to `Generated Dynamic HDR`

### DIFF
--- a/docs/json/radarr/cf/generated-dynamic-hdr.json
+++ b/docs/json/radarr/cf/generated-dynamic-hdr.json
@@ -71,6 +71,15 @@
       }
     },
     {
+      "name": "VisionXpert",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(VisionXpert)$"
+      }
+    },
+    {
       "name": "HDR10+",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->

Add RlsGrp `VisionXpert` to `Generated Dynamic HDR`

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

Added RlsGrp `VisionXpert` to `Generated Dynamic HDR`

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

New Features:
- Add the VisionXpert release group to the Generated Dynamic HDR custom format for Radarr.