### PR TITLE
fix(starr): update Upscaled CF

### DIFF
--- a/docs/json/radarr/cf/upscaled.json
+++ b/docs/json/radarr/cf/upscaled.json
@@ -59,7 +59,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "(?<=\\b[12]\\d{3}\\b).*\\b(AI[ ._-]?Enhanced?|UPS(UHD)?|Upscaled?([ ._-]?UHD)?|UpRez)\\b"
+        "value": "(?<=\\b[12]\\d{3}\\b).*\\b(AI[ ._-]?Enhanced?|UPS(UHD)?|[Uu]p[Ss]caled?([ ._-]?UHD)?|UpRez)\\b"
       }
     }
   ]

--- a/docs/json/sonarr/cf/upscaled.json
+++ b/docs/json/sonarr/cf/upscaled.json
@@ -59,7 +59,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "(?<=\\b\\d{3,4}p\\b).*\\b(AI[ ._-]?Enhanced?|UPS(UHD)?|Upscaled?([ ._-]?UHD)?|UpRez)\\b"
+        "value": "(?<=\\b\\d{3,4}p\\b).*\\b(AI[ ._-]?Enhanced?|UPS(UHD)?|[Uu]p[Ss]caled?([ ._-]?UHD)?|UpRez)\\b"
       }
     }
   ]


### PR DESCRIPTION
# Pull Request

## Purpose

Fixes the case of `UpScaled` (weird capitalization). Came across this and this filter didn't catch it.

Example: `Tora!Tora!Tora! (1970) UpScaled 2160p H265 10 bit DV HDR10+ ita eng AC3 5.1 sub ita eng-Licdom.mkv`

## Approach

Simply just changed the regex to be more case insensitive.

## Open Questions and Pre-Merge TODOs

N/A

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [X] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [X] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Bug Fixes:
- Ensure the Upscaled custom format correctly matches releases regardless of capitalization in both Radarr and Sonarr JSON definitions.