### PR TITLE
feat(sonarr-anime): Enable season-pack cf-group for anime

### DIFF
--- a/docs/json/sonarr/cf-groups/season-packs.json
+++ b/docs/json/sonarr/cf-groups/season-packs.json
@@ -22,7 +22,8 @@
       "[German] HD Remux + WEB": "0dd5f085ed61a1e01f6d347779dfa1bc",
       "[German] UHD Bluray + WEB": "3b0fa37fddaaefc931b75f2889d4b4f5",
       "[German] UHD Bluray + WEB (Alternative)": "7324309a7d1e10dc0dc2cea6c70ed852",
-      "[German] UHD Remux + WEB": "08cececf1840290f6fd490b7d79e8642"
+      "[German] UHD Remux + WEB": "08cececf1840290f6fd490b7d79e8642",
+      "[Anime] Remux-1080p": "20e0fc959f1f1704bed501f23bdae76f"
     }
   }
 }


### PR DESCRIPTION
# Pull Request

## Purpose

Anime consumers do like season packs too

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Enhancements:
- Extend season-pack custom format group JSON to include anime-specific configuration.