### PR TITLE
fix(guide-sync): The streaming service `VRV` had the same hash as the `VDL` streaming services

### DIFF
--- a/docs/json/radarr/cf-groups/streaming-services-anime.json
+++ b/docs/json/radarr/cf-groups/streaming-services-anime.json
@@ -5,7 +5,7 @@
   "custom_formats": [
     {
       "name": "VRV",
-      "trash_id": "996e8ce50025e8b1e8fa95fcb28c4e5a",
+      "trash_id": "44a8ee6403071dd7b8a3a8dd3fe8cb20",
       "required": true
     }
   ],


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->

The streaming service `VRV` had the same hash as the `VDL` streaming services

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

Corrected the `VRV` streaming service hash to the original one it had when it was created.

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Bug Fixes:
- Fix the VRV streaming service hash clash with VDL in the anime streaming services configuration.