### PR TITLE
feat(downloaders): Add mover.py version check to the mover-tuning-start script

### DIFF
--- a/includes/downloaders/mover-tuning-start.sh
+++ b/includes/downloaders/mover-tuning-start.sh
@@ -4,11 +4,11 @@ set -euo pipefail # Exit on error, undefined variables, and pipe failures
 # =======================================
 # Script: qBittorrent Cache Mover - Start
 # Version: 1.2.0
-# Updated: 20260127
+# Updated: 20260128
 # =======================================
 
 # Script version and update check URLs
-readonly SCRIPT_VERSION="1.1.0"
+readonly SCRIPT_VERSION="1.2.0"
 readonly SCRIPT_RAW_URL="https://raw.githubusercontent.com/TRaSH-Guides/Guides/refs/heads/master/includes/downloaders/mover-tuning-start.sh"
 readonly CONFIG_RAW_URL="https://raw.githubusercontent.com/TRaSH-Guides/Guides/refs/heads/master/includes/downloaders/mover-tuning.cfg"
 
@@ -121,7 +121,7 @@ check_script_version() {
     log "Checking for script updates..."
 
     # Check if version check is enabled
-    if [[ "${ENABLE_VERSION_CHECK:-true}" != "true" ]]; then
+    if [[ "${ENABLE_VERSION_CHECK:-true}" != true ]]; then
         log "Version check disabled"
         return 0
     fi
@@ -184,7 +184,7 @@ check_config_version() {
     log "Checking for config file updates..."
 
     # Check if version check is enabled
-    if [[ "${ENABLE_VERSION_CHECK:-true}" != "true" ]]; then
+    if [[ "${ENABLE_VERSION_CHECK:-true}" != true ]]; then
         log "Config version check disabled"
         return 0
     fi
@@ -250,7 +250,7 @@ check_mover_version() {
     log "Checking for mover.py updates..."
 
     # Check if version check is enabled
-    if [[ "${ENABLE_VERSION_CHECK:-true}" != "true" ]]; then
+    if [[ "${ENABLE_VERSION_CHECK:-true}" != true ]]; then
         log "Mover version check disabled"
         return 0
     fi
@@ -291,10 +291,10 @@ check_mover_version() {
     local local_hash remote_hash
     if command -v sha256sum &> /dev/null; then
         local_hash=$(sha256sum "$MOVER_SCRIPT" | awk '{print $1}')
-        remote_hash=$(echo "$remote_mover" | sha256sum | awk '{print $1}')
+        remote_hash=$(printf '%s' "$remote_mover" | sha256sum | awk '{print $1}')
     else
         local_hash=$(md5sum "$MOVER_SCRIPT" | awk '{print $1}')
-        remote_hash=$(echo "$remote_mover" | md5sum | awk '{print $1}')
+        remote_hash=$(printf '%s' "$remote_mover" | md5sum | awk '{print $1}')
     fi
 
     # Compare hashes


### PR DESCRIPTION
# Pull Request

## Purpose

Add mover.py version check to the mover-tuning-start script

The mover.py script doesn't have a version number so Hash-based detection is used instead of version comparison:

Calculates SHA256 (or MD5 as fallback) hash of local mover.py
Fetches remote mover.py and calculates its hash
Compares the two - if they differ, sends an Unraid notification

Benefits of this approach:

Works without version numbers
Detects ANY changes to the file
Very reliable for detecting updates

- [x ] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x ] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Add automatic detection of updates to mover.py in the mover-tuning-start script using hash comparison against the GitHub version and wire it into the main execution flow.

New Features:
- Introduce a mover.py update check that compares local and remote script hashes and notifies Unraid when an update is available.

Enhancements:
- Bump the mover-tuning-start script version metadata to reflect the new functionality.