### PR TITLE
chore(guide-sync): Disabled the wrong quality source in the new profile SQP-4 (MA Hybrid)

### DIFF
--- a/docs/json/radarr/quality-profiles/sqp-4-ma-hybrid.json
+++ b/docs/json/radarr/quality-profiles/sqp-4-ma-hybrid.json
@@ -38,7 +38,7 @@
     { "name": "BR-DISK", "allowed": false },
     { "name": "Remux-2160p", "allowed": false },
     { "name": "HDTV-2160p", "allowed": false },
-    { "name": "Remux-1080p", "allowed": true },
+    { "name": "Remux-1080p", "allowed": false },
     { "name": "HDTV-1080p", "allowed": false },
     { "name": "HDTV-720p", "allowed": false },
     { "name": "DVD-R", "allowed": false },


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->

Disabled the wrong quality source in the new profile SQP-4 (MA Hybrid)

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

Disabled the wrong quality source in the new profile SQP-4 (MA Hybrid)

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [ ] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Bug Fixes:
- Disable the incorrect quality source entry in the SQP-4 (MA Hybrid) quality profile configuration.