### PR TITLE
feat(radarr): Add RlsGrp `GuyZo` to `Upscaled` + `Generated Dynamic HDR`

### DIFF
--- a/docs/json/radarr/cf/generated-dynamic-hdr.json
+++ b/docs/json/radarr/cf/generated-dynamic-hdr.json
@@ -36,6 +36,15 @@
       }
     },
     {
+      "name": "GuyZo",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(GuyZo|BR-GuyZo)$"
+      }
+    },
+    {
       "name": "SasukeducK",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,

--- a/docs/json/radarr/cf/upscaled.json
+++ b/docs/json/radarr/cf/upscaled.json
@@ -28,6 +28,15 @@
       }
     },
     {
+      "name": "GuyZo",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(GuyZo|BR-GuyZo)\\b"
+      }
+    },
+    {
       "name": "Regrade",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->

Added RlsGrp `GuyZo` to `Upscaled` + `Generated Dynamic HDR`.

This release group provides 2160p versions of movies when no 2160p source is currently available. They also create generated (Dynamic) HDR formats.  

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

Add RlsGrp `GuyZo` to `Upscaled` + `Generated Dynamic HDR`.

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Add the GuyZo release group to Radarr custom formats for upscaled and generated dynamic HDR content.

New Features:
- Include GuyZo as a supported release group in the Upscaled custom format for Radarr.
- Include GuyZo as a supported release group in the Generated Dynamic HDR custom format for Radarr.