### PR TITLE
feat(downloaders): Make mover.py version check more robust

### DIFF
--- a/includes/downloaders/mover-tuning-start.sh
+++ b/includes/downloaders/mover-tuning-start.sh
@@ -290,16 +290,16 @@ check_mover_version() {
     # Calculate hashes (normalize line endings and trailing newlines)
     # Strip \r and trailing newlines to ensure consistent comparison
     local local_hash remote_hash local_content remote_content
-    
+
     # Read and normalize local file
     local_content=$(tr -d '\r' < "$MOVER_SCRIPT")
     # Remove trailing newlines by using parameter expansion
     local_content="${local_content%$'\n'}"
-    
+
     # Normalize remote content
     remote_content=$(printf '%s' "$remote_mover" | tr -d '\r')
     remote_content="${remote_content%$'\n'}"
-    
+
     if command -v sha256sum &> /dev/null; then
         local_hash=$(printf '%s' "$local_content" | sha256sum | awk '{print $1}')
         remote_hash=$(printf '%s' "$remote_content" | sha256sum | awk '{print $1}')
@@ -314,14 +314,14 @@ check_mover_version() {
     # Compare hashes
     if [[ "$local_hash" != "$remote_hash" ]]; then
         log "⚠ mover.py differs from GitHub version"
-        
+
         # Additional diagnostics
         local local_size remote_size
         local_size=$(wc -c < "$MOVER_SCRIPT")
         remote_size=$(printf '%s' "$remote_mover" | wc -c)
         log "Local size:  $local_size bytes"
         log "Remote size: $remote_size bytes"
-        
+
         notify "mover.py Update" "A newer version of mover.py is available on GitHub<br><br>📖 Delete mover.py and re-run script to update"
     else
         log "✓ mover.py is up to date"


### PR DESCRIPTION
# Pull Request

## Purpose

updated the hash calculation to use tr -d '\r' which removes all carriage return characters before hashing
This ensures both the local file and remote content are normalized to the same line ending format before comparison

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x ] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Improve robustness of mover-tuning start script version checking and hashing for mover.py updates.

Bug Fixes:
- Ensure ENABLE_VERSION_CHECK is correctly respected by comparing its value as the string "true".
- Normalize line endings before hashing local and remote mover.py files so version checks are reliable across different environments.

Enhancements:
- Bump mover-tuning-start.sh script version metadata to 1.2.1 to reflect the latest changes.