### PR TITLE
feat(radarr): Added `YKW` to be matched as `MA` release

### DIFF
--- a/docs/json/radarr/cf/ma.json
+++ b/docs/json/radarr/cf/ma.json
@@ -4,7 +4,7 @@
     "default": 20,
     "sqp-4-ma-hybrid": 70
   },
-  "trash_regex": "https://regex101.com/r/B0AMvg/latest",
+  "trash_regex": "https://regex101.com/r/k6okQj/1",
   "name": "MA",
   "includeCustomFormatWhenRenaming": true,
   "specifications": [
@@ -14,7 +14,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "(?<!dts[ .-]?hd[ .-]?)\\bma\\b(?=.*\\bweb[ ._-]?(dl|rip)\\b)"
+        "value": "(?<!dts[ .-]?hd[ .-]?)\\b(ma|ykw)\\b(?=.*\\bweb[ ._-]?(dl|rip)\\b)"
       }
     }
   ]


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->

There is a certain release group that is intentionally vague about the source used. For them, there must be very good security-related reasons for it.
YKW stands for info in the release notes: Video sourced from **Y**ou**K**now**W**here

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

Added `YKW` to be matched as `MA` release and updated regex test case

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

New Features:
- Treat releases tagged with YKW as MA source in Radarr custom format matching.