### PR TITLE
fix(downloaders): Update Fixing Run Errors script

### DIFF
--- a/docs/Downloaders/qBittorrent/Tips/How-to-run-the-unRaid-mover-for-qBittorrent.md
+++ b/docs/Downloaders/qBittorrent/Tips/How-to-run-the-unRaid-mover-for-qBittorrent.md
@@ -125,10 +125,10 @@ chmod +x /mnt/user/appdata/qbt-mover/mover-tuning-end.sh
 
 After editing the scripts, make sure they use LF line endings (Unix format). If you edited the files on Windows, they may have CRLF line endings, which can cause errors.
 
-Run the following command to convert all `.sh` and `.cfg` files to the correct format:
+Run the following command to convert line endings in all .sh and .cfg files from Windows format (CRLF) to Unix format (LF), and make the scripts executable:
 
 ```bash
-for file in *.sh *.cfg; do [ -f "$file" ] && sed -i 's/\r$//' "$file" && echo "Converted $file"; done
+for file in *.sh *.cfg *.py; do [ -f "$file" ] && sed -i 's/\r$//' "$file" && echo "Converted $file"; done && chmod +x *.sh *.py 2>/dev/null
 ```
 
 **How to use this command:**


### PR DESCRIPTION
# Pull Request

## Purpose

Add chmod +x to the Fix Run Errors script so we are sure all scripts are executable.

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x ] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x ] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Documentation:
- Clarify instructions for converting .sh, .cfg, and .py files from CRLF to LF and marking shell and Python scripts as executable in the qBittorrent unRAID mover guide.