### PR TITLE
feat(starr): Add machine-readable conflict declarations for mutually exclusive CFs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,7 @@ Here you will find guidelines for contributing to [TRaSH Guides](https://trash-g
         - [Group Specific settings](#group-specific-settings)
         - [Group Custom Format specific settings](#group-custom-format-specific-settings)
     - [quality-profile-groups](#quality-profile-groups)
+    - [conflicts](#conflicts)
 - [Recommendations](#recommendations)
     - [Preview Docs Locally](#preview-docs-locally)
     - [Preview after Pull Request](#preview-after-pull-request)
@@ -218,13 +219,16 @@ When updating or adding a new CF, the test case URL (`trash_regex`) needs to be 
 - Radarr: `docs/json/radarr/quality-profiles`
     - `docs/json/radarr/cf-groups`
     - `docs/json/radarr/quality-profile-groups/groups.json`
+    - `docs/json/radarr/conflicts.json`
 - Sonarr: `docs/json/sonarr/quality-profiles`
     - `docs/json/sonarr/cf-groups`
     - `docs/json/sonarr/quality-profile-groups/groups.json`
+    - `docs/json/sonarr/conflicts.json`
 
 - `docs/json/xxxarr/quality-profiles` = The base quality profile with all the mandatory Custom Formats.
 - `docs/json/xxxarr/cf-groups` = The optional/User choices that wouldn't break the Quality Profile.
 - `docs/json/xxxarr/quality-profile-groups` = The `groups.json` file contains an array of groups. The order of groups determines display order, and profiles within each group are sorted alphabetically by their name.
+- `docs/json/xxxarr/conflicts.json` = Declares mutually exclusive Custom Formats so sync tools can warn users about conflicting selections.
 
 ### quality-profiles
 
@@ -339,6 +343,38 @@ The `groups.json` file contains an array of groups. The order of groups determin
 
 > [!IMPORTANT]
 > All `trash_id` values in the `profiles` array must correspond to existing quality profiles in the `quality-profiles` directory. Each quality profile should belong to exactly one group.
+
+### conflicts
+
+The conflicts file declares Custom Formats that are mutually exclusive. Sync tools read this to warn users when they pick CFs that don't make sense together (for example, two SDR variants in the same profile).
+
+- Radarr: `docs/json/radarr/conflicts.json`
+- Sonarr: `docs/json/sonarr/conflicts.json`
+
+Each file has a `custom_formats` array, and each entry in that array is one conflict group. Inside a group, the `trash_id` is the object key and the value holds `name` and `desc`:
+
+```json
+{
+    "custom_formats": [
+        {
+            "9c38ebb7384dada637be8899efa68e6f": {
+                "name": "SDR",
+                "desc": ""
+            },
+            "25c12f78430a3a23413652cbd1d48d77": {
+                "name": "SDR (no WEBDL)",
+                "desc": ""
+            }
+        }
+    ]
+}
+```
+
+- All CFs within a group are mutually exclusive with each other. A group must have at least 2 entries.
+- `name` is a human-readable comment. It has no functional effect; keep it in sync with the real CF name so you can tell at a glance which `trash_id` is which.
+- `desc` is an optional free-text field for longer maintainer notes. No formatting rules.
+- The schema (`schemas/conflicts.schema.json`) validates that keys are 32-character hex strings.
+- When you add a new CF that conflicts with an existing one, add or update the conflict group in the relevant `conflicts.json` file.
 
 ---
 

--- a/docs/json/radarr/conflicts.json
+++ b/docs/json/radarr/conflicts.json
@@ -1,13 +1,25 @@
 {
   "$schema": "../../../schemas/conflicts.schema.json",
   "custom_formats": [
-    [
-      { "trash_id": "9c38ebb7384dada637be8899efa68e6f", "name": "SDR" },
-      { "trash_id": "25c12f78430a3a23413652cbd1d48d77", "name": "SDR (no WEBDL)" }
-    ],
-    [
-      { "trash_id": "dc98083864ea246d05a42df0d05f81cc", "name": "x265 (HD)" },
-      { "trash_id": "839bea857ed2c0a8e084f3cbdbd65ecb", "name": "x265 (no HDR/DV)" }
-    ]
+    {
+      "9c38ebb7384dada637be8899efa68e6f": {
+        "name": "SDR",
+        "desc": ""
+      },
+      "25c12f78430a3a23413652cbd1d48d77": {
+        "name": "SDR (no WEBDL)",
+        "desc": ""
+      }
+    },
+    {
+      "dc98083864ea246d05a42df0d05f81cc": {
+        "name": "x265 (HD)",
+        "desc": ""
+      },
+      "839bea857ed2c0a8e084f3cbdbd65ecb": {
+        "name": "x265 (no HDR/DV)",
+        "desc": ""
+      }
+    }
   ]
 }

--- a/docs/json/radarr/conflicts.json
+++ b/docs/json/radarr/conflicts.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "../../../schemas/conflicts.schema.json",
+  "custom_formats": [
+    [
+      { "trash_id": "9c38ebb7384dada637be8899efa68e6f", "name": "SDR" },
+      { "trash_id": "25c12f78430a3a23413652cbd1d48d77", "name": "SDR (no WEBDL)" }
+    ],
+    [
+      { "trash_id": "dc98083864ea246d05a42df0d05f81cc", "name": "x265 (HD)" },
+      { "trash_id": "839bea857ed2c0a8e084f3cbdbd65ecb", "name": "x265 (no HDR/DV)" }
+    ]
+  ]
+}

--- a/docs/json/sonarr/conflicts.json
+++ b/docs/json/sonarr/conflicts.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "../../../schemas/conflicts.schema.json",
+  "custom_formats": [
+    [
+      { "trash_id": "2016d1676f5ee13a5b7257ff86ac9a93", "name": "SDR" },
+      { "trash_id": "83304f261cf516bb208c18c54c0adf97", "name": "SDR (no WEBDL)" }
+    ],
+    [
+      { "trash_id": "47435ece6b99a0b477caf360e79ba0bb", "name": "x265 (HD)" },
+      { "trash_id": "9b64dff695c2115facf1b6ea59c9bd07", "name": "x265 (no HDR/DV)" }
+    ]
+  ]
+}

--- a/docs/json/sonarr/conflicts.json
+++ b/docs/json/sonarr/conflicts.json
@@ -1,13 +1,25 @@
 {
   "$schema": "../../../schemas/conflicts.schema.json",
   "custom_formats": [
-    [
-      { "trash_id": "2016d1676f5ee13a5b7257ff86ac9a93", "name": "SDR" },
-      { "trash_id": "83304f261cf516bb208c18c54c0adf97", "name": "SDR (no WEBDL)" }
-    ],
-    [
-      { "trash_id": "47435ece6b99a0b477caf360e79ba0bb", "name": "x265 (HD)" },
-      { "trash_id": "9b64dff695c2115facf1b6ea59c9bd07", "name": "x265 (no HDR/DV)" }
-    ]
+    {
+      "2016d1676f5ee13a5b7257ff86ac9a93": {
+        "name": "SDR",
+        "desc": ""
+      },
+      "83304f261cf516bb208c18c54c0adf97": {
+        "name": "SDR (no WEBDL)",
+        "desc": ""
+      }
+    },
+    {
+      "47435ece6b99a0b477caf360e79ba0bb": {
+        "name": "x265 (HD)",
+        "desc": ""
+      },
+      "9b64dff695c2115facf1b6ea59c9bd07": {
+        "name": "x265 (no HDR/DV)",
+        "desc": ""
+      }
+    }
   ]
 }

--- a/metadata.json
+++ b/metadata.json
@@ -7,7 +7,8 @@
       "naming": ["docs/json/radarr/naming"],
       "quality_profiles": ["docs/json/radarr/quality-profiles"],
       "custom_format_groups": ["docs/json/radarr/cf-groups"],
-      "quality_profile_groups": ["docs/json/radarr/quality-profile-groups"]
+      "quality_profile_groups": ["docs/json/radarr/quality-profile-groups"],
+      "conflicts": ["docs/json/radarr/conflicts.json"]
     },
     "sonarr": {
       "custom_formats": ["docs/json/sonarr/cf"],
@@ -15,7 +16,8 @@
       "naming": ["docs/json/sonarr/naming"],
       "quality_profiles": ["docs/json/sonarr/quality-profiles"],
       "custom_format_groups": ["docs/json/sonarr/cf-groups"],
-      "quality_profile_groups": ["docs/json/sonarr/quality-profile-groups"]
+      "quality_profile_groups": ["docs/json/sonarr/quality-profile-groups"],
+      "conflicts": ["docs/json/sonarr/conflicts.json"]
     }
   }
 }

--- a/metadata.schema.json
+++ b/metadata.schema.json
@@ -28,7 +28,8 @@
         "naming": { "$ref": "#/$defs/paths_object" },
         "quality_profiles": { "$ref": "#/$defs/paths_object" },
         "custom_format_groups": { "$ref": "#/$defs/paths_object" },
-        "quality_profile_groups": { "$ref": "#/$defs/paths_object" }
+        "quality_profile_groups": { "$ref": "#/$defs/paths_object" },
+        "conflicts": { "$ref": "#/$defs/paths_object" }
       }
     },
     "sonarr": {
@@ -40,7 +41,8 @@
         "naming": { "$ref": "#/$defs/paths_object" },
         "quality_profiles": { "$ref": "#/$defs/paths_object" },
         "custom_format_groups": { "$ref": "#/$defs/paths_object" },
-        "quality_profile_groups": { "$ref": "#/$defs/paths_object" }
+        "quality_profile_groups": { "$ref": "#/$defs/paths_object" },
+        "conflicts": { "$ref": "#/$defs/paths_object" }
       }
     }
   }

--- a/schemas/conflicts.schema.json
+++ b/schemas/conflicts.schema.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema",
+  "$id": "https://raw.githubusercontent.com/TRaSH-/Guides/master/schemas/conflicts.schema.json",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "$schema": { "type": "string" },
+    "custom_formats": {
+      "type": "array",
+      "items": {
+        "type": "array",
+        "minItems": 2,
+        "items": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["trash_id"],
+          "properties": {
+            "trash_id": { "type": "string" },
+            "name": { "type": "string" }
+          }
+        }
+      }
+    }
+  }
+}

--- a/schemas/conflicts.schema.json
+++ b/schemas/conflicts.schema.json
@@ -8,17 +8,20 @@
     "custom_formats": {
       "type": "array",
       "items": {
-        "type": "array",
-        "minItems": 2,
-        "items": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": ["trash_id"],
-          "properties": {
-            "trash_id": { "type": "string" },
-            "name": { "type": "string" }
+        "type": "object",
+        "minProperties": 2,
+        "patternProperties": {
+          "^[a-f0-9]{32}$": {
+            "type": "object",
+            "required": ["name"],
+            "additionalProperties": false,
+            "properties": {
+              "name": { "type": "string" },
+              "desc": { "type": "string" }
+            }
           }
-        }
+        },
+        "additionalProperties": false
       }
     }
   }


### PR DESCRIPTION
## Summary

Adds `conflicts.json` files for Radarr and Sonarr that declare which custom formats are mutually exclusive, so sync tools can warn users when they select conflicting CFs.

- New `schemas/conflicts.schema.json` for validation
- New `docs/json/radarr/conflicts.json` and `docs/json/sonarr/conflicts.json` with known conflict groups
- `metadata.json` and `metadata.schema.json` updated with `conflicts` path key for both services

## Known conflicts declared

Each service has two conflict groups:

- SDR vs SDR (no WEBDL)
- x265 (HD) vs x265 (no HDR/DV)

These are the only CF-level mutual exclusions documented in the guides (confirmed by searching all markdown and cf-group descriptions for exclusivity language).

## Structure

Based on a discussion with @austinwbest, conflict entries use the trash_id as the object key with `name` and `desc` properties on the value. This is intended to be a forward-looking pattern that could eventually unify how all resource files in the repo are structured.

```json
{
  "custom_formats": [
    {
      "9c38ebb7384dada637be8899efa68e6f": {
        "name": "SDR",
        "desc": ""
      },
      "25c12f78430a3a23413652cbd1d48d77": {
        "name": "SDR (no WEBDL)",
        "desc": ""
      }
    }
  ]
}
```

- Each conflict group is an object keyed by trash_id, so three-way (or larger) mutual exclusion works without redundant pairwise entries
- `name` is required; `desc` is optional and left empty for maintainers to fill in if they want
- Schema validates keys as 32-char hex via `patternProperties`, enforces `minProperties: 2` per group
- `conflicts` paths in metadata point to files (not directories) since there's one file per service