### PR TITLE
fix(starr-french): Avoid false positive with Tanoshii in the release title

### DIFF
--- a/docs/json/radarr/cf/french-anime-tier-01.json
+++ b/docs/json/radarr/cf/french-anime-tier-01.json
@@ -77,7 +77,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "\\b(TANOSHii)\\b"
+        "value": "\\b(-TANOSHii)\\b"
       }
     },
     {

--- a/docs/json/sonarr/cf/french-anime-tier-01.json
+++ b/docs/json/sonarr/cf/french-anime-tier-01.json
@@ -77,7 +77,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "\\b(TANOSHii)\\b"
+        "value": "\\b(-TANOSHii)\\b"
       }
     },
     {


### PR DESCRIPTION
# Pull Request

## Purpose

Certain release titles include `Tanoshii` as part of an anime title, for exemple :

`Easygoing Territory Defense by the Optimistic Lord S01E01 The Young Geniuss Harsh Expulsion From His Home 1080p CR WEB-DL AAC2.0 H.264-VARYG (Okiraku Ryoushu no Tanoshii Ryouchi Bouei, Multi-Subs)`

Because regex matching is case-insensitive, it can incorrectly match these releases and creating false positives.

This PR adjusts the regex to avoid incorrectly matching releases.

## Approach

Updated the relevant regex

## Requirements

- [X] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [X] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Bug Fixes:
- Refine the Tanoshii-related regex in French anime tier-01 Radarr and Sonarr configs to prevent matching releases where it appears as part of an anime title.