### PR TITLE
fix(docs): pin pygments below 2.20 to fix build

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -7,3 +7,4 @@ mkdocs-minify-plugin==0.8.0
 mkdocs-redirects==1.2.3
 mkdocs-include-markdown-plugin==7.2.1
 mkdocs-markdownextradata-plugin==0.2.6
+pygments<2.20


### PR DESCRIPTION
## Summary

A new version of `pygments` (2.20.0) was released today and it breaks the mkdocs build. Since `pygments` isn't pinned in `docs/requirements.txt`, the CI picked it up automatically and all PR preview deployments started failing (the Cloudflare Pages "Build failed!" comment with blank preview URLs).

This pins `pygments<2.20` to restore the previous working version until the upstream bug is fixed.

I've filed a bug report with the library that causes the issue: https://github.com/facelessuser/pymdown-extensions/issues/2864

Once that's resolved, this pin can be removed.