### PR TITLE
feat(radarr): Add RlsGrp `Unkn0wn` if it's not a Remux to `LQ (Release Title)` 

### DIFF
--- a/docs/json/radarr/cf/lq-release-title.json
+++ b/docs/json/radarr/cf/lq-release-title.json
@@ -127,6 +127,15 @@
       }
     },
     {
+      "name": "UnKn0wn (NoRemux)",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "(?<!\\b(remux).*?)\\b(unkn0wn)\\b"
+      }
+    },
+    {
       "name": "Will1869",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->

Add RlsGrp `Unkn0wn` if it's not a Remux to `LQ (Release Title)` 

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

Added RlsGrp `Unkn0wn` if it's not a Remux to `LQ (Release Title)` 
[RegEx Test Case](https://regex101.com/r/d14yie/1)

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

New Features:
- Add support for assigning the `Unkn0wn` release group to non-remux Radarr low-quality releases when no group is detected.