### PR TITLE
feat(guide-sync): overhaul feature comparison table

### DIFF
--- a/docs/Guide-Sync/index.md
+++ b/docs/Guide-Sync/index.md
@@ -7,37 +7,64 @@ Here you will find officially supported third-party Guide Sync Tools. These tool
 
 These are third-party applications that sync several sections of the guide with your Sonarr/Radarr (or multiple).
 
-## Radarr Features
+## Features
 
-| Radarr Features                                                                    |     Notifiarr      |     Recyclarr      |     Configarr      |
-| ---------------------------------------------------------------------------------- | :----------------: | :----------------: | :----------------: |
-| GUI (graphical user interface)                                                     | :white_check_mark: |                    |                    |
-| Custom Formats                                                                     | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| Predefined config files available (editable to personal preferences)               |                    | :white_check_mark: | :white_check_mark: |
-| Predefined profiles sync (with several personal selectable options)                | :white_check_mark: |                    |                    |
-| Clear all Custom Formats                                                           | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| Scores                                                                             | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| Quality Settings (File Size)                                                       | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| Naming Scheme                                                                      | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| Quality Profiles                                                                   | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+Both Radarr and Sonarr share the same feature set across all three tools.
 
-## Sonarr Features
+### Definitions
 
-| Sonarr Features                                                      |     Notifiarr      |     Recyclarr      |     Configarr      |
-| -------------------------------------------------------------------- | :----------------: | :----------------: | :----------------: |
-| GUI (graphical user interface)                                       | :white_check_mark: |                    |                    |
-| Custom Formats                                                       | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| Predefined config files available (editable to personal preferences) |                    | :white_check_mark: | :white_check_mark: |
-| Predefined profiles sync (with several personal selectable options)  | :white_check_mark: |                    |                    |
-| Clear all Custom Formats                                             | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| Scores                                                               | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| Quality Settings (File Size)                                         | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| Naming Scheme                                                        | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| Quality Profiles                                                     | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+- **Custom Formats**: Sync individual custom format definitions from the TRaSH Guides.
+- **Custom Format Groups**: Sync a curated bundle of related custom formats together.
+- **Quality Profiles**: Sync guide-provided quality profile configurations, including qualities, groups, upgrade settings, and associated custom format scores.
+- **Quality Definitions (file sizes)**: Sync recommended min/max file size limits per quality level.
+- **Naming Scheme**: Sync file and folder naming patterns from the guides.
+- **User-defined Custom Formats**: Author your own custom format specifications that don't exist in the TRaSH Guides. You can also add TRaSH custom formats that aren't part of a synced profile.
+- **User-defined Quality Profiles**: Build a quality profile from scratch rather than starting from a guide template.
+- **Score multiplier**: Apply a multiplier to all TRaSH scores in a profile (e.g. 0.5x to halve them) rather than overriding each one individually.
+- **Profile cloning**: Copy an existing profile to a new name or another instance.
+- **Profile renaming**: Change the display name of a synced profile.
+
+### TRaSH-Guide sync
+
+Syncing content from the TRaSH Guides to your Sonarr/Radarr instances.
+
+| Feature                                  |     Notifiarr      |     Recyclarr      |     Configarr      |
+| ---------------------------------------- | :----------------: | :----------------: | :----------------: |
+| Custom Formats                           | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| Custom Format Groups                     | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| Quality Profiles                         | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| Quality Definitions (file sizes)         | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| Naming Scheme                            | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+
+### Customization
+
+Going beyond the guides with your own settings.
+
+| Feature                                  |     Notifiarr      |     Recyclarr      |     Configarr      |
+| ---------------------------------------- | :----------------: | :----------------: | :----------------: |
+| User-defined Custom Formats              | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| User-defined Quality Profiles            |       (1)          | :white_check_mark: | :white_check_mark: |
+| Override/modify scores                   | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| Score multiplier                         | :white_check_mark: |  :material-minus:  |  :material-minus:  |
+| Profile cloning                          | :white_check_mark: |  :material-minus:  | :white_check_mark: |
+| Profile renaming                         | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| Clear all Custom Formats                 | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+
+1. Profiles are based on guide templates with customizable settings; cannot create a profile from scratch.
+
+### Setup and operation
+
+| Feature                                  |     Notifiarr      |     Recyclarr      |     Configarr      |
+| ---------------------------------------- | :----------------: | :----------------: | :----------------: |
+| GUI (graphical user interface)           | :white_check_mark: |  :material-minus:  |  :material-minus:  |
+| Predefined config files/templates        |  :material-minus:  | :white_check_mark: | :white_check_mark: |
+| Multi-instance support                   | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| Notifications                            | :white_check_mark: | :white_check_mark: |  :material-minus:  |
+| Whisparr/Readarr/Lidarr support          |  :material-minus:  |  :material-minus:  | :white_check_mark: |
 
 ---
 
-### Notifiarr
+## Notifiarr
 
 [Notifiarr](https://notifiarr.com){:target="\_blank" rel="noopener noreferrer"} ([Patron feature](https://notifiarr.wiki/pages/faq/faq/#q-what-are-the-user-level-differences){:target="\_blank" rel="noopener noreferrer"})
 
@@ -47,7 +74,7 @@ Once set up, it is fully automated and checks for updates to custom formats and 
 
 [Instructions](https://notifiarr.wiki/pages/integrations/trash/){:target="\_blank" rel="noopener noreferrer"}
 
-#### Video Tutorial
+### Video Tutorial
 
 !!! tip ""
 
@@ -59,14 +86,14 @@ Once set up, it is fully automated and checks for updates to custom formats and 
 
 ---
 
-### Recyclarr
+## Recyclarr
 
 [Info](/Recyclarr/){:target="\_blank" rel="noopener noreferrer"} // [Documentation](https://recyclarr.dev/guide/){:target="\_blank" rel="noopener noreferrer"}
 
 Recyclarr is a command line application utilizing configuration files to sync the guides to Radarr &
 Sonarr.
 
-### Configarr
+## Configarr
 
 [GitHub](https://github.com/raydak-labs/configarr){:target="\_blank" rel="noopener noreferrer"} // [Documentation](https://configarr.raydak.de){:target="\_blank" rel="noopener noreferrer"}
 


### PR DESCRIPTION
# Pull Request

## Purpose

The existing comparison table had ambiguous feature names (e.g. "Predefined profiles sync"), missing features, and blank cells that were hard to read.

## Approach

- Split the single table into three categorized sections: TRaSH-Guide sync, Customization, and Setup and operation.
- Added new feature rows: Custom Format Groups, user-defined Custom Formats, user-defined Quality Profiles, score multiplier, profile cloning, profile renaming, notifications, and Whisparr/Readarr/Lidarr support.
- Added a definitions section above the tables so each feature name is unambiguous.
- Replaced blank cells with `:material-minus:` for a clearer visual distinction between supported and unsupported.
- Fixed heading levels so Notifiarr/Recyclarr/Configarr tool descriptions are at the same level as Features (not nested under it).
- Merged the Radarr and Sonarr tables into one since the feature sets are identical across all three tools.

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Overhaul the Guide Sync feature comparison section to provide clearer, categorized tables and consistent headings for supported tools.

New Features:
- Introduce categorized feature tables for TRaSH-Guide sync, customization, and setup/operation covering Radarr and Sonarr.
- Add feature coverage for user-defined formats and profiles, score multipliers, profile cloning/renaming, notifications, and additional *arr app support.

Enhancements:
- Add a definitions section to clarify feature terminology used in the comparison tables.
- Unify Radarr and Sonarr feature listings into a single shared feature table for all three tools and replace blank cells with explicit unsupported indicators.
- Align Notifiarr, Recyclarr, and Configarr headings and video tutorial heading levels for more consistent documentation structure.