### PR TITLE
fix(starr): correct CF name casing in cf-groups to match source CFs

### DIFF
--- a/docs/json/radarr/cf-groups/audio-formats.json
+++ b/docs/json/radarr/cf-groups/audio-formats.json
@@ -5,7 +5,7 @@
   "default": "true",
   "custom_formats": [
     {
-      "name": "TrueHD Atmos",
+      "name": "TrueHD ATMOS",
       "trash_id": "496f355514737f7d83bf7aa4d24f8169",
       "required": true
     },

--- a/docs/json/radarr/cf-groups/optional-misc-sqp.json
+++ b/docs/json/radarr/cf-groups/optional-misc-sqp.json
@@ -24,7 +24,7 @@
       "required": false
     },
     {
-      "name": "Multi",
+      "name": "MULTi",
       "trash_id": "4b900e171accbfb172729b63323ea8ca",
       "required": false
     },

--- a/docs/json/radarr/cf-groups/optional-misc.json
+++ b/docs/json/radarr/cf-groups/optional-misc.json
@@ -24,7 +24,7 @@
       "required": false
     },
     {
-      "name": "Multi",
+      "name": "MULTi",
       "trash_id": "4b900e171accbfb172729b63323ea8ca",
       "required": false
     },

--- a/docs/json/radarr/cf-groups/sqp-4-ma-hybrid-optional-release-groups.json
+++ b/docs/json/radarr/cf-groups/sqp-4-ma-hybrid-optional-release-groups.json
@@ -9,7 +9,7 @@
       "required": false
     },
     {
-      "name": "SIC",
+      "name": "SiC",
       "trash_id": "8cd3ac70db7ac318cf9a0e01333940a4",
       "required": false
     },
@@ -19,7 +19,7 @@
       "required": false
     },
     {
-      "name": "Mainframe",
+      "name": "MainFrame",
       "trash_id": "8016f2f66e751dea613e6b5b94bf633c",
       "required": false
     }

--- a/docs/json/sonarr/cf-groups/audio-formats.json
+++ b/docs/json/sonarr/cf-groups/audio-formats.json
@@ -4,7 +4,7 @@
   "trash_description": "Audio Formats, something you see mainly with Remuxes and UHD HQ Encodes. Add this only if you choose a Quality Profile that covers Remuxes and HQ UHD Encodes.",
   "custom_formats": [
     {
-      "name": "TrueHD Atmos",
+      "name": "TrueHD ATMOS",
       "trash_id": "0d7824bb924701997f874e7ff7d4844a",
       "required": true
     },

--- a/docs/json/sonarr/cf-groups/streaming-services-general.json
+++ b/docs/json/sonarr/cf-groups/streaming-services-general.json
@@ -45,7 +45,7 @@
       "required": true
     },
     {
-      "name": "Hulu",
+      "name": "HULU",
       "trash_id": "f6cce30f1733d5c8194222a7507909bb",
       "required": true
     },


### PR DESCRIPTION
## Summary
- Fixed 7 `name` mismatches in cf-groups JSON files where the casing didn't match the source Custom Format JSON
- **Sonarr**: `Hulu` → `HULU`, `TrueHD Atmos` → `TrueHD ATMOS`
- **Radarr**: `TrueHD Atmos` → `TrueHD ATMOS`, `Multi` → `MULTi` (2 files), `SIC` → `SiC`, `Mainframe` → `MainFrame`

## Test plan
- [ ] Verify each cf-groups `name` now matches its corresponding CF JSON in `docs/json/{sonarr,radarr}/cf/`
- [ ] Confirm no downstream sync app breakage from the name corrections

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Correct CF group name casing mismatches in Sonarr and Radarr cf-groups JSON files so they match the source Custom Format definitions.