### PR TITLE
feat(radarr): Move RlsGrp BYNDR to WEB Tier 01

### DIFF
--- a/docs/json/radarr/cf/web-tier-01.json
+++ b/docs/json/radarr/cf/web-tier-01.json
@@ -63,6 +63,15 @@
       }
     },
     {
+      "name": "BYNDR",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(BYNDR)$"
+      }
+    },
+    {
       "name": "CMRG",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,

--- a/docs/json/radarr/cf/web-tier-02.json
+++ b/docs/json/radarr/cf/web-tier-02.json
@@ -27,15 +27,6 @@
       }
     },
     {
-      "name": "BYNDR",
-      "implementation": "ReleaseGroupSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "^(BYNDR)$"
-      }
-    },
-    {
       "name": "dB",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->

One of the few groups that are doing 4k MA or 4k NF, including 1080p MA, where many other groups don't go beyond AMZN.

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

Move RlsGrp `BYNDR` from `WEB Tier 02` to `WEB Tier 01`

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Enhancements:
- Promote the BYNDR release group from WEB Tier 02 to WEB Tier 01 in the Radarr custom format JSON configuration.