### PR TITLE
fix(downloaders): ensure fclones remains executable after reboot on unRAID

### DIFF
--- a/includes/downloaders/mover-tuning-end.sh
+++ b/includes/downloaders/mover-tuning-end.sh
@@ -3,8 +3,8 @@ set -euo pipefail # Exit on error, undefined variables, and pipe failures
 
 # =====================================
 # Script: qBittorrent Cache Mover - End
-# Version: 1.3.0
-# Updated: 20260314
+# Version: 1.3.1
+# Updated: 20260411
 # =====================================
 
 # Script version and update check URLs

--- a/includes/downloaders/mover-tuning-end.sh
+++ b/includes/downloaders/mover-tuning-end.sh
@@ -247,6 +247,7 @@ install_fclones_binary() {
                 echo "# fclones boot-time setup" >> "$GO_FILE"
                 echo "export PATH=/usr/local/bin:\$PATH" >> "$GO_FILE"
                 echo "cp $BOOT_DIR/fclones /usr/local/bin/fclones" >> "$GO_FILE"
+                echo "chmod +x /usr/local/bin/fclones" >> "$GO_FILE"
             else
                 log "⚠ Cannot write to $GO_FILE. Please check permissions. (continuing anyway)"
             fi

--- a/includes/downloaders/mover-tuning-end.sh
+++ b/includes/downloaders/mover-tuning-end.sh
@@ -240,24 +240,24 @@ install_fclones_binary() {
         cp "$BOOT_DIR/fclones" /usr/local/bin/fclones 2>/dev/null || true
         chmod +x /usr/local/bin/fclones 2>/dev/null || true
 
-		# Add boot-time copy and PATH setup if not already in /boot/config/go
-		if [ -w "$GO_FILE" ]; then
-			if grep -q "^# fclones boot-time setup$" "$GO_FILE" 2>/dev/null; then
-				# Upgrade legacy boot-time setup from cp to guarded install -m 755
-				sed -i -E \
-					"s|^[[:space:]]*cp[[:space:]]+.*fclones[[:space:]]+/usr/local/bin/fclones[[:space:]]*$|[ -f \"$BOOT_DIR/fclones\" ] \&\& install -m 755 \"$BOOT_DIR/fclones\" \"$FCLONES_BIN\"|" \
-					"$GO_FILE"
-			else
-				{
-					echo ""
-					echo "# fclones boot-time setup"
-					echo 'export PATH=/usr/local/bin:$PATH'
-					echo "[ -f \"$BOOT_DIR/fclones\" ] && install -m 755 \"$BOOT_DIR/fclones\" \"$FCLONES_BIN\""
-				} >> "$GO_FILE"
-			fi
-		else
-			log "⚠ Cannot write to $GO_FILE. Please check permissions. (continuing anyway)"
-		fi
+        # Add boot-time copy and PATH setup if not already in /boot/config/go
+        if [ -w "$GO_FILE" ]; then
+            if grep -q "^# fclones boot-time setup$" "$GO_FILE" 2>/dev/null; then
+                # Upgrade legacy boot-time setup from cp to guarded install -m 755
+                sed -i -E \
+                    "s|^[[:space:]]*cp[[:space:]]+.*fclones[[:space:]]+/usr/local/bin/fclones[[:space:]]*$|[ -f \"$BOOT_DIR/fclones\" ] \&\& install -m 755 \"$BOOT_DIR/fclones\" \"$FCLONES_BIN\"|" \
+                    "$GO_FILE"
+            else
+                {
+                    echo ""
+                    echo "# fclones boot-time setup"
+                    echo 'export PATH=/usr/local/bin:$PATH'
+                    echo "[ -f \"$BOOT_DIR/fclones\" ] && install -m 755 \"$BOOT_DIR/fclones\" \"$FCLONES_BIN\""
+                } >> "$GO_FILE"
+            fi
+        else
+            log "⚠ Cannot write to $GO_FILE. Please check permissions. (continuing anyway)"
+        fi
 
         rm -rf "$TMP_DIR"
         log "✓ fclones $VERSION_NO_V installed successfully"

--- a/includes/downloaders/mover-tuning-end.sh
+++ b/includes/downloaders/mover-tuning-end.sh
@@ -240,18 +240,24 @@ install_fclones_binary() {
         cp "$BOOT_DIR/fclones" /usr/local/bin/fclones 2>/dev/null || true
         chmod +x /usr/local/bin/fclones 2>/dev/null || true
 
-        # Add boot-time copy and PATH setup if not already in /boot/config/go
-        if ! grep -q "fclones boot-time setup" "$GO_FILE" 2>/dev/null; then
-            if [ -w "$GO_FILE" ]; then
-                echo "" >> "$GO_FILE"
-                echo "# fclones boot-time setup" >> "$GO_FILE"
-                echo "export PATH=/usr/local/bin:\$PATH" >> "$GO_FILE"
-                echo "cp $BOOT_DIR/fclones /usr/local/bin/fclones" >> "$GO_FILE"
-                echo "chmod +x /usr/local/bin/fclones" >> "$GO_FILE"
-            else
-                log "⚠ Cannot write to $GO_FILE. Please check permissions. (continuing anyway)"
-            fi
-        fi
+		# Add boot-time copy and PATH setup if not already in /boot/config/go
+		if [ -w "$GO_FILE" ]; then
+			if grep -q "^# fclones boot-time setup$" "$GO_FILE" 2>/dev/null; then
+				# Upgrade legacy boot-time setup from cp to guarded install -m 755
+				sed -i -E \
+					"s|^[[:space:]]*cp[[:space:]]+.*fclones[[:space:]]+/usr/local/bin/fclones[[:space:]]*$|[ -f \"$BOOT_DIR/fclones\" ] \&\& install -m 755 \"$BOOT_DIR/fclones\" \"$FCLONES_BIN\"|" \
+					"$GO_FILE"
+			else
+				{
+					echo ""
+					echo "# fclones boot-time setup"
+					echo 'export PATH=/usr/local/bin:$PATH'
+					echo "[ -f \"$BOOT_DIR/fclones\" ] && install -m 755 \"$BOOT_DIR/fclones\" \"$FCLONES_BIN\""
+				} >> "$GO_FILE"
+			fi
+		else
+			log "⚠ Cannot write to $GO_FILE. Please check permissions. (continuing anyway)"
+		fi
 
         rm -rf "$TMP_DIR"
         log "✓ fclones $VERSION_NO_V installed successfully"


### PR DESCRIPTION
# Pull Request

## Purpose

On unRAID, the `fclones` binary is restored to `/usr/local/bin` at boot through the generated `/boot/config/go` boot-time setup. The current script appends `PATH` export and `cp`, but does not also restore the execute bit after the copy. As a result, `fclones` can end up present after reboot but not executable. The file this change touches is `includes/downloaders/mover-tuning-end.sh`.

## Approach

Add the following line to the block that writes the `fclones boot-time setup` section into `/boot/config/go`:

```sh
echo "chmod +x /usr/local/bin/fclones" >> "$GO_FILE"
```
This ensures the copied binary is executable on every boot, not only when the installer is first run. While

```sh
chmod +x "$BOOT_DIR/fclones" 2>/dev/null || true
```
is already applied there are cases where these permissions do not persist. This is a minimal fix for those cases.

## Open Questions and Pre-Merge TODOs

None.

## Learning

None.

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Bug Fixes:
- Restore execute permissions for the fclones binary on unRAID at boot by adding a chmod step to the boot-time setup script.