### PR TITLE
chore(prowlarr): Remove FlareSolverr warning

### DIFF
--- a/docs/Prowlarr/prowlarr-setup-flaresolverr.md
+++ b/docs/Prowlarr/prowlarr-setup-flaresolverr.md
@@ -8,8 +8,6 @@
     - A FlareSolverr Proxy will only be used for requests if and only if the Proxy and the Indexer have matching tags
     - A FlareSolverr Proxy configured without any tags or has no indexers with matching tags will be disabled.
 
-!!! bug "FlareSolverr is currently non-functional. It is also being monitored by the Cloudflare team, so it is unlikely to ever be fixed.<br><br>If you're using an indexer that needs FlaresSolverr and if they offer it, try another base URL till you find one that works. If none work, then you're out of luck.<br><br>There is no need to contact Servarr or Sonarr support. They are not the FlareSolverr support team and cannot help you with questions that don't relate specifically to adding FlareSolverr to Prowlarr.<br><br>FlareSolverr is a third-party program that solves Cloudflare captchas for some indexers. They use GitHub for support, and you should go there to ask them questions or catch up on the current status of the program.<br><br>The current open issue on their GitHub can be found [HERE](https://github.com/FlareSolverr/FlareSolverr/issues/1253){:target="\_blank" rel="noopener noreferrer"}"
-
 ## Install FlareSolverr
 
 Please follow the installation instruction from [FlareSolverr](https://github.com/FlareSolverr/FlareSolverr#installation){:target="\_blank" rel="noopener noreferrer"}


### PR DESCRIPTION
# Pull Request

## Purpose

I saw the warning about FlareSolverr being non-functional, but after checking the issue linked in the message (https://github.com/FlareSolverr/FlareSolverr/issues/1253), it appears that it has been fixed. Also, after testing myself I can confirm that FlareSolverr is now working as expected. So, I figure that this warning is now misleading, and should be removed so people don't automatically give up on FlareSolverr as a potential solution.

Sorry if I didn't set this PR up correctly, I can adjust it if that's preferred.

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Documentation:
- Remove the obsolete notice claiming FlareSolverr is currently non-functional from the Prowlarr FlareSolverr setup guide.