### PR TITLE
feat(guide-sync): Add the German Anime profile to the `groups.json`, update `CONTRIBUTING.md` to state that updating the `groups.json` is mandatory

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -217,11 +217,14 @@ When updating or adding a new CF, the test case URL (`trash_regex`) needs to be 
 
 - Radarr: `docs/json/radarr/quality-profiles`
     - `docs/json/radarr/cf-groups`
+    - `docs/json/radarr/quality-profile-groups/groups.json`
 - Sonarr: `docs/json/sonarr/quality-profiles`
-    - `docs/json/Sonarr/cf-groups`
+    - `docs/json/sonarr/cf-groups`
+    - `docs/json/sonarr/quality-profile-groups/groups.json`
 
 - `docs/json/xxxarr/quality-profiles` = The base quality profile with all the mandatory Custom Formats.
 - `docs/json/xxxarr/cf-groups` = The optional/User choices that wouldn't break the Quality Profile.
+- `docs/json/xxxarr/quality-profile-groups` = The `groups.json` file contains an array of groups. The order of groups determines display order, and profiles within each group are sorted alphabetically by their name.
 
 ### quality-profiles
 

--- a/docs/json/radarr/quality-profile-groups/groups.json
+++ b/docs/json/radarr/quality-profile-groups/groups.json
@@ -32,6 +32,7 @@
   {
     "name": "German",
     "profiles": {
+      "german-anime-hd-bluray-web": "bf3cc2e99ad9a804a9b0d0e538e1fbba",
       "german-hd-bluray-web": "2b90e905c99490edc7c7a5787443748b",
       "german-hd-remux-web": "c13c33fdd2c306266b34cb9946de5919",
       "german-uhd-bluray-web": "27cc3d153c0a799fd139ef1ff4c4cc42",


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->

The German Anime Profile was missing from the `groups.json` so it didn't show up for the 3rd-party apps. Added to the  `CONTRIBUTING.md` to state that updating the `groups.json` is mandatory if you add a new profile.

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

- Add the German Anime profile to the `groups.json`.
- Updated the  `CONTRIBUTING.md` to state that updating the `groups.json` is mandatory if you add a new profile.

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Add the German Anime quality profile to the shared groups configuration and document the requirement to keep groups.json updated when adding profiles.

New Features:
- Expose the German Anime quality profile to third-party apps via the shared groups.json configuration.

Documentation:
- Document the locations of quality-profile group JSON files for Radarr and Sonarr and clarify that groups.json must be updated when adding new profiles.