### PR TITLE
feat(starr): Add RlsGrp `R&H` to `LQ`

### DIFF
--- a/docs/json/radarr/cf/lq.json
+++ b/docs/json/radarr/cf/lq.json
@@ -684,6 +684,15 @@
       }
     },
     {
+      "name": "R&H",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(R&H)$"
+      }
+    },
+    {
       "name": "RARBG",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,

--- a/docs/json/sonarr/cf/lq.json
+++ b/docs/json/sonarr/cf/lq.json
@@ -198,6 +198,15 @@
       }
     },
     {
+      "name": "R&H",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(R&H)$"
+      }
+    },
+    {
       "name": "SasukeducK",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->

Add RlsGrp `R&H` to `LQ`
They are known to create fake DV/HDR10(+)

The reason they aren't added to the `Generated Dynamic HDR` is that they don't only create Dynamic HDR Formats but also static HDR10. 

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

Added RlsGrp `R&H` to `LQ`

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Add the R&H release group to the low-quality (LQ) custom format configuration for both Radarr and Sonarr JSON guides.

New Features:
- Recognize the R&H release group as low quality (LQ) content in Radarr custom format configuration.
- Recognize the R&H release group as low quality (LQ) content in Sonarr custom format configuration.