### PR TITLE
feat(radarr): Add none MA WEBDL from the RlsGrp `HHWEB` to the `LQ (Release Title)` Custom Format

### DIFF
--- a/docs/json/radarr/cf/lq-release-title.json
+++ b/docs/json/radarr/cf/lq-release-title.json
@@ -6,7 +6,6 @@
     "german-anime": -35000
   },
   "trash_regex": "https://regex101.com/r/8TIqc2/latest",
-  "trash_regex2": "https://regex101.com/r/ugw8mD/1",
   "name": "LQ (Release Title)",
   "includeCustomFormatWhenRenaming": false,
   "specifications": [


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->

Add none MA WEBDL from the RlsGrp `HHWEB` to the `LQ (Release Title)` Custom Format.
We received multiple reports that their releases often include hardcoded subtitles. All of these reports involve non-MA WEBDL releases, which is why we're now blocking their non-MA WEBDL releases.

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

Add none MA WEBDL from the RlsGrp `HHWEB` to the `LQ (Release Title)` Custom Format
[Regex Test Case](https://regex101.com/r/ugw8mD/1)

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Enhancements:
- Extend the Radarr LQ (Release Title) custom format JSON to include non-MA WEBDL releases from the HHWEB release group so they are flagged/penalized.