### PR TITLE
fix(starr): Cleaned up and improved readability of the regex for Repack1,2,3

### DIFF
--- a/docs/json/radarr/cf/repack-proper.json
+++ b/docs/json/radarr/cf/repack-proper.json
@@ -25,7 +25,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "\\b(?:(?:repack|proper)[23])\\b|\\bREAL\\.(?:REAL\\.)?(?:PROPER|REPACK)\\b"
+        "value": "\\b((repack|proper)[23])\\b|\\bREAL\\.(REAL\\.)?(PROPER|REPACK)\\b"
       }
     }
   ]

--- a/docs/json/radarr/cf/repack2.json
+++ b/docs/json/radarr/cf/repack2.json
@@ -11,7 +11,7 @@
   "includeCustomFormatWhenRenaming": true,
   "specifications": [
     {
-      "name": "Repack/Proper 2 or Real Proper/Repack",
+      "name": "Repack/Proper 2 or REAL.PROPER/REPACK",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,
       "required": true,
@@ -20,13 +20,14 @@
       }
     },
     {
-      "name": "Not Higher Version Repack/Proper",
+      "name": "Not Repack/Proper 3",
       "implementation": "ReleaseTitleSpecification",
       "negate": true,
       "required": true,
       "fields": {
-        "value": "\\b((repack|proper)3)\\b|\\b(REAL\\.REAL\\.(PROPER|REPACK))\\b"
+        "value": "\\b((repack|proper)3)\\b|\\bREAL\\.(REAL\\.)(PROPER|REPACK)\\b"
       }
     }
   ]
 }
+

--- a/docs/json/radarr/cf/repack3.json
+++ b/docs/json/radarr/cf/repack3.json
@@ -11,7 +11,7 @@
   "includeCustomFormatWhenRenaming": true,
   "specifications": [
     {
-      "name": "Repack/Proper 3 or Real Real Proper/Repack",
+      "name": "Repack/Proper 3 or REAL.REAL.PROPER/REPACK",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,
       "required": true,

--- a/docs/json/sonarr/cf/repack-proper.json
+++ b/docs/json/sonarr/cf/repack-proper.json
@@ -25,7 +25,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "\\b(?:(?:repack|proper)[23])\\b|\\bREAL\\.(?:REAL\\.)?(?:PROPER|REPACK)\\b"
+        "value": "\\b((repack|proper)[23])\\b|\\bREAL\\.(REAL\\.)?(PROPER|REPACK)\\b"
       }
     }
   ]

--- a/docs/json/sonarr/cf/repack2.json
+++ b/docs/json/sonarr/cf/repack2.json
@@ -6,11 +6,12 @@
     "french-anime-multi": 2,
     "french-anime-vostfr": 2
   },
+  "trash_regex": "https://regex101.com/r/kQ4oeP/1",
   "name": "Repack2",
   "includeCustomFormatWhenRenaming": true,
   "specifications": [
     {
-      "name": "Repack/Proper 2 or Real Proper/Repack",
+      "name": "Repack/Proper 2 or REAL.PROPER/REPACK",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,
       "required": true,
@@ -19,12 +20,12 @@
       }
     },
     {
-      "name": "Not Higher Version Repack/Proper",
+      "name": "Not Repack/Proper 3",
       "implementation": "ReleaseTitleSpecification",
       "negate": true,
       "required": true,
       "fields": {
-        "value": "\\b((repack|proper)3)\\b|\\b(REAL\\.REAL\\.(PROPER|REPACK))\\b"
+        "value": "\\b((repack|proper)3)\\b|\\bREAL\\.(REAL\\.)(PROPER|REPACK)\\b"
       }
     }
   ]

--- a/docs/json/sonarr/cf/repack3.json
+++ b/docs/json/sonarr/cf/repack3.json
@@ -6,11 +6,12 @@
     "french-anime-multi": 3,
     "french-anime-vostfr": 3
   },
+  "trash_regex": "https://regex101.com/r/7YIkWD/1",
   "name": "Repack3",
   "includeCustomFormatWhenRenaming": true,
   "specifications": [
     {
-      "name": "Repack/Proper 3 or Real Real Proper/Repack",
+      "name": "Repack/Proper 3 or REAL.REAL.PROPER/REPACK",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,
       "required": true,


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->

Cleaned up and improved readability of the regex for Repack1,2,3

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

Cleaned up and improved readability of the regex for Repack1,2,3

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Refine Radarr and Sonarr Repack/Repack2/Repack3 custom format definitions to use clearer, more maintainable regular expressions for detecting repacks and propers.

Enhancements:
- Simplify and improve the readability of regex patterns in Radarr Repack/Repack2/Repack3 custom format JSON definitions.
- Align Sonarr Repack/Repack2/Repack3 custom format JSON regex patterns with the cleaned-up, more readable structure used for Radarr.