### PR TITLE
fix(guide-sync): Add missing VOSTFR custom format in French VOSTFR quality profiles

### DIFF
--- a/docs/json/radarr/quality-profiles/french-vostfr-hd-bluray-web.json
+++ b/docs/json/radarr/quality-profiles/french-vostfr-hd-bluray-web.json
@@ -139,6 +139,7 @@
     "VOQ": "f7caa1942be5cc547c266bd3dbc2cda9",
     "VQ": "95aa50f71a01c82354a7a2b385f1c4d8",
     "VFB": "b3fb499641d7b3c2006be1d9eb014cb3",
+    "VOSTFR": "9172b2f683f6223e3a1846427b417a3d",
     "Language: Not Original": "d6e9318c875905d6cfb5bee961afcea9",
     "Language: Not French": "533f782474f0819643c2ec0c1eeeb0ac",
     "Language: Original + French": "0542a48746585dc4444bbbb8a6bdf6ea",

--- a/docs/json/radarr/quality-profiles/french-vostfr-hd-remux-web.json
+++ b/docs/json/radarr/quality-profiles/french-vostfr-hd-remux-web.json
@@ -139,6 +139,7 @@
     "VOQ": "f7caa1942be5cc547c266bd3dbc2cda9",
     "VQ": "95aa50f71a01c82354a7a2b385f1c4d8",
     "VFB": "b3fb499641d7b3c2006be1d9eb014cb3",
+    "VOSTFR": "9172b2f683f6223e3a1846427b417a3d",
     "Language: Not Original": "d6e9318c875905d6cfb5bee961afcea9",
     "Language: Not French": "533f782474f0819643c2ec0c1eeeb0ac",
     "Language: Original + French": "0542a48746585dc4444bbbb8a6bdf6ea",

--- a/docs/json/radarr/quality-profiles/french-vostfr-uhd-bluray-web.json
+++ b/docs/json/radarr/quality-profiles/french-vostfr-uhd-bluray-web.json
@@ -139,6 +139,7 @@
     "VOQ": "f7caa1942be5cc547c266bd3dbc2cda9",
     "VQ": "95aa50f71a01c82354a7a2b385f1c4d8",
     "VFB": "b3fb499641d7b3c2006be1d9eb014cb3",
+    "VOSTFR": "9172b2f683f6223e3a1846427b417a3d",
     "Language: Not Original": "d6e9318c875905d6cfb5bee961afcea9",
     "Language: Not French": "533f782474f0819643c2ec0c1eeeb0ac",
     "Language: Original + French": "0542a48746585dc4444bbbb8a6bdf6ea",

--- a/docs/json/radarr/quality-profiles/french-vostfr-uhd-remux-web.json
+++ b/docs/json/radarr/quality-profiles/french-vostfr-uhd-remux-web.json
@@ -139,6 +139,7 @@
     "VOQ": "f7caa1942be5cc547c266bd3dbc2cda9",
     "VQ": "95aa50f71a01c82354a7a2b385f1c4d8",
     "VFB": "b3fb499641d7b3c2006be1d9eb014cb3",
+    "VOSTFR": "9172b2f683f6223e3a1846427b417a3d",
     "Language: Not Original": "d6e9318c875905d6cfb5bee961afcea9",
     "Language: Not French": "533f782474f0819643c2ec0c1eeeb0ac",
     "Language: Original + French": "0542a48746585dc4444bbbb8a6bdf6ea",

--- a/docs/json/sonarr/quality-profiles/french-vostfr-bluray-web-1080p.json
+++ b/docs/json/sonarr/quality-profiles/french-vostfr-bluray-web-1080p.json
@@ -104,6 +104,7 @@
     "VOQ": "802dd70b856c423a9b0cb7f34ac42be1",
     "VQ": "82085412d9a53ba8d8e46fc624eb701d",
     "VFB": "0ce1e39a4676c6692ce47935278dac76",
+    "VOSTFR": "07a32f77690263bb9fda1842db7e273f",
     "Language: Not Original": "ae575f95ab639ba5d15f663bf019e3e8",
     "Language: Not French": "322fca6f8f3694acc1401ddb530fd33d",
     "Language: Original + French": "10e77b96ae4770a7de645a91a53ce29a",

--- a/docs/json/sonarr/quality-profiles/french-vostfr-bluray-web-2160p.json
+++ b/docs/json/sonarr/quality-profiles/french-vostfr-bluray-web-2160p.json
@@ -104,6 +104,7 @@
     "VOQ": "802dd70b856c423a9b0cb7f34ac42be1",
     "VQ": "82085412d9a53ba8d8e46fc624eb701d",
     "VFB": "0ce1e39a4676c6692ce47935278dac76",
+    "VOSTFR": "07a32f77690263bb9fda1842db7e273f",
     "Language: Not Original": "ae575f95ab639ba5d15f663bf019e3e8",
     "Language: Not French": "322fca6f8f3694acc1401ddb530fd33d",
     "Language: Original + French": "10e77b96ae4770a7de645a91a53ce29a",


### PR DESCRIPTION
# Pull Request

## Purpose

Add missing VOSTFR custom format in VOSTFR quality profiles.

## Approach

When using Recyclarr with a French VOSTFR quality profile, the VOSTFR custom format is not included by default. This change will fix this.

## Requirements

- [X] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [X] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Include the VOSTFR custom format in all French VOSTFR Radarr and Sonarr quality profile JSON definitions.

Bug Fixes:
- Ensure French VOSTFR Radarr quality profiles include the appropriate VOSTFR custom format.
- Ensure French VOSTFR Sonarr quality profiles include the appropriate VOSTFR custom format.

Documentation:
- Update documented Radarr French VOSTFR quality profile JSON files to reference the VOSTFR custom format.
- Update documented Sonarr French VOSTFR quality profile JSON files to reference the VOSTFR custom format.