### PR TITLE
fix(starr): update Upscaled CF

### DIFF
--- a/docs/json/radarr/cf/upscaled.json
+++ b/docs/json/radarr/cf/upscaled.json
@@ -59,7 +59,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "(?<=\\b[12]\\d{3}\\b).*\\b(AI[ ._-]?Enhanced|UPS(UHD)?|Upscaled?([ ._-]?UHD)?|UpRez)\\b"
+        "value": "(?<=\\b[12]\\d{3}\\b).*\\b(AI[ ._-]?Enhanced?|UPS(UHD)?|Upscaled?([ ._-]?UHD)?|UpRez)\\b"
       }
     }
   ]

--- a/docs/json/sonarr/cf/upscaled.json
+++ b/docs/json/sonarr/cf/upscaled.json
@@ -59,7 +59,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "(?<=\\b\\d{3,4}p\\b).*\\b(AI[ ._-]?Enhanced|UPS(UHD)?|Upscaled?([ ._-]?UHD)?|UpRez)\\b"
+        "value": "(?<=\\b\\d{3,4}p\\b).*\\b(AI[ ._-]?Enhanced?|UPS(UHD)?|Upscaled?([ ._-]?UHD)?|UpRez)\\b"
       }
     }
   ]


### PR DESCRIPTION
# Pull Request

## Purpose

Update Upscaled CF to catch more cases (`AI.Enhance` now matches as well as `AI.Enhanced`)

## Approach

Adjust regex to make final `d` in Enhanced optional (matching the existing optional `d` in Upscaled)

## Open Questions and Pre-Merge TODOs

<!-- - [x] Use GitHub checklists. When solved, check the box and explain the answer. -->

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).

(I think I have followed the contributing guide; I definitely followed the last change to these files)

## Summary by Sourcery

Bug Fixes:
- Adjust Upscaled custom format regex so both 'AI.Enhance' and 'AI.Enhanced' style tags are correctly matched in Radarr and Sonarr.