### PR TITLE
fix(starr): correct formatItems name casing to match source CFs

### DIFF
--- a/docs/json/radarr/quality-profiles/sqp-1-1080p.json
+++ b/docs/json/radarr/quality-profiles/sqp-1-1080p.json
@@ -82,7 +82,7 @@
     "3D": "b8cd450cbfa689c0259a01d9e29ba3d6",
     "Extras": "0a3f082873eb454bde444150b70253cc",
     "Sing-Along Versions": "712d74cd88bceb883ee32f773656b1f5",
-    "10 bit": "a5d148168c4506b55cf53984107c396e",
+    "10bit": "a5d148168c4506b55cf53984107c396e",
     "AV1": "cae4ca30163749b891686f95532519bd",
     "1080p": "820b09bb9acbfde9c35c71e0e565dad8",
     "720p": "b2be17d608fc88818940cd1833b0b24c"

--- a/docs/json/radarr/quality-profiles/sqp-1-2160p.json
+++ b/docs/json/radarr/quality-profiles/sqp-1-2160p.json
@@ -87,7 +87,7 @@
     "Upscaled": "bfd8eb01832d646a0a89c4deb46f8564",
     "Extras": "0a3f082873eb454bde444150b70253cc",
     "Sing-Along Versions": "712d74cd88bceb883ee32f773656b1f5",
-    "10 bit": "a5d148168c4506b55cf53984107c396e",
+    "10bit": "a5d148168c4506b55cf53984107c396e",
     "AV1": "cae4ca30163749b891686f95532519bd",
     "1080p": "820b09bb9acbfde9c35c71e0e565dad8",
     "720p": "b2be17d608fc88818940cd1833b0b24c"

--- a/docs/json/radarr/quality-profiles/sqp-1-web-1080p.json
+++ b/docs/json/radarr/quality-profiles/sqp-1-web-1080p.json
@@ -88,7 +88,7 @@
     "3D": "b8cd450cbfa689c0259a01d9e29ba3d6",
     "Extras": "0a3f082873eb454bde444150b70253cc",
     "Sing-Along Versions": "712d74cd88bceb883ee32f773656b1f5",
-    "10 bit": "a5d148168c4506b55cf53984107c396e",
+    "10bit": "a5d148168c4506b55cf53984107c396e",
     "AV1": "cae4ca30163749b891686f95532519bd",
     "1080p": "820b09bb9acbfde9c35c71e0e565dad8",
     "720p": "b2be17d608fc88818940cd1833b0b24c",

--- a/docs/json/radarr/quality-profiles/sqp-1-web-2160p.json
+++ b/docs/json/radarr/quality-profiles/sqp-1-web-2160p.json
@@ -92,7 +92,7 @@
     "Upscaled": "bfd8eb01832d646a0a89c4deb46f8564",
     "Extras": "0a3f082873eb454bde444150b70253cc",
     "Sing-Along Versions": "712d74cd88bceb883ee32f773656b1f5",
-    "10 bit": "a5d148168c4506b55cf53984107c396e",
+    "10bit": "a5d148168c4506b55cf53984107c396e",
     "AV1": "cae4ca30163749b891686f95532519bd",
     "1080p": "820b09bb9acbfde9c35c71e0e565dad8",
     "720p": "b2be17d608fc88818940cd1833b0b24c"

--- a/docs/json/radarr/quality-profiles/sqp-3-audio.json
+++ b/docs/json/radarr/quality-profiles/sqp-3-audio.json
@@ -48,7 +48,7 @@
     { "name": "Unknown", "allowed": false }
   ],
   "formatItems": {
-    "TrueHD Atmos": "496f355514737f7d83bf7aa4d24f8169",
+    "TrueHD ATMOS": "496f355514737f7d83bf7aa4d24f8169",
     "DTS X": "2f22d89048b01681dde8afe203bf2e95",
     "ATMOS (undefined)": "417804f7f2c4308c1f4c5d380d4c4475",
     "DD+ ATMOS": "1af239278386be2919e1bcee0bde047e",

--- a/docs/json/sonarr/quality-profiles/french-multi-vf-bluray-web-1080p.json
+++ b/docs/json/sonarr/quality-profiles/french-multi-vf-bluray-web-1080p.json
@@ -130,7 +130,7 @@
     "Repack2": "eb3d5cc0a2be0db205fb823640db6a3c",
     "Repack3": "44e7c4de10ae50265753082e5dc76047",
     "AUViO": "b0d6195c23ae254932da00512db7e8a8",
-    "MyCanal": "f27d46a831e6b16fa3fee2c4e5d10984",
+    "MyCANAL": "f27d46a831e6b16fa3fee2c4e5d10984",
     "SALTO": "0455d6519a550dbf648c97b56e7231d2"
   }
 }

--- a/docs/json/sonarr/quality-profiles/french-multi-vf-bluray-web-2160p.json
+++ b/docs/json/sonarr/quality-profiles/french-multi-vf-bluray-web-2160p.json
@@ -132,7 +132,7 @@
     "UHD Streaming Boost": "43b3cf48cb385cd3eac608ee6bca7f09",
     "HD Streaming Boost": "218e93e5702f44a68ad9e3c6ba87d2f0",
     "AUViO": "b0d6195c23ae254932da00512db7e8a8",
-    "MyCanal": "f27d46a831e6b16fa3fee2c4e5d10984",
+    "MyCANAL": "f27d46a831e6b16fa3fee2c4e5d10984",
     "SALTO": "0455d6519a550dbf648c97b56e7231d2"
   }
 }

--- a/docs/json/sonarr/quality-profiles/french-multi-vo-bluray-web-1080p.json
+++ b/docs/json/sonarr/quality-profiles/french-multi-vo-bluray-web-1080p.json
@@ -80,7 +80,7 @@
     "Repack2": "eb3d5cc0a2be0db205fb823640db6a3c",
     "Repack3": "44e7c4de10ae50265753082e5dc76047",
     "AUViO": "b0d6195c23ae254932da00512db7e8a8",
-    "MyCanal": "f27d46a831e6b16fa3fee2c4e5d10984",
+    "MyCANAL": "f27d46a831e6b16fa3fee2c4e5d10984",
     "SALTO": "0455d6519a550dbf648c97b56e7231d2"
   }
 }

--- a/docs/json/sonarr/quality-profiles/french-multi-vo-bluray-web-2160p.json
+++ b/docs/json/sonarr/quality-profiles/french-multi-vo-bluray-web-2160p.json
@@ -82,7 +82,7 @@
     "UHD Streaming Boost": "43b3cf48cb385cd3eac608ee6bca7f09",
     "HD Streaming Boost": "218e93e5702f44a68ad9e3c6ba87d2f0",
     "AUViO": "b0d6195c23ae254932da00512db7e8a8",
-    "MyCanal": "f27d46a831e6b16fa3fee2c4e5d10984",
+    "MyCANAL": "f27d46a831e6b16fa3fee2c4e5d10984",
     "SALTO": "0455d6519a550dbf648c97b56e7231d2"
   }
 }

--- a/docs/json/sonarr/quality-profiles/french-vostfr-bluray-web-1080p.json
+++ b/docs/json/sonarr/quality-profiles/french-vostfr-bluray-web-1080p.json
@@ -130,7 +130,7 @@
     "Repack2": "eb3d5cc0a2be0db205fb823640db6a3c",
     "Repack3": "44e7c4de10ae50265753082e5dc76047",
     "AUViO": "b0d6195c23ae254932da00512db7e8a8",
-    "MyCanal": "f27d46a831e6b16fa3fee2c4e5d10984",
+    "MyCANAL": "f27d46a831e6b16fa3fee2c4e5d10984",
     "SALTO": "0455d6519a550dbf648c97b56e7231d2"
   }
 }

--- a/docs/json/sonarr/quality-profiles/french-vostfr-bluray-web-2160p.json
+++ b/docs/json/sonarr/quality-profiles/french-vostfr-bluray-web-2160p.json
@@ -132,7 +132,7 @@
     "UHD Streaming Boost": "43b3cf48cb385cd3eac608ee6bca7f09",
     "HD Streaming Boost": "218e93e5702f44a68ad9e3c6ba87d2f0",
     "AUViO": "b0d6195c23ae254932da00512db7e8a8",
-    "MyCanal": "f27d46a831e6b16fa3fee2c4e5d10984",
+    "MyCANAL": "f27d46a831e6b16fa3fee2c4e5d10984",
     "SALTO": "0455d6519a550dbf648c97b56e7231d2"
   }
 }


### PR DESCRIPTION
## Summary
- Fixed 11 `formatItems` key name mismatches in quality profiles where the casing didn't match the source Custom Format JSON
- **Radarr**: `10 bit` → `10bit` (4 profiles), `TrueHD Atmos` → `TrueHD ATMOS` (1 profile)
- **Sonarr**: `MyCanal` → `MyCANAL` (6 profiles)

## Test plan
- [ ] Verify each `formatItems` key now matches its corresponding CF `name` in `docs/json/{sonarr,radarr}/cf/`
- [ ] Confirm no downstream sync app breakage from the name corrections

## Summary by Sourcery

Align quality profile format item names with their corresponding Custom Format definitions.

Bug Fixes:
- Correct casing of Radarr quality profile formatItems names to match source Custom Format JSON definitions.
- Correct casing of Sonarr quality profile formatItems names to match source Custom Format JSON definitions.