### PR TITLE
feat(guide-sync): Add trash_url to quality profile JSON files

### DIFF
--- a/docs/json/radarr/quality-profiles/anime-remux-1080p.json
+++ b/docs/json/radarr/quality-profiles/anime-remux-1080p.json
@@ -2,6 +2,7 @@
   "trash_id": "722b624f9af1e492284c4bc842153a38",
   "name": "[Anime] Remux-1080p",
   "trash_description": "Anime Quality Profile that covers:<br>- SDTV, DVD<br>- HDTV 720p, 1080p<br>- WEBDL: 480p, 720, 1080p<br>- Bluray 480p, 576p, 720p, 1080p<br>- Remux 1080p",
+  "trash_url": "https://trash-guides.info/Radarr/radarr-setup-quality-profiles-anime/#quality-profile",
   "group": 81,
   "trash_score_set": "anime-radarr",
   "upgradeAllowed": true,

--- a/docs/json/radarr/quality-profiles/french-multi-vo-hd-bluray-web.json
+++ b/docs/json/radarr/quality-profiles/french-multi-vo-hd-bluray-web.json
@@ -2,6 +2,7 @@
   "trash_id": "2572ce3ea4eef1c19d59e0e20ed1cea7",
   "name": "[French MULTi.VO] HD Bluray + WEB",
   "trash_description": "French Quality Profile that covers:<br>- WEBDL: 1080p<br>- Bluray 720p, 1080p",
+  "trash_url": "https://trash-guides.info/Radarr/radarr-setup-quality-profiles-french-en/#hd-bluray-web-1080p",
   "group": "21",
   "trash_score_set": "french-multi-vo",
   "upgradeAllowed": true,

--- a/docs/json/radarr/quality-profiles/french-multi-vo-hd-remux-web.json
+++ b/docs/json/radarr/quality-profiles/french-multi-vo-hd-remux-web.json
@@ -2,6 +2,7 @@
   "trash_id": "c6460a102b312200c095a2d0982e0461",
   "name": "[French MULTi.VO] HD Remux (1080p)",
   "trash_description": "French Quality Profile that covers:<br>- WEBDL: 1080p<br>- Bluray 1080p<br>- Remux: 1080p",
+  "trash_url": "https://trash-guides.info/Radarr/radarr-setup-quality-profiles-french-en/#hd-remux-1080p",
   "group": "21",
   "trash_score_set": "french-multi-vo",
   "upgradeAllowed": true,

--- a/docs/json/radarr/quality-profiles/french-multi-vo-uhd-bluray-web.json
+++ b/docs/json/radarr/quality-profiles/french-multi-vo-uhd-bluray-web.json
@@ -2,6 +2,7 @@
   "trash_id": "92ead7022d13a7858d54e328e6a2f8f9",
   "name": "[French MULTi.VO] UHD Bluray + WEB",
   "trash_description": "French Quality Profile that covers:<br>- WEBDL: 1080p, 2160p<br>- Bluray: 2160p<br>- Remux: 1080p",
+  "trash_url": "https://trash-guides.info/Radarr/radarr-setup-quality-profiles-french-en/#uhd-bluray-web-2160p",
   "group": "21",
   "trash_score_set": "french-multi-vo",
   "upgradeAllowed": true,

--- a/docs/json/radarr/quality-profiles/french-multi-vo-uhd-remux-web.json
+++ b/docs/json/radarr/quality-profiles/french-multi-vo-uhd-remux-web.json
@@ -2,6 +2,7 @@
   "trash_id": "1fef28c8c919f31cd86283b1baf527d4",
   "name": "[French MULTi.VO] UHD Remux (2160p)",
   "trash_description": "French Quality Profile that covers:<br>- WEBDL: 1080p, 2160p<br>- Bluray: 2160p<br>- Remux: 2160p",
+  "trash_url": "https://trash-guides.info/Radarr/radarr-setup-quality-profiles-french-en/#uhd-remux-2160p",
   "group": "21",
   "trash_score_set": "french-multi-vo",
   "upgradeAllowed": true,

--- a/docs/json/radarr/quality-profiles/german-hd-bluray-web.json
+++ b/docs/json/radarr/quality-profiles/german-hd-bluray-web.json
@@ -2,6 +2,7 @@
   "trash_id": "2b90e905c99490edc7c7a5787443748b",
   "name": "[German] HD Bluray + WEB",
   "trash_description": "German Quality Profile that covers:<br>- WEBDL: 720p, 1080p<br>- Bluray: 720p, 1080p",
+  "trash_url": "https://trash-guides.info/Radarr/radarr-setup-quality-profiles-german-en/#hd-bluray-web",
   "group": 11,
   "trash_score_set": "german",
   "upgradeAllowed": true,

--- a/docs/json/radarr/quality-profiles/german-hd-remux-web.json
+++ b/docs/json/radarr/quality-profiles/german-hd-remux-web.json
@@ -2,6 +2,7 @@
   "trash_id": "c13c33fdd2c306266b34cb9946de5919",
   "name": "[German] HD Remux + WEB",
   "trash_description": "German Quality Profile that covers:<br>- WEBDL: 1080p<br>- Remux: 1080p",
+  "trash_url": "https://trash-guides.info/Radarr/radarr-setup-quality-profiles-german-en/#hd-remux-web",
   "group": 11,
   "trash_score_set": "german",
   "upgradeAllowed": true,

--- a/docs/json/radarr/quality-profiles/german-uhd-bluray-web-alternative.json
+++ b/docs/json/radarr/quality-profiles/german-uhd-bluray-web-alternative.json
@@ -2,6 +2,7 @@
   "trash_id": "425da1ba30711b55d2eb371437ec98d7",
   "name": "[German] UHD Bluray + WEB (Alternative)",
   "trash_description": "German Quality Profile that covers:<br>- WEBDL: 720p, 1080p, 2160p<br>- Bluray: 720p, 1080p, 2160p",
+  "trash_url": "https://trash-guides.info/Radarr/radarr-setup-quality-profiles-german-en/#uhd-bluray-web",
   "group": 12,
   "trash_score_set": "german",
   "upgradeAllowed": true,

--- a/docs/json/radarr/quality-profiles/german-uhd-bluray-web.json
+++ b/docs/json/radarr/quality-profiles/german-uhd-bluray-web.json
@@ -2,6 +2,7 @@
   "trash_id": "27cc3d153c0a799fd139ef1ff4c4cc42",
   "name": "[German] UHD Bluray + WEB",
   "trash_description": "German Quality Profile that covers:<br>- WEBDL: 2160p<br>- Bluray: 2160p",
+  "trash_url": "https://trash-guides.info/Radarr/radarr-setup-quality-profiles-german-en/#uhd-bluray-web",
   "group": 11,
   "trash_score_set": "german",
   "upgradeAllowed": true,

--- a/docs/json/radarr/quality-profiles/german-uhd-remux-web.json
+++ b/docs/json/radarr/quality-profiles/german-uhd-remux-web.json
@@ -2,6 +2,7 @@
   "trash_id": "79faa9943cef2f510b997b1f2a9f3ea6",
   "name": "[German] Remux + WEB 2160p",
   "trash_description": "German Quality Profile that covers:<br>- WEBDL: 2160p<br>- Remux: 2160p",
+  "trash_url": "https://trash-guides.info/Radarr/radarr-setup-quality-profiles-german-en/#uhd-remux-web",
   "group": 11,
   "trash_score_set": "german",
   "upgradeAllowed": true,

--- a/docs/json/radarr/quality-profiles/hd-bluray-web.json
+++ b/docs/json/radarr/quality-profiles/hd-bluray-web.json
@@ -2,6 +2,7 @@
   "trash_id": "d1d67249d3890e49bc12e275d989a7e9",
   "name": "HD Bluray + WEB",
   "trash_description": "Quality Profile that covers:<br>- WEBDL: 1080p<br>- Bluray: 720p, 1080p",
+  "trash_url": "https://trash-guides.info/Radarr/radarr-setup-quality-profiles/#hd-bluray-web",
   "group": 1,
   "upgradeAllowed": true,
   "cutoff": "Bluray-1080p",

--- a/docs/json/radarr/quality-profiles/remux-2160p-alternative.json
+++ b/docs/json/radarr/quality-profiles/remux-2160p-alternative.json
@@ -2,6 +2,7 @@
   "trash_id": "dd3cd75deb9645bae838d1c5da6388d5",
   "name": "Remux 2160p (Alternative)",
   "trash_description": "Quality Profile that covers:<br>- SDTV, DVD<br>- HDTV: 720p, 1080p<br>- WEBDL: 480p, 720, 1080p, 2160p<br>- Bluray: 480p, 576p, 720p, 1080p, 2160p<br>- Remux: 1080p, 2160p",
+  "trash_url": "https://trash-guides.info/Radarr/radarr-setup-quality-profiles/#remux-web-2160p",
   "group": 2,
   "upgradeAllowed": true,
   "cutoff": "Remux-2160p",

--- a/docs/json/radarr/quality-profiles/remux-2160p-combined.json
+++ b/docs/json/radarr/quality-profiles/remux-2160p-combined.json
@@ -2,6 +2,7 @@
   "trash_id": "d1d310673359205736b4b84acd5ea8c8",
   "name": "Remux 2160p (Combined)",
   "trash_description": "Quality Profile that covers:<br>- WEBDL: 1080p, 2160p<br>- Bluray: 1080p, 2160p<br>- Remux: 1080p, 2160p",
+  "trash_url": "https://trash-guides.info/Radarr/radarr-setup-quality-profiles/#remux-web-2160p",
   "group": 2,
   "upgradeAllowed": true,
   "cutoff": "Remux-2160p",

--- a/docs/json/radarr/quality-profiles/remux-web-1080p.json
+++ b/docs/json/radarr/quality-profiles/remux-web-1080p.json
@@ -2,6 +2,7 @@
   "trash_id": "9ca12ea80aa55ef916e3751f4b874151",
   "name": "Remux + WEB 1080p",
   "trash_description": "Quality Profile that covers:<br>- WEBDL: 1080p<br>- Remux: 1080p",
+  "trash_url": "https://trash-guides.info/Radarr/radarr-setup-quality-profiles/#remux-web-1080p",
   "group": 1,
   "upgradeAllowed": true,
   "cutoff": "Remux-1080p",

--- a/docs/json/radarr/quality-profiles/remux-web-2160p.json
+++ b/docs/json/radarr/quality-profiles/remux-web-2160p.json
@@ -2,6 +2,7 @@
   "trash_id": "fd161a61e3ab826d3a22d53f935696dd",
   "name": "Remux + WEB 2160p",
   "trash_description": "Quality Profile that covers:<br>- WEBDL: 2160p<br>- Remux: 2160p",
+  "trash_url": "https://trash-guides.info/Radarr/radarr-setup-quality-profiles/#remux-web-2160p",
   "group": 1,
   "upgradeAllowed": true,
   "cutoff": "Remux-2160p",

--- a/docs/json/radarr/quality-profiles/uhd-bluray-web.json
+++ b/docs/json/radarr/quality-profiles/uhd-bluray-web.json
@@ -2,6 +2,7 @@
   "trash_id": "64fb5f9858489bdac2af690e27c8f42f",
   "name": "UHD Bluray + WEB",
   "trash_description": "Quality Profile that covers:<br>- WEBDL: 2160p<br>- Bluray: 2160p",
+  "trash_url": "https://trash-guides.info/Radarr/radarr-setup-quality-profiles/#uhd-bluray-web",
   "group": 1,
   "upgradeAllowed": true,
   "cutoff": "Bluray-2160p",

--- a/docs/json/sonarr/quality-profiles/anime-remux-1080p.json
+++ b/docs/json/sonarr/quality-profiles/anime-remux-1080p.json
@@ -2,6 +2,7 @@
   "trash_id": "20e0fc959f1f1704bed501f23bdae76f",
   "name": "[Anime] Remux-1080p",
   "trash_description": "Anime Quality Profile that covers:<br>- SDTV, DVD<br>- HDTV 720p, 1080p<br>- WEBDL: 480p, 720, 1080p<br>- Bluray 480p, 576p, 720p, 1080p<br>- Remux 1080p",
+  "trash_url": "https://trash-guides.info/Sonarr/sonarr-setup-quality-profiles-anime/#quality-profile",
   "group": 81,
   "trash_score_set": "anime-sonarr",
   "upgradeAllowed": true,

--- a/docs/json/sonarr/quality-profiles/french-multi-vo-bluray-web-1080p.json
+++ b/docs/json/sonarr/quality-profiles/french-multi-vo-bluray-web-1080p.json
@@ -3,6 +3,7 @@
   "trash_id": "4c48f506c1116a3a57ae33f12346bd15",
   "name": "[French MULTi.VO] HD Bluray + WEB (1080p)",
   "trash_description": "French Quality Profile that covers:<br>- WEBDL: 720p, 1080p<br>- Bluray 720p, 1080p",
+  "trash_url": "https://trash-guides.info/Sonarr/sonarr-setup-quality-profiles-french-en/#hd-bluray-web-1080p",
   "group": "21",
   "trash_score_set": "french-multi-vo",
   "upgradeAllowed": true,

--- a/docs/json/sonarr/quality-profiles/french-multi-vo-bluray-web-2160p.json
+++ b/docs/json/sonarr/quality-profiles/french-multi-vo-bluray-web-2160p.json
@@ -3,6 +3,7 @@
   "trash_id": "6fa7364373e8f06206871d9c20a4fb3e",
   "name": "[French MULTi.VO] UHD Bluray + WEB (2160p)",
   "trash_description": "French Quality Profile that covers:<br>- WEBDL: 1080p, 2160p<br>- Bluray 1080p, 2160p",
+  "trash_url": "https://trash-guides.info/Sonarr/sonarr-setup-quality-profiles-french-en/#uhd-bluray-web-2160p",
   "group": "21",
   "trash_score_set": "french-multi-vo",
   "upgradeAllowed": true,

--- a/docs/json/sonarr/quality-profiles/german-hd-bluray-web.json
+++ b/docs/json/sonarr/quality-profiles/german-hd-bluray-web.json
@@ -2,6 +2,7 @@
   "trash_id": "dca7e5e9e99c703bcbdaaa471dd40e98",
   "name": "[German] HD Bluray + WEB",
   "trash_description": "German Quality Profile that covers:<br>- WEBDL: 720p, 1080p<br>- Bluray: 720p, 1080p",
+  "trash_url": "https://trash-guides.info/Sonarr/sonarr-setup-quality-profiles-german-en/#hd-bluray-web",
   "group": 11,
   "trash_score_set": "german",
   "upgradeAllowed": true,

--- a/docs/json/sonarr/quality-profiles/german-hd-remux-web.json
+++ b/docs/json/sonarr/quality-profiles/german-hd-remux-web.json
@@ -2,6 +2,7 @@
   "trash_id": "0dd5f085ed61a1e01f6d347779dfa1bc",
   "name": "[German] HD Remux + WEB",
   "trash_description": "German Quality Profile that covers:<br>- WEBDL: 1080p<br>- Remux: 1080p",
+  "trash_url": "https://trash-guides.info/Sonarr/sonarr-setup-quality-profiles-german-en/#hd-remux-web",
   "group": 11,
   "trash_score_set": "german",
   "upgradeAllowed": true,

--- a/docs/json/sonarr/quality-profiles/german-uhd-bluray-web-alternative.json
+++ b/docs/json/sonarr/quality-profiles/german-uhd-bluray-web-alternative.json
@@ -2,6 +2,7 @@
   "trash_id": "7324309a7d1e10dc0dc2cea6c70ed852",
   "name": "[German] UHD Bluray + WEB (Alternative)",
   "trash_description": "German Quality Profile that covers:<br>- WEBDL: 720p, 1080p, 2160p<br>- Bluray: 720p, 1080p, 2160p",
+  "trash_url": "https://trash-guides.info/Sonarr/sonarr-setup-quality-profiles-german-en/#uhd-bluray-web-2160p",
   "group": 12,
   "trash_score_set": "german",
   "upgradeAllowed": true,

--- a/docs/json/sonarr/quality-profiles/german-uhd-bluray-web.json
+++ b/docs/json/sonarr/quality-profiles/german-uhd-bluray-web.json
@@ -2,6 +2,7 @@
   "trash_id": "3b0fa37fddaaefc931b75f2889d4b4f5",
   "name": "[German] UHD Bluray + WEB",
   "trash_description": "German Quality Profile that covers:<br>- WEBDL: 2160p<br>- Bluray: 2160p",
+  "trash_url": "https://trash-guides.info/Sonarr/sonarr-setup-quality-profiles-german-en/#uhd-bluray-web-2160p",
   "group": 11,
   "trash_score_set": "german",
   "upgradeAllowed": true,

--- a/docs/json/sonarr/quality-profiles/german-uhd-remux-web.json
+++ b/docs/json/sonarr/quality-profiles/german-uhd-remux-web.json
@@ -2,6 +2,7 @@
   "trash_id": "08cececf1840290f6fd490b7d79e8642",
   "name": "[German] UHD Remux + WEB",
   "trash_description": "German Quality Profile that covers:<br>- WEBDL: 2160p<br>- Remux: 2160p",
+  "trash_url": "https://trash-guides.info/Sonarr/sonarr-setup-quality-profiles-german-en/#uhd-remux-web-2160p",
   "group": 11,
   "trash_score_set": "german",
   "upgradeAllowed": true,

--- a/docs/json/sonarr/quality-profiles/web-1080p-alternative.json
+++ b/docs/json/sonarr/quality-profiles/web-1080p-alternative.json
@@ -2,6 +2,7 @@
   "trash_id": "9d142234e45d6143785ac55f5a9e8dc9",
   "name": "WEB-1080p (Alternative)",
   "trash_description": "Quality Profile that covers:<br>- SDTV, DVD<br>- HDTV 720p, 1080p<br>- WEBDL: 480p, 720, 1080p<br>- Bluray 480p, 576p, 720p, 1080p",
+  "trash_url": "https://trash-guides.info/Sonarr/sonarr-setup-quality-profiles/#web-1080p",
   "group": 2,
   "upgradeAllowed": true,
   "cutoff": "WEB 1080p",

--- a/docs/json/sonarr/quality-profiles/web-1080p.json
+++ b/docs/json/sonarr/quality-profiles/web-1080p.json
@@ -2,6 +2,7 @@
   "trash_id": "72dae194fc92bf828f32cde7744e51a1",
   "name": "WEB-1080p",
   "trash_description": "Quality Profile that covers:<br>- WEBDL: 1080p",
+  "trash_url": "https://trash-guides.info/Sonarr/sonarr-setup-quality-profiles/#web-1080p",
   "group": 1,
   "upgradeAllowed": true,
   "cutoff": "WEB 1080p",

--- a/docs/json/sonarr/quality-profiles/web-2160p-alternative.json
+++ b/docs/json/sonarr/quality-profiles/web-2160p-alternative.json
@@ -2,6 +2,7 @@
   "trash_id": "dfa5eaae7894077ad6449169b6eb03e0",
   "name": "WEB-2160p (Alternative)",
   "trash_description": "Quality Profile that covers:<br>- SDTV, DVD<br>- HDTV 720p, 1080p<br>- WEBDL: 480p, 720, 1080p, 2160p<br>- Bluray 480p, 576p, 720p, 1080p, 2160p",
+  "trash_url": "https://trash-guides.info/Sonarr/sonarr-setup-quality-profiles/#web-2160p",
   "group": 4,
   "upgradeAllowed": true,
   "cutoff": "WEB 2160p",

--- a/docs/json/sonarr/quality-profiles/web-2160p-combined.json
+++ b/docs/json/sonarr/quality-profiles/web-2160p-combined.json
@@ -2,6 +2,7 @@
   "trash_id": "c4cadd6b35b95f62c3d47a408e53e2f7",
   "name": "WEB-2160p (Combined)",
   "trash_description": "Quality Profile that covers:<br>- WEBDL: 1080p, 2160p",
+  "trash_url": "https://trash-guides.info/Sonarr/sonarr-setup-quality-profiles/#web-2160p",
   "group": 4,
   "upgradeAllowed": true,
   "cutoff": "WEB 2160p",

--- a/docs/json/sonarr/quality-profiles/web-2160p.json
+++ b/docs/json/sonarr/quality-profiles/web-2160p.json
@@ -2,6 +2,7 @@
   "trash_id": "d1498e7d189fbe6c7110ceaabb7473e6",
   "name": "WEB-2160p",
   "trash_description": "Quality Profile that covers:<br>- WEBDL: 2160p",
+  "trash_url": "https://trash-guides.info/Sonarr/sonarr-setup-quality-profiles/#web-2160p",
   "group": 3,
   "upgradeAllowed": true,
   "cutoff": "WEB 2160p",


### PR DESCRIPTION
## Summary

- Add `trash_url` property to quality profile JSON files for Radarr and Sonarr
- Enables third-party sync tools to link users directly to documentation pages

## Context

Per Discord discussion with TRaSH, this adds a new `trash_url` field to quality profile JSON files that tools like Recyclarr can use to provide clickable hyperlinks to the relevant trash-guides.info documentation page.

Example:
```json
{
  "trash_id": "72dae194fc92bf828f32cde7744e51a1",
  "name": "WEB-1080p",
  "trash_description": "Quality Profile that covers:<br>- WEBDL: 1080p",
  "trash_url": "https://trash-guides.info/Sonarr/sonarr-setup-quality-profiles/#web-1080p",
  "group": 1,
  ...
}
```

## Changes

- **29 files updated** with `trash_url` property
  - 13 Sonarr quality profiles
  - 16 Radarr quality profiles

- **9 SQP profiles excluded** (no public documentation - users directed to Discord)

## Notes

- Variant profiles (Alternative, Combined) link to same anchor as base profile
- URLs point to specific anchor links on trash-guides.info documentation pages

## Summary by Sourcery

Add documentation links to Radarr and Sonarr quality profile JSON definitions to support guide-aware sync tooling.

New Features:
- Expose a trash_url field on supported Radarr and Sonarr quality profile JSON files to link directly to their corresponding trash-guides.info documentation anchors.

Enhancements:
- Align variant quality profiles (e.g., alternative/combined) to share documentation anchors with their base profiles where applicable.