### PR TITLE
feat(guide-sync): Add the Sonarr German Anime profile to the groups.json

### DIFF
--- a/docs/json/sonarr/quality-profile-groups/groups.json
+++ b/docs/json/sonarr/quality-profile-groups/groups.json
@@ -29,6 +29,7 @@
   {
     "name": "German",
     "profiles": {
+      "german-anime-hd-bluray-web": "6fe5937e1dcc2269e23b49eb46dfe6d6",
       "german-hd-bluray-web": "dca7e5e9e99c703bcbdaaa471dd40e98",
       "german-hd-remux-web": "0dd5f085ed61a1e01f6d347779dfa1bc",
       "german-uhd-bluray-web": "3b0fa37fddaaefc931b75f2889d4b4f5",


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->

Add the Sonarr German Anime profile to the groups.json

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

Added the Sonarr German Anime profile to the groups.json

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

New Features:
- Introduce a Sonarr German Anime quality profile entry in the quality-profile-groups configuration.