### PR TITLE
feat(guide-sync): add conflicts.json validation

### DIFF
--- a/.github/workflows/custom-format-validation.yml
+++ b/.github/workflows/custom-format-validation.yml
@@ -7,6 +7,8 @@ on:
       - docs/json/guide-only/*.json
       - docs/json/radarr/cf/*.json
       - docs/json/sonarr/cf/*.json
+      - docs/json/radarr/conflicts.json
+      - docs/json/sonarr/conflicts.json
       - schemas/**/*.json
   pull_request:
     paths:
@@ -14,6 +16,8 @@ on:
       - docs/json/guide-only/*.json
       - docs/json/radarr/cf/*.json
       - docs/json/sonarr/cf/*.json
+      - docs/json/radarr/conflicts.json
+      - docs/json/sonarr/conflicts.json
       - schemas/**/*.json
 
 jobs:
@@ -40,6 +44,12 @@ jobs:
 
       - name: Validate Sonarr Custom Formats
         run: check-jsonschema -v --schemafile schemas/sonarr-cf.schema.json docs/json/sonarr/cf/*.json
+
+      - name: Validate Conflicts
+        run: |
+          for f in docs/json/radarr/conflicts.json docs/json/sonarr/conflicts.json; do
+            [ -f "$f" ] && check-jsonschema -v --schemafile schemas/conflicts.schema.json "$f"
+          done
 
       - name: Validate custom format consistency
         run: python scripts/validate-custom-formats.py

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,6 +44,12 @@ repos:
         types: [json]
         args: ["-v", "--schemafile", "schemas/sonarr-naming.schema.json"]
 
+      - id: check-jsonschema
+        name: Validate Conflicts
+        files: ^docs/json/(radarr|sonarr)/conflicts\.json$
+        types: [json]
+        args: ["-v", "--schemafile", "schemas/conflicts.schema.json"]
+
   - repo: local
     hooks:
       - id: validate-custom-formats
@@ -52,7 +58,7 @@ repos:
         language: python
         pass_filenames: false
         files: >-
-          ^docs/json/(radarr|sonarr)/(cf|cf-groups|quality-profiles)/
+          ^docs/json/(radarr|sonarr)/(cf|cf-groups|quality-profiles)/|^docs/json/(radarr|sonarr)/conflicts\.json$
 
       - id: validate-quality-profiles
         name: Validate Quality Profiles

--- a/scripts/validate-custom-formats.py
+++ b/scripts/validate-custom-formats.py
@@ -136,8 +136,6 @@ def validate_app(app: str) -> list[str]:
         if conflicts_data is not None:
             for group in conflicts_data.get("custom_formats", []):
                 for tid, entry in group.items():
-                    if tid == "$schema":
-                        continue
                     if not isinstance(entry, dict):
                         continue
                     entry_name = entry.get("name", "")

--- a/scripts/validate-custom-formats.py
+++ b/scripts/validate-custom-formats.py
@@ -134,9 +134,19 @@ def validate_app(app: str) -> list[str]:
     if conflicts_file.is_file():
         conflicts_data = load_json(conflicts_file, errors)
         if conflicts_data is not None:
-            for group in conflicts_data.get("custom_formats", []):
+            for group_idx, group in enumerate(conflicts_data.get("custom_formats", [])):
+                if not isinstance(group, dict):
+                    errors.append(
+                        f"[{app}] conflicts.json: conflict group"
+                        f" {group_idx} is not an object"
+                    )
+                    continue
                 for tid, entry in group.items():
                     if not isinstance(entry, dict):
+                        errors.append(
+                            f"[{app}] conflicts.json: entry for"
+                            f" trash_id '{tid}' is not an object"
+                        )
                         continue
                     entry_name = entry.get("name", "")
 

--- a/scripts/validate-custom-formats.py
+++ b/scripts/validate-custom-formats.py
@@ -5,6 +5,7 @@ Checks:
     1. Per-app trash_id uniqueness across CF files, cf-groups, and quality profiles
     2. cf-groups entries reference valid CFs (trash_id exists, name matches)
     3. CF and cf-groups filenames follow naming conventions (lowercase, dashes only)
+    4. conflicts.json entries reference valid CFs (trash_id exists, name matches)
 
 Exit code 0 on success, 1 on any failure.
 """
@@ -37,6 +38,7 @@ def validate_app(app: str) -> list[str]:
 
     cf_dir = BASE / app / "cf"
     cf_groups_dir = BASE / app / "cf-groups"
+    conflicts_file = BASE / app / "conflicts.json"
     profiles_dir = BASE / app / "quality-profiles"
 
     # --- Load all CF files ---
@@ -127,6 +129,34 @@ def validate_app(app: str) -> list[str]:
                     f"[{app}] cf-groups/{filename} name mismatch:"
                     f" '{entry_name}' but cf/{cf_filename} has '{cf_name}'"
                 )
+
+    # --- Check 4: conflicts.json entries reference valid CFs ---
+    if conflicts_file.is_file():
+        conflicts_data = load_json(conflicts_file, errors)
+        if conflicts_data is not None:
+            for group in conflicts_data.get("custom_formats", []):
+                for tid, entry in group.items():
+                    if tid == "$schema":
+                        continue
+                    if not isinstance(entry, dict):
+                        continue
+                    entry_name = entry.get("name", "")
+
+                    if tid not in cf_by_tid:
+                        errors.append(
+                            f"[{app}] conflicts.json references trash_id"
+                            f" '{tid}' ({entry_name}) which doesn't exist"
+                            f" in {app} CFs"
+                        )
+                        continue
+
+                    cf_filename, cf_name = cf_by_tid[tid]
+                    if entry_name != cf_name:
+                        errors.append(
+                            f"[{app}] conflicts.json name mismatch:"
+                            f" '{entry_name}' but cf/{cf_filename}"
+                            f" has '{cf_name}'"
+                        )
 
     return errors
 


### PR DESCRIPTION
## Summary

Adds schema validation and cross-file consistency checks for the `conflicts.json` files introduced in #2681.

### Schema validation
Wires up `schemas/conflicts.schema.json` to both:
- `.pre-commit-config.yaml` (new `check-jsonschema` hook)
- `.github/workflows/custom-format-validation.yml` (new CI step)

### Cross-file consistency (in `validate-custom-formats.py`)
For each entry in a conflict group:
- **`trash_id` exists**: the key must match an actual CF file in `{app}/cf/`
- **`name` matches**: the `name` property must match the CF's `name` field

## Error examples

**Conflict entry references a `trash_id` that doesn't exist:**
```
ERROR: [radarr] conflicts.json references trash_id 'abc123...' (Some CF) which doesn't exist in radarr CFs
```

**Conflict entry name doesn't match the source CF:**
```
ERROR: [radarr] conflicts.json name mismatch: 'SDR (No WEBDL)' but cf/sdr-no-webdl.json has 'SDR (no WEBDL)'
```

## Test plan
- [x] Rebase onto master after #2681 merged
- [x] Run `python scripts/validate-custom-formats.py` — passes with no errors
- [x] Run `check-jsonschema` against both conflicts files — passes
- [x] Run `ruff` lint and format checks — clean
- [x] Change a conflict entry's `name` to mismatch its CF — script catches it
- [x] Change a conflict entry's key to a nonexistent `trash_id` — script catches it
- [x] Introduce a malformed conflicts.json — schema validation catches it (invalid key pattern + minProperties)

## Summary by Sourcery

Add validation and CI wiring for conflicts.json custom format conflict definitions.

New Features:
- Introduce conflicts.json cross-file consistency checks ensuring referenced custom formats exist and names match.

Enhancements:
- Extend custom format validation script to include conflicts.json files for each app.

Build:
- Add pre-commit hook to validate conflicts.json files against the conflicts schema.
- Expand validate-custom-formats pre-commit hook to run when conflicts.json files change.

CI:
- Run JSON Schema validation for radarr and sonarr conflicts.json files in the custom-format-validation workflow.