### PR TITLE
feat(starr-french): Move TFA from French Web Tier 1 to French Web Tier 2

### DIFF
--- a/docs/json/radarr/cf/french-web-tier-01.json
+++ b/docs/json/radarr/cf/french-web-tier-01.json
@@ -138,15 +138,6 @@
       }
     },
     {
-      "name": "TFA",
-      "implementation": "ReleaseGroupSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "^(TFA)$"
-      }
-    },
-    {
       "name": "TiNA",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,

--- a/docs/json/radarr/cf/french-web-tier-02.json
+++ b/docs/json/radarr/cf/french-web-tier-02.json
@@ -102,6 +102,15 @@
       }
     },
     {
+      "name": "TFA",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(TFA)$"
+      }
+    },
+    {
       "name": "TkHD",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,

--- a/docs/json/sonarr/cf/french-web-tier-01.json
+++ b/docs/json/sonarr/cf/french-web-tier-01.json
@@ -111,15 +111,6 @@
       }
     },
     {
-      "name": "TFA",
-      "implementation": "ReleaseGroupSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "^(TFA)$"
-      }
-    },
-    {
       "name": "TiNA",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,

--- a/docs/json/sonarr/cf/french-web-tier-02.json
+++ b/docs/json/sonarr/cf/french-web-tier-02.json
@@ -118,6 +118,15 @@
       "fields": {
         "value": "^(TAT)$"
       }
+    },
+    {
+      "name": "TFA",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(TFA)$"
+      }
     }
   ]
 }


### PR DESCRIPTION
# Pull Request

## Purpose

This PR moves TFA from French Web Tier 1 to French Web TIer 2

## Approach

TFA is a find team, but they have a tendancy to : 

- Include very low bitrate audio
- Include unnecessary tracks

While it remains a fine team, I thing the real Tier 1 teams should have precedence over TFA

## Requirements

- [X] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [X] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Update French Web release tier assignments for Radarr and Sonarr configurations.

Enhancements:
- Reclassify TFA from French Web Tier 1 to Tier 2 in Radarr configuration JSON.
- Reclassify TFA from French Web Tier 1 to Tier 2 in Sonarr configuration JSON.