### PR TITLE
feat(guide): Add custom format group informational tables

### DIFF
--- a/docs/Radarr/Radarr-collection-of-custom-formats.md
+++ b/docs/Radarr/Radarr-collection-of-custom-formats.md
@@ -3517,13 +3517,6 @@ Custom Format Groups are logical groupings of custom formats used by sync tools 
     {%- endfor %}
 
 {% endif -%}
-
-??? example "JSON - [Click to show/hide]"
-
-    ```json
-    [[% filter indent(width=4) %]][[% include 'json/radarr/cf-groups/{{ key }}.json' %]][[% endfilter %]]
-    ```
-
 <sub><sup>[TOP](#index)</sup></sub>
 
 ---

--- a/docs/Sonarr/sonarr-collection-of-custom-formats.md
+++ b/docs/Sonarr/sonarr-collection-of-custom-formats.md
@@ -3545,13 +3545,6 @@ Custom Format Groups are logical groupings of custom formats used by sync tools 
     {%- endfor %}
 
 {% endif -%}
-
-??? example "JSON - [Click to show/hide]"
-
-    ```json
-    [[% filter indent(width=4) %]][[% include 'json/sonarr/cf-groups/{{ key }}.json' %]][[% endfilter %]]
-    ```
-
 <sub><sup>[TOP](#index)</sup></sub>
 
 ---


### PR DESCRIPTION
# Pull Request

## Purpose

Adds a new "Custom Format Groups" section to both the Radarr and Sonarr collection-of-custom-formats pages. Users have requested a human-readable reference for CF Groups, which are the logical groupings of custom formats used by downstream sync tools like Recyclarr and Notifiarr. This section is dynamically generated from the existing JSON data in docs/json/{radarr,sonarr}/cf-groups/, so it stays in sync automatically as groups are added, modified, or removed.

## Approach

- Uses Jinja2 templates (via the markdownextradata and macros plugins already in use) to loop over all cf-groups JSON files and render each group with:
  - Group metadata table (name, trash ID, default flag)
  - Collapsible description panel
  - Custom formats table with anchor links back to the individual CF sections
  - Collapsible quality profiles table
  - Collapsible raw JSON block
- Groups are sorted alphabetically by key and organised under category subheaders (Audio, HDR, Optional, etc.) extracted from the [Category] prefix in group names
- SQP groups are excluded entirely, and SQP quality profiles are filtered from the display within non-SQP groups
- An info admonition clarifies these are reference metadata for sync tools and not importable into Radarr/Sonarr
- INDEX table updated on both pages with a link to the new section

## Open Questions and Pre-Merge TODOs

- [x] Verify rendering on the live preview site before merge

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Add autogenerated reference sections for Custom Format Groups to the Radarr and Sonarr collection-of-custom-formats guides, including index entries linking to them.

New Features:
- Expose dynamically generated Custom Format Group tables in the Radarr and Sonarr custom formats documentation, sourced from existing JSON metadata and organized by category.
- Provide per-group summaries including metadata, descriptions, member custom formats, applicable quality profiles, and raw JSON for external sync tools.