### PR TITLE
fix(guide-sync): Sonarr WEB 1080p/2160p Alternative Quality Profile JSON Quality Ordering

### DIFF
--- a/docs/json/sonarr/quality-profiles/web-1080p-alternative.json
+++ b/docs/json/sonarr/quality-profiles/web-1080p-alternative.json
@@ -24,15 +24,15 @@
     },
     { "name": "Bluray-720p", "allowed": true },
     { "name": "HDTV-720p", "allowed": true },
-    { "name": "Bluray-576p", "allowed": true },
+    { "name": "Bluray-576p", "allowed": false },
     {
       "name": "WEB 480p",
-      "allowed": true,
+      "allowed": false,
       "items": ["WEBRip-480p", "WEBDL-480p"]
     },
-    { "name": "Bluray-480p", "allowed": true },
-    { "name": "DVD", "allowed": true },
-    { "name": "SDTV", "allowed": true },
+    { "name": "Bluray-480p", "allowed": false },
+    { "name": "DVD", "allowed": false },
+    { "name": "SDTV", "allowed": false },
     { "name": "Bluray-2160p Remux", "allowed": false },
     { "name": "Bluray-2160p", "allowed": false },
     {

--- a/docs/json/sonarr/quality-profiles/web-2160p-alternative.json
+++ b/docs/json/sonarr/quality-profiles/web-2160p-alternative.json
@@ -15,12 +15,12 @@
       "allowed": true,
       "items": ["WEBRip-2160p", "WEBDL-2160p"]
     },
-    { "name": "Bluray-2160p", "allowed": true },
     {
       "name": "WEB 1080p",
       "allowed": true,
       "items": ["WEBRip-1080p", "WEBDL-1080p"]
     },
+    { "name": "Bluray-2160p", "allowed": true },
     { "name": "Bluray-1080p", "allowed": true },
     { "name": "HDTV-1080p", "allowed": true },
     {
@@ -30,15 +30,15 @@
     },
     { "name": "Bluray-720p", "allowed": true },
     { "name": "HDTV-720p", "allowed": true },
-    { "name": "Bluray-576p", "allowed": true },
+    { "name": "Bluray-576p", "allowed": false },
     {
       "name": "WEB 480p",
-      "allowed": true,
+      "allowed": false,
       "items": ["WEBRip-480p", "WEBDL-480p"]
     },
-    { "name": "Bluray-480p", "allowed": true },
-    { "name": "DVD", "allowed": true },
-    { "name": "SDTV", "allowed": true },
+    { "name": "Bluray-480p", "allowed": false },
+    { "name": "DVD", "allowed": false },
+    { "name": "SDTV", "allowed": false },
     { "name": "Bluray-2160p Remux", "allowed": false },
     { "name": "HDTV-2160p", "allowed": false },
     { "name": "Bluray-1080p Remux", "allowed": false },


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->

Fix Sonarr WEB 1080p/2160p Alternative Quality Profile JSON Quality Ordering

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

The JSON had the wrong order and enabled certain quality sources that weren't in the written guide, so we fixed it to match the guide.

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Correct Sonarr WEB 1080p and 2160p alternative quality profile JSONs to align with the documented guide ordering and enabled qualities.

Bug Fixes:
- Fix incorrect quality ordering in the Sonarr WEB 1080p alternative quality profile JSON.
- Disable or remove unintended quality sources in the Sonarr WEB 1080p alternative quality profile JSON that were not present in the written guide.
- Fix incorrect quality ordering in the Sonarr WEB 2160p alternative quality profile JSON.
- Disable or remove unintended quality sources in the Sonarr WEB 2160p alternative quality profile JSON that were not present in the written guide.