### PR TITLE
chore(gha): update pr naming check to allow mkdocs

### DIFF
--- a/.github/workflows/pr-naming-check.yml
+++ b/.github/workflows/pr-naming-check.yml
@@ -19,14 +19,14 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const titleRegex = /^(Revert \")?(((feat|fix|chore)\((((radarr|sonarr|starr)(-(german|french|anime))?)|(prowlarr|lidarr|bazarr|hardlinks|downloaders|plex|guide(-sync)?|misc|glossary|gha|deps|config|mkdocs))\))|(docs|style|refactor|perf|test|update|build|ci)(\([\w\/-]+\))?):\s.+$/;
+            const titleRegex = /^(Revert \")?(feat|fix|chore)\((((radarr|sonarr|starr)(-(german|french|anime))?)|(prowlarr|lidarr|bazarr|hardlinks|downloaders|plex|guide(-sync)?|misc|glossary|gha|mkdocs|docs|style|refactor|perf|test|update|build|ci))\):\s.+$/;
             const title = context.payload.pull_request.title;
             const isValid = titleRegex.test(title);
             if (!isValid) {
               if ((context.payload.action === 'opened') || (context.payload.action === 'reopened')) {
                 const prNumber = context.payload.pull_request.number;
                 const author = context.payload.pull_request.user.login;
-                const message = `@${author} your pull request title "${context.payload.pull_request.title}" does not conform to our [naming conventions](https://www.conventionalcommits.org/en/v1.0.0/).\n\nPlease update the title to match the pattern: "feat|build|chore|style|fix|update|ci(\\<area\\>): \\<description\\>\n\nYou can check your title at this [regex101 link](https://regex101.com/r/StPfFi/2)."`;
+                const message = `@${author} your pull request title "${context.payload.pull_request.title}" does not conform to our [naming conventions](https://www.conventionalcommits.org/en/v1.0.0/).\n\nPlease update the title to match the pattern: "feat|chore|fix(\\<area\\>): \\<description\\>\n\nYou can check your title at this [regex101 link](https://regex101.com/r/ppDr7P/1)."`;
                 github.rest.issues.createComment({
                   owner: context.repo.owner,
                   repo: context.repo.repo,


### PR DESCRIPTION
# Pull Request

## Purpose

Updates to the GHA that checks PR names to allow PRs with (mkdocs) in the name
Additional refine the regex to be stricter and update regex101 examples

## Summary by Sourcery

CI:
- Extend the PR title validation regex in the GitHub Actions workflow to accept the mkdocs scope.