### PR TITLE
fix(starr-french): align Bad Dual Groups trash scores

### DIFF
--- a/docs/json/radarr/cf/bad-dual-groups.json
+++ b/docs/json/radarr/cf/bad-dual-groups.json
@@ -2,8 +2,8 @@
   "trash_id": "b6832f586342ef70d9c128d40c07b872",
   "trash_scores": {
     "default": -10000,
-    "french-multi-vf": 0,
-    "french-multi-vo": 0,
+    "french-multi-vf": -10000,
+    "french-multi-vo": -10000,
     "german": -35000
   },
   "name": "Bad Dual Groups",

--- a/docs/json/sonarr/cf/bad-dual-groups.json
+++ b/docs/json/sonarr/cf/bad-dual-groups.json
@@ -2,8 +2,8 @@
   "trash_id": "32b367365729d530ca1c124a0b180c64",
   "trash_scores": {
     "default": -10000,
-    "french-multi-vf": 0,
-    "french-multi-vo": 0,
+    "french-multi-vf": -10000,
+    "french-multi-vo": -10000,
     "german": -35000
   },
   "name": "Bad Dual Groups",


### PR DESCRIPTION
# Pull Request

## Purpose

Align json configuration with online guides.

## Approach

Per French online guides (i.e. https://trash-guides.info/Radarr/radarr-setup-quality-profiles-french-en/ and https://trash-guides.info/Sonarr/sonarr-setup-quality-profiles-french-en/), optional CF `Bad Dual Groups` score should be set to `-10000` instead of `0`.

## Open Questions and Pre-Merge TODOs

This has been discussed on discord: https://discord.com/channels/492590071455940612/1474907781462102171

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Bug Fixes:
- Set the Bad Dual Groups custom format score to -10000 in both Radarr and Sonarr French JSON configs to match the official guides.