### PR TITLE
chore(gha): remove backend changes from the changelog

### DIFF
--- a/.github/workflows/automatic-changelog.yml
+++ b/.github/workflows/automatic-changelog.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Run git log
         run: |
-          git log --no-merges --perl-regexp --author='^(?!.*(\[bot\]|actions@github\.com)).*$' --grep='^(feat|fix|chore|docs|style|refactor|perf|test|build|revert|update)(\(.*?\))?:(?! Update CONTRIBUTORS.md)' --since="${{ env.LAST_EDIT_TIME }}" --pretty="%s" > log_output.txt
+          git log --no-merges --perl-regexp --author='^(?!.*(\[bot\]|actions@github\.com)).*$' --grep='^(feat|fix|docs|style|refactor|perf|test|build|revert|update)(\((?!mkdocs|pr-naming-check).*?\))?:(?! Update CONTRIBUTORS.md)' --since="${{ env.LAST_EDIT_TIME }}" --pretty="%s" > log_output.txt
 
       - name: Check if there are new commits
         run: |


### PR DESCRIPTION
# Pull Request

## Purpose

Remove backend related changes from the changelog. Requested by Trash

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Enhancements:
- Refine the git log filter in the automatic changelog workflow to omit backend-related commit types and exclude mkdocs and pr-naming-check chore scopes from the changelog.