### PR TITLE
feat(starr): Add RlsGrp `BLOOM` to `WEB Tier 03`

### DIFF
--- a/docs/json/radarr/cf/web-tier-03.json
+++ b/docs/json/radarr/cf/web-tier-03.json
@@ -27,6 +27,15 @@
       }
     },
     {
+      "name": "BLOOM",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(BLOOM)$"
+      }
+    },
+    {
       "name": "Dooky",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,

--- a/docs/json/sonarr/cf/web-tier-03.json
+++ b/docs/json/sonarr/cf/web-tier-03.json
@@ -26,6 +26,15 @@
       }
     },
     {
+      "name": "BLOOM",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(BLOOM)$"
+      }
+    },
+    {
       "name": "Dooky",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->

Add RlsGrp `BLOOM` to `WEB Tier 03`

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

Add RlsGrp `BLOOM` to `WEB Tier 03`

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Add the BLOOM release group to the WEB Tier 03 configuration for both Radarr and Sonarr.

New Features:
- Include BLOOM in the WEB Tier 03 release group list for Radarr.
- Include BLOOM in the WEB Tier 03 release group list for Sonarr.