### PR TITLE
feat(sonarr-anime): Add HIDIVE & WKN to the anime-remux profile

### DIFF
--- a/docs/json/sonarr/quality-profiles/anime-remux-1080p.json
+++ b/docs/json/sonarr/quality-profiles/anime-remux-1080p.json
@@ -86,6 +86,8 @@
     "ABEMA": "a370d974bc7b80374de1d9ba7519760b",
     "ADN": "d54cd2bf1326287275b56bccedb72ee2",
     "B-Global": "7dd31f3dee6d2ef8eeaa156e23c3857e",
-    "Bilibili": "4c67ff059210182b59cdd41697b8cb08"
+    "Bilibili": "4c67ff059210182b59cdd41697b8cb08",
+    "HIDIVE": "570b03b3145a25011bf073274a407259",
+    "WKN": "e5e6405d439dcd1af90962538acd4fe0"
   }
 }


### PR DESCRIPTION
These two services are listed under Anime-Streaming Service (https://trash-guides.info/Sonarr/sonarr-collection-of-custom-formats/#anime-streaming-services) we should have them included in the profile by default (like the other services)

---

Note:
Another approach would be creating the custom-format-group Anime Streaming Services (similar to the one in Radarr) and adding it to the anime-remux QP.

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Include additional anime streaming services in the default anime-remux 1080p quality profile.

New Features:
- Add HIDIVE to the anime-remux 1080p quality profile as a default anime streaming service.
- Add WKN to the anime-remux 1080p quality profile as a default anime streaming service.