### PR TITLE
feat(starr): Add RlsGrp `HHWEB` to WEB Tier 03

### DIFF
--- a/docs/json/radarr/cf/web-tier-03.json
+++ b/docs/json/radarr/cf/web-tier-03.json
@@ -9,6 +9,24 @@
   "includeCustomFormatWhenRenaming": false,
   "specifications": [
     {
+      "name": "WEBDL",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 7
+      }
+    },
+    {
+      "name": "WEBRIP",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 8
+      }
+    },
+    {
       "name": "Dooky",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,
@@ -87,24 +105,6 @@
       "required": false,
       "fields": {
         "value": "^(SwAgLaNdEr)$"
-      }
-    },
-    {
-      "name": "WEBDL",
-      "implementation": "SourceSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": 7
-      }
-    },
-    {
-      "name": "WEBRIP",
-      "implementation": "SourceSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": 8
       }
     }
   ]

--- a/docs/json/sonarr/cf/web-tier-03.json
+++ b/docs/json/sonarr/cf/web-tier-03.json
@@ -9,6 +9,24 @@
   "includeCustomFormatWhenRenaming": false,
   "specifications": [
     {
+      "name": "WEBDL",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 3
+      }
+    },
+    {
+      "name": "WEBRIP",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 4
+      }
+    },
+    {
       "name": "Dooky",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,
@@ -78,24 +96,6 @@
       "required": false,
       "fields": {
         "value": "^(ViSiON)$"
-      }
-    },
-    {
-      "name": "WEBDL",
-      "implementation": "SourceSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": 3
-      }
-    },
-    {
-      "name": "WEBRIP",
-      "implementation": "SourceSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": 4
       }
     }
   ]


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->

Added RlsGrp `HHWEB` to WEB Tier 03. They have released a nice collection of MA WEB-DL releases.

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

Added RlsGrp `HHWEB` to WEB Tier 03

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Add the HHWEB release group to the WEB Tier 03 custom format configuration for both Radarr and Sonarr.

New Features:
- Include HHWEB as an accepted release group in the WEB Tier 03 profile for Radarr.
- Include HHWEB as an accepted release group in the WEB Tier 03 profile for Sonarr.