### PR TITLE
feat(starr-french): Add THESYNDICATE to French Web tier

### DIFF
--- a/docs/json/radarr/cf/french-web-tier-01.json
+++ b/docs/json/radarr/cf/french-web-tier-01.json
@@ -147,6 +147,15 @@
       }
     },
     {
+      "name": "THESYNDiCATE",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(THESYNDiCATE)$"
+      }
+    },
+    {
       "name": "TiNA",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,

--- a/docs/json/sonarr/cf/french-web-tier-01.json
+++ b/docs/json/sonarr/cf/french-web-tier-01.json
@@ -120,6 +120,15 @@
       }
     },
     {
+      "name": "THESYNDiCATE",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(THESYNDiCATE)$"
+      }
+    },
+    {
       "name": "TiNA",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,


### PR DESCRIPTION
# Pull Request

## Purpose

Add THESYNDICATE to French Web tier

## Approach

-

## Open Questions and Pre-Merge TODOs

-

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Add THESYNDICATE to the French Web tier custom format definitions for both Radarr and Sonarr.

New Features:
- Include THESYNDICATE as an accepted group in the French Web Tier 01 custom format for Radarr.
- Include THESYNDICATE as an accepted group in the French Web Tier 01 custom format for Sonarr.