### PR TITLE
feat(starr): Add new Custom Format `WiTH.ASL`, `WiTH.BSL`, and update `WiTH.AD`

### DIFF
--- a/docs/Radarr/Radarr-collection-of-custom-formats.md
+++ b/docs/Radarr/Radarr-collection-of-custom-formats.md
@@ -125,9 +125,9 @@ We've made 3 guides related to this.
 | [Scene](#scene)                                       |                                                                                                                       |
 | [VC-1](#vc-1)                                         |                                                                                                                       |
 | [VP9](#vp9)                                           |                                                                                                                       |
-| [WiTH.AD](#with-ad)                                   |                                                                                                                       |
-| [WiTH.ASL](#with-asl)                                 |                                                                                                                       |
-| [WiTH.BSL](#with-bsl)                                 |                                                                                                                       |
+| [WiTH AD](#with-ad)                                    |                                                                                                                       |
+| [WiTH ASL](#with-asl)                                  |                                                                                                                       |
+| [WiTH BSL](#with-bsl)                                  |                                                                                                                       |
 | [x264](#x264)                                         |                                                                                                                       |
 | [x265 (no HDR/DV)](#x265-no-hdrdv)                    |                                                                                                                       |
 | [x265](#x265)                                         |                                                                                                                       |
@@ -1409,7 +1409,7 @@ We've made 3 guides related to this.
 
 ---
 
-### WiTH.AD
+### WiTH AD
 
 ??? question "Description - [Click to show/hide]"
 
@@ -1425,7 +1425,7 @@ We've made 3 guides related to this.
 
 ---
 
-### WiTH.ASL
+### WiTH ASL
 
 ??? question "Description - [Click to show/hide]"
 
@@ -1441,7 +1441,7 @@ We've made 3 guides related to this.
 
 ---
 
-### WiTH.BSL
+### WiTH BSL
 
 ??? question "Description - [Click to show/hide]"
 

--- a/docs/Radarr/Radarr-collection-of-custom-formats.md
+++ b/docs/Radarr/Radarr-collection-of-custom-formats.md
@@ -102,36 +102,33 @@ We've made 3 guides related to this.
 
 ---
 
-| Miscellaneous                                         | Language profiles                                                                                                     |
-|-------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------|
-| [720p](#720p)                                         | [Language: German](#language-german)                                                                                  |
-| [1080p](#1080p)                                       | [Language: German DL](#language-german-dl)                                                                            |
-| [2160p](#2160p)                                       | [Language: German DL (undefined)](#language-german-dl-undefined)                                                      |
-| [Bad Dual Groups](#bad-dual-groups)                   | [Language: Not English (English Only)](#language-not-english)                                                         |
-| [Black and White Editions](#black-and-white-editions) | [Language: Not French (French Only)](#language-not-french)                                                            |
-| [Dutch Groups](#dutch-groups)                         | [Language: Not Original (Original Only)](#language-not-original)                                                      |
-| [FreeLeech](#freeleech)                               | [Language: Original + French](#language-original-plus-french)                                                         |
-| [HFR](#hfr)                                           | [Language: Not German or English](#language-not-german-or-english)                                                    |
-| [Internal](#internal)                                 | [Language: Not German, Japanese or English](#language-not-german-japanese-or-english)                                 |
-| [MPEG2](#mpeg2)                                       | [Language: Not German, Japanese, Korean, Chinese or English](#language-not-german-japanese-korean-chinese-or-english) |
-| [Multi](#multi)                                       | [Language: German Anime Subbed](#language-german-anime-subbed)                                                        |
-| [No-RlsGroup](#no-rlsgroup)                           |                                                                                                                       |
-| [Obfuscated](#obfuscated)                             |                                                                                                                       |
-| [P2P Internal](#p2p-internal)                         |                                                                                                                       |
-| [Repack/Proper](#repackproper)                        |                                                                                                                       |
-| [Repack2](#repack2)                                   |                                                                                                                       |
-| [Repack3](#repack3)                                   |                                                                                                                       |
-| [Retags](#retags)                                     |                                                                                                                       |
-| [Scene](#scene)                                       |                                                                                                                       |
-| [VC-1](#vc-1)                                         |                                                                                                                       |
-| [VP9](#vp9)                                           |                                                                                                                       |
-| [WiTH AD](#with-ad)                                   |                                                                                                                       |
-| [WiTH ASL](#with-asl)                                 |                                                                                                                       |
-| [WiTH BSL](#with-bsl)                                 |                                                                                                                       |
-| [x264](#x264)                                         |                                                                                                                       |
-| [x265 (no HDR/DV)](#x265-no-hdrdv)                    |                                                                                                                       |
-| [x265](#x265)                                         |                                                                                                                       |
-| [x266](#x266)                                         |                                                                                                                       |
+| Miscellaneous                                         | Language profiles                                                                                                     | Accessibility (Optional) |
+|-------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------|--------------------------|
+| [720p](#720p)                                         | [Language: German](#language-german)                                                                                  | [WiTH AD](#with-ad)      |
+| [1080p](#1080p)                                       | [Language: German DL](#language-german-dl)                                                                            | [WiTH ASL](#with-asl)    |
+| [2160p](#2160p)                                       | [Language: German DL (undefined)](#language-german-dl-undefined)                                                      | [WiTH BASL](#with-basl)  |
+| [Bad Dual Groups](#bad-dual-groups)                   | [Language: Not English (English Only)](#language-not-english)                                                         | [WiTH BSL](#with-bsl)    |
+| [Black and White Editions](#black-and-white-editions) | [Language: Not French (French Only)](#language-not-french)                                                            |                          |
+| [Dutch Groups](#dutch-groups)                         | [Language: Not Original (Original Only)](#language-not-original)                                                      |                          |
+| [FreeLeech](#freeleech)                               | [Language: Original + French](#language-original-plus-french)                                                         |                          |
+| [HFR](#hfr)                                           | [Language: Not German or English](#language-not-german-or-english)                                                    |                          |
+| [Internal](#internal)                                 | [Language: Not German, Japanese or English](#language-not-german-japanese-or-english)                                 |                          |
+| [MPEG2](#mpeg2)                                       | [Language: Not German, Japanese, Korean, Chinese or English](#language-not-german-japanese-korean-chinese-or-english) |                          |
+| [Multi](#multi)                                       | [Language: German Anime Subbed](#language-german-anime-subbed)                                                        |                          |
+| [No-RlsGroup](#no-rlsgroup)                           |                                                                                                                       |                          |
+| [Obfuscated](#obfuscated)                             |                                                                                                                       |                          |
+| [P2P Internal](#p2p-internal)                         |                                                                                                                       |                          |
+| [Repack/Proper](#repackproper)                        |                                                                                                                       |                          |
+| [Repack2](#repack2)                                   |                                                                                                                       |                          |
+| [Repack3](#repack3)                                   |                                                                                                                       |                          |
+| [Retags](#retags)                                     |                                                                                                                       |                          |
+| [Scene](#scene)                                       |                                                                                                                       |                          |
+| [VC-1](#vc-1)                                         |                                                                                                                       |                          |
+| [VP9](#vp9)                                           |                                                                                                                       |                          |
+| [x264](#x264)                                         |                                                                                                                       |                          |
+| [x265 (no HDR/DV)](#x265-no-hdrdv)                    |                                                                                                                       |                          |
+| [x265](#x265)                                         |                                                                                                                       |                          |
+| [x266](#x266)                                         |                                                                                                                       |                          |
 
 ---
 
@@ -1409,7 +1406,13 @@ We've made 3 guides related to this.
 
 ---
 
+## Accessibility (Optional)
+
+---
+
 ### WiTH AD
+
+<sub>Audio Description</sub>
 
 ??? question "Description - [Click to show/hide]"
 
@@ -1427,6 +1430,8 @@ We've made 3 guides related to this.
 
 ### WiTH ASL
 
+<sub>American Sign Language</sub>
+
 ??? question "Description - [Click to show/hide]"
 
     {! include-markdown "../../includes/cf-descriptions/with-asl.md" !}
@@ -1441,7 +1446,27 @@ We've made 3 guides related to this.
 
 ---
 
+### WiTH BASL
+
+<sub>Black American Sign Language</sub>
+
+??? question "Description - [Click to show/hide]"
+
+    {! include-markdown "../../includes/cf-descriptions/with-basl.md" !}
+
+??? example "JSON - [Click to show/hide]"
+
+    ```json
+    [[% filter indent(width=4) %]][[% include 'json/radarr/cf/with-basl.json' %]][[% endfilter %]]
+    ```
+
+<sub><sup>[TOP](#index)</sup></sub>
+
+---
+
 ### WiTH BSL
+
+<sub>British Sign Language</sub>
 
 ??? question "Description - [Click to show/hide]"
 

--- a/docs/Radarr/Radarr-collection-of-custom-formats.md
+++ b/docs/Radarr/Radarr-collection-of-custom-formats.md
@@ -125,9 +125,9 @@ We've made 3 guides related to this.
 | [Scene](#scene)                                       |                                                                                                                       |
 | [VC-1](#vc-1)                                         |                                                                                                                       |
 | [VP9](#vp9)                                           |                                                                                                                       |
-| [WiTH AD](#with-ad)                                    |                                                                                                                       |
-| [WiTH ASL](#with-asl)                                  |                                                                                                                       |
-| [WiTH BSL](#with-bsl)                                  |                                                                                                                       |
+| [WiTH AD](#with-ad)                                   |                                                                                                                       |
+| [WiTH ASL](#with-asl)                                 |                                                                                                                       |
+| [WiTH BSL](#with-bsl)                                 |                                                                                                                       |
 | [x264](#x264)                                         |                                                                                                                       |
 | [x265 (no HDR/DV)](#x265-no-hdrdv)                    |                                                                                                                       |
 | [x265](#x265)                                         |                                                                                                                       |

--- a/docs/Radarr/Radarr-collection-of-custom-formats.md
+++ b/docs/Radarr/Radarr-collection-of-custom-formats.md
@@ -125,9 +125,9 @@ We've made 3 guides related to this.
 | [Scene](#scene)                                       |                                                                                                                       |
 | [VC-1](#vc-1)                                         |                                                                                                                       |
 | [VP9](#vp9)                                           |                                                                                                                       |
-| [WiTH AD](#with-ad)                                   |                                                                                                                       |
-| [WiTH ASL](#with-asl)                                 |                                                                                                                       |
-| [WiTH BSL](#with-bsl)                                 |                                                                                                                       |
+| [WiTH.AD](#with-ad)                                   |                                                                                                                       |
+| [WiTH.ASL](#with-asl)                                 |                                                                                                                       |
+| [WiTH.BSL](#with-bsl)                                 |                                                                                                                       |
 | [x264](#x264)                                         |                                                                                                                       |
 | [x265 (no HDR/DV)](#x265-no-hdrdv)                    |                                                                                                                       |
 | [x265](#x265)                                         |                                                                                                                       |
@@ -1409,7 +1409,7 @@ We've made 3 guides related to this.
 
 ---
 
-### WiTH AD
+### WiTH.AD
 
 ??? question "Description - [Click to show/hide]"
 
@@ -1425,7 +1425,7 @@ We've made 3 guides related to this.
 
 ---
 
-### WiTH ASL
+### WiTH.ASL
 
 ??? question "Description - [Click to show/hide]"
 
@@ -1441,7 +1441,7 @@ We've made 3 guides related to this.
 
 ---
 
-### WiTH BSL
+### WiTH.BSL
 
 ??? question "Description - [Click to show/hide]"
 

--- a/docs/Radarr/Radarr-collection-of-custom-formats.md
+++ b/docs/Radarr/Radarr-collection-of-custom-formats.md
@@ -126,6 +126,8 @@ We've made 3 guides related to this.
 | [VC-1](#vc-1)                                         |                                                                                                                       |
 | [VP9](#vp9)                                           |                                                                                                                       |
 | [WiTH AD](#with-ad)                                   |                                                                                                                       |
+| [WiTH ASL](#with-asl)                                 |                                                                                                                       |
+| [WiTH BSL](#with-bsl)                                 |                                                                                                                       |
 | [x264](#x264)                                         |                                                                                                                       |
 | [x265 (no HDR/DV)](#x265-no-hdrdv)                    |                                                                                                                       |
 | [x265](#x265)                                         |                                                                                                                       |
@@ -1417,6 +1419,38 @@ We've made 3 guides related to this.
 
     ```json
     [[% filter indent(width=4) %]][[% include 'json/radarr/cf/with-ad.json' %]][[% endfilter %]]
+    ```
+
+<sub><sup>[TOP](#index)</sup></sub>
+
+---
+
+### WiTH ASL
+
+??? question "Description - [Click to show/hide]"
+
+    {! include-markdown "../../includes/cf-descriptions/with-asl.md" !}
+
+??? example "JSON - [Click to show/hide]"
+
+    ```json
+    [[% filter indent(width=4) %]][[% include 'json/radarr/cf/with-asl.json' %]][[% endfilter %]]
+    ```
+
+<sub><sup>[TOP](#index)</sup></sub>
+
+---
+
+### WiTH BSL
+
+??? question "Description - [Click to show/hide]"
+
+    {! include-markdown "../../includes/cf-descriptions/with-bsl.md" !}
+
+??? example "JSON - [Click to show/hide]"
+
+    ```json
+    [[% filter indent(width=4) %]][[% include 'json/radarr/cf/with-bsl.json' %]][[% endfilter %]]
     ```
 
 <sub><sup>[TOP](#index)</sup></sub>

--- a/docs/Sonarr/sonarr-collection-of-custom-formats.md
+++ b/docs/Sonarr/sonarr-collection-of-custom-formats.md
@@ -121,9 +121,9 @@ Special thanks to everyone who has helped in the creation and testing of these C
 | [Season Packs](#season-pack)        |                                                                                                                       |
 | [VC-1](#vc-1)                       |                                                                                                                       |
 | [VP9](#vp9)                         |                                                                                                                       |
-| [WiTH.AD](#with-ad)                 |                                                                                                                       |
-| [WiTH.ASL](#with-asl)               |                                                                                                                       |
-| [WiTH.BSL](#with-bsl)               |                                                                                                                       |
+| [WiTH AD](#with-ad)                  |                                                                                                                       |
+| [WiTH ASL](#with-asl)                |                                                                                                                       |
+| [WiTH BSL](#with-bsl)                |                                                                                                                       |
 | [x264](#x264)                       |                                                                                                                       |
 | [x265 (no HDR/DV)](#x265-no-hdrdv)  |                                                                                                                       |
 | [x265](#x265)                       |                                                                                                                       |
@@ -1215,7 +1215,7 @@ Special thanks to everyone who has helped in the creation and testing of these C
 
 ---
 
-### WiTH.AD
+### WiTH AD
 
 ??? question "Description - [Click to show/hide]"
 
@@ -1231,7 +1231,7 @@ Special thanks to everyone who has helped in the creation and testing of these C
 
 ---
 
-### WiTH.ASL
+### WiTH ASL
 
 ??? question "Description - [Click to show/hide]"
 
@@ -1247,7 +1247,7 @@ Special thanks to everyone who has helped in the creation and testing of these C
 
 ---
 
-### WiTH.BSL
+### WiTH BSL
 
 ??? question "Description - [Click to show/hide]"
 

--- a/docs/Sonarr/sonarr-collection-of-custom-formats.md
+++ b/docs/Sonarr/sonarr-collection-of-custom-formats.md
@@ -99,35 +99,32 @@ Special thanks to everyone who has helped in the creation and testing of these C
 
 ---
 
-| Miscellaneous                       | Language profiles                                                                                                     |
-|-------------------------------------|-----------------------------------------------------------------------------------------------------------------------|
-| [720p](#720p)                       | [Language: German](#language-german)                                                                                  |
-| [1080p](#1080p)                     | [Language: German DL](#language-german-dl)                                                                            |
-| [2160p](#2160p)                     | [Language: German DL (undefined)](#language-german-dl-undefined)                                                      |
-| [Bad Dual Groups](#bad-dual-groups) | [Language: Not English (English Only)](#language-not-english)                                                         |
-| [FreeLeech](#freeleech)             | [Language: Not French (French Only)](#language-not-french)                                                            |
-| [HFR](#hfr)                         | [Language: Not Original (Original Only)](#language-not-original)                                                      |
-| [Internal](#internal)               | [Language: Original + French](#language-original-plus-french)                                                         |
-| [MPEG2](#mpeg2)                     | [Language: Not German or English](#language-not-german-or-english)                                                    |
-| [Multi](#multi)                     | [Language: Not German, Japanese or English](#language-not-german-japanese-or-english)                                 |
-| [No-RlsGroup](#no-rlsgroup)         | [Language: Not German, Japanese, Korean, Chinese or English](#language-not-german-japanese-korean-chinese-or-english) |
-| [Obfuscated](#obfuscated)           | [Language: German Anime Subbed](#language-german-anime-subbed)                                                        |
-| [P2P Internal](#p2p-internal)       |                                                                                                                       |
-| [Repack/Proper](#repackproper)      |                                                                                                                       |
-| [Repack2](#repack2)                 |                                                                                                                       |
-| [Repack3](#repack3)                 |                                                                                                                       |
-| [Retags](#retags)                   |                                                                                                                       |
-| [Scene](#scene)                     |                                                                                                                       |
-| [Season Packs](#season-pack)        |                                                                                                                       |
-| [VC-1](#vc-1)                       |                                                                                                                       |
-| [VP9](#vp9)                         |                                                                                                                       |
-| [WiTH AD](#with-ad)                 |                                                                                                                       |
-| [WiTH ASL](#with-asl)               |                                                                                                                       |
-| [WiTH BSL](#with-bsl)               |                                                                                                                       |
-| [x264](#x264)                       |                                                                                                                       |
-| [x265 (no HDR/DV)](#x265-no-hdrdv)  |                                                                                                                       |
-| [x265](#x265)                       |                                                                                                                       |
-| [x266](#x266)                       |                                                                                                                       |
+| Miscellaneous                       | Language profiles                                                                                                     | Accessibility (Optional) |
+|-------------------------------------|-----------------------------------------------------------------------------------------------------------------------|--------------------------|
+| [720p](#720p)                       | [Language: German](#language-german)                                                                                  | [WiTH AD](#with-ad)      |
+| [1080p](#1080p)                     | [Language: German DL](#language-german-dl)                                                                            | [WiTH ASL](#with-asl)    |
+| [2160p](#2160p)                     | [Language: German DL (undefined)](#language-german-dl-undefined)                                                      | [WiTH BASL](#with-basl)  |
+| [Bad Dual Groups](#bad-dual-groups) | [Language: Not English (English Only)](#language-not-english)                                                         | [WiTH BSL](#with-bsl)    |
+| [FreeLeech](#freeleech)             | [Language: Not French (French Only)](#language-not-french)                                                            |                          |
+| [HFR](#hfr)                         | [Language: Not Original (Original Only)](#language-not-original)                                                      |                          |
+| [Internal](#internal)               | [Language: Original + French](#language-original-plus-french)                                                         |                          |
+| [MPEG2](#mpeg2)                     | [Language: Not German or English](#language-not-german-or-english)                                                    |                          |
+| [Multi](#multi)                     | [Language: Not German, Japanese or English](#language-not-german-japanese-or-english)                                 |                          |
+| [No-RlsGroup](#no-rlsgroup)         | [Language: Not German, Japanese, Korean, Chinese or English](#language-not-german-japanese-korean-chinese-or-english) |                          |
+| [Obfuscated](#obfuscated)           | [Language: German Anime Subbed](#language-german-anime-subbed)                                                        |                          |
+| [P2P Internal](#p2p-internal)       |                                                                                                                       |                          |
+| [Repack/Proper](#repackproper)      |                                                                                                                       |                          |
+| [Repack2](#repack2)                 |                                                                                                                       |                          |
+| [Repack3](#repack3)                 |                                                                                                                       |                          |
+| [Retags](#retags)                   |                                                                                                                       |                          |
+| [Scene](#scene)                     |                                                                                                                       |                          |
+| [Season Packs](#season-pack)        |                                                                                                                       |                          |
+| [VC-1](#vc-1)                       |                                                                                                                       |                          |
+| [VP9](#vp9)                         |                                                                                                                       |                          |
+| [x264](#x264)                       |                                                                                                                       |                          |
+| [x265 (no HDR/DV)](#x265-no-hdrdv)  |                                                                                                                       |                          |
+| [x265](#x265)                       |                                                                                                                       |                          |
+| [x266](#x266)                       |                                                                                                                       |                          |
 
 ---
 
@@ -1215,7 +1212,13 @@ Special thanks to everyone who has helped in the creation and testing of these C
 
 ---
 
+## Accessibility (Optional)
+
+---
+
 ### WiTH AD
+
+<sub>Audio Description</sub>
 
 ??? question "Description - [Click to show/hide]"
 
@@ -1233,6 +1236,8 @@ Special thanks to everyone who has helped in the creation and testing of these C
 
 ### WiTH ASL
 
+<sub>American Sign Language</sub>
+
 ??? question "Description - [Click to show/hide]"
 
     {! include-markdown "../../includes/cf-descriptions/with-asl.md" !}
@@ -1247,7 +1252,27 @@ Special thanks to everyone who has helped in the creation and testing of these C
 
 ---
 
+### WiTH BASL
+
+<sub>Black American Sign Language</sub>
+
+??? question "Description - [Click to show/hide]"
+
+    {! include-markdown "../../includes/cf-descriptions/with-basl.md" !}
+
+??? example "JSON - [Click to show/hide]"
+
+    ```json
+    [[% filter indent(width=4) %]][[% include 'json/sonarr/cf/with-basl.json' %]][[% endfilter %]]
+    ```
+
+<sub><sup>[TOP](#index)</sup></sub>
+
+---
+
 ### WiTH BSL
+
+<sub>British Sign Language</sub>
 
 ??? question "Description - [Click to show/hide]"
 

--- a/docs/Sonarr/sonarr-collection-of-custom-formats.md
+++ b/docs/Sonarr/sonarr-collection-of-custom-formats.md
@@ -121,9 +121,9 @@ Special thanks to everyone who has helped in the creation and testing of these C
 | [Season Packs](#season-pack)        |                                                                                                                       |
 | [VC-1](#vc-1)                       |                                                                                                                       |
 | [VP9](#vp9)                         |                                                                                                                       |
-| [WiTH AD](#with-ad)                 |                                                                                                                       |
-| [WiTH ASL](#with-asl)               |                                                                                                                       |
-| [WiTH BSL](#with-bsl)               |                                                                                                                       |
+| [WiTH.AD](#with-ad)                 |                                                                                                                       |
+| [WiTH.ASL](#with-asl)               |                                                                                                                       |
+| [WiTH.BSL](#with-bsl)               |                                                                                                                       |
 | [x264](#x264)                       |                                                                                                                       |
 | [x265 (no HDR/DV)](#x265-no-hdrdv)  |                                                                                                                       |
 | [x265](#x265)                       |                                                                                                                       |
@@ -1215,7 +1215,7 @@ Special thanks to everyone who has helped in the creation and testing of these C
 
 ---
 
-### WiTH AD
+### WiTH.AD
 
 ??? question "Description - [Click to show/hide]"
 
@@ -1231,7 +1231,7 @@ Special thanks to everyone who has helped in the creation and testing of these C
 
 ---
 
-### WiTH ASL
+### WiTH.ASL
 
 ??? question "Description - [Click to show/hide]"
 
@@ -1247,7 +1247,7 @@ Special thanks to everyone who has helped in the creation and testing of these C
 
 ---
 
-### WiTH BSL
+### WiTH.BSL
 
 ??? question "Description - [Click to show/hide]"
 

--- a/docs/Sonarr/sonarr-collection-of-custom-formats.md
+++ b/docs/Sonarr/sonarr-collection-of-custom-formats.md
@@ -121,9 +121,9 @@ Special thanks to everyone who has helped in the creation and testing of these C
 | [Season Packs](#season-pack)        |                                                                                                                       |
 | [VC-1](#vc-1)                       |                                                                                                                       |
 | [VP9](#vp9)                         |                                                                                                                       |
-| [WiTH AD](#with-ad)                  |                                                                                                                       |
-| [WiTH ASL](#with-asl)                |                                                                                                                       |
-| [WiTH BSL](#with-bsl)                |                                                                                                                       |
+| [WiTH AD](#with-ad)                 |                                                                                                                       |
+| [WiTH ASL](#with-asl)               |                                                                                                                       |
+| [WiTH BSL](#with-bsl)               |                                                                                                                       |
 | [x264](#x264)                       |                                                                                                                       |
 | [x265 (no HDR/DV)](#x265-no-hdrdv)  |                                                                                                                       |
 | [x265](#x265)                       |                                                                                                                       |

--- a/docs/Sonarr/sonarr-collection-of-custom-formats.md
+++ b/docs/Sonarr/sonarr-collection-of-custom-formats.md
@@ -122,6 +122,8 @@ Special thanks to everyone who has helped in the creation and testing of these C
 | [VC-1](#vc-1)                       |                                                                                                                       |
 | [VP9](#vp9)                         |                                                                                                                       |
 | [WiTH AD](#with-ad)                 |                                                                                                                       |
+| [WiTH ASL](#with-asl)               |                                                                                                                       |
+| [WiTH BSL](#with-bsl)               |                                                                                                                       |
 | [x264](#x264)                       |                                                                                                                       |
 | [x265 (no HDR/DV)](#x265-no-hdrdv)  |                                                                                                                       |
 | [x265](#x265)                       |                                                                                                                       |
@@ -1223,6 +1225,38 @@ Special thanks to everyone who has helped in the creation and testing of these C
 
     ```json
     [[% filter indent(width=4) %]][[% include 'json/sonarr/cf/with-ad.json' %]][[% endfilter %]]
+    ```
+
+<sub><sup>[TOP](#index)</sup></sub>
+
+---
+
+### WiTH ASL
+
+??? question "Description - [Click to show/hide]"
+
+    {! include-markdown "../../includes/cf-descriptions/with-asl.md" !}
+
+??? example "JSON - [Click to show/hide]"
+
+    ```json
+    [[% filter indent(width=4) %]][[% include 'json/sonarr/cf/with-asl.json' %]][[% endfilter %]]
+    ```
+
+<sub><sup>[TOP](#index)</sup></sub>
+
+---
+
+### WiTH BSL
+
+??? question "Description - [Click to show/hide]"
+
+    {! include-markdown "../../includes/cf-descriptions/with-bsl.md" !}
+
+??? example "JSON - [Click to show/hide]"
+
+    ```json
+    [[% filter indent(width=4) %]][[% include 'json/sonarr/cf/with-bsl.json' %]][[% endfilter %]]
     ```
 
 <sub><sup>[TOP](#index)</sup></sub>

--- a/docs/json/radarr/cf-groups/optional-accessibility.json
+++ b/docs/json/radarr/cf-groups/optional-accessibility.json
@@ -1,81 +1,26 @@
 {
-  "name": "[Optional] Miscellaneous",
-  "trash_id": "9337080378236ce4c0b183e35790d2a7",
+  "name": "[Optional] Accessibility",
+  "trash_id": "bc3c13e52f2971319bc1748ffa3d1078",
   "trash_description": "Optional Custom Formats make sure to read the individual descriptions that you can find in the guide.<br>PLEASE DON'T USE THE ADD ALL OPTION FOR THIS GROUP!!!",
   "custom_formats": [
     {
-      "name": "Bad Dual Groups",
-      "trash_id": "b6832f586342ef70d9c128d40c07b872",
+      "name": "WiTH AD",
+      "trash_id": "127bdbadcf3e4463a8c707759fbaad75",
       "required": false
     },
     {
-      "name": "Black and White Editions",
-      "trash_id": "cc444569854e9de0b084ab2b8b1532b2",
+      "name": "WiTH ASL",
+      "trash_id": "09c60ba54fadb511c6986a7edec4da4b",
       "required": false
     },
     {
-      "name": "DV (Disk)",
-      "trash_id": "f700d29429c023a5734505e77daeaea7",
+      "name": "WiTH BASL",
+      "trash_id": "41e4baea7b10ddefc6609d52f742dacd",
       "required": false
     },
     {
-      "name": "HFR",
-      "trash_id": "73613461ac2cea99d52c4cd6e177ab82",
-      "required": false
-    },
-    {
-      "name": "MULTi",
-      "trash_id": "4b900e171accbfb172729b63323ea8ca",
-      "required": false
-    },
-    {
-      "name": "No-RlsGroup",
-      "trash_id": "ae9b7c9ebde1f3bd336a8cbd1ec4c5e5",
-      "required": false
-    },
-    {
-      "name": "Obfuscated",
-      "trash_id": "7357cf5161efbf8c4d5d0c30b4815ee2",
-      "required": false
-    },
-    {
-      "name": "P2P Internal",
-      "trash_id": "80f51de4636a294e31552e90d2e1decb",
-      "required": false
-    },
-    {
-      "name": "Retags",
-      "trash_id": "5c44f52a8714fdd79bb4d98e2673be1f",
-      "required": false
-    },
-    {
-      "name": "Scene",
-      "trash_id": "f537cf427b64c38c8e36298f657e4828",
-      "required": false
-    },
-    {
-      "name": "VC-1",
-      "trash_id": "11cd1db7165d6a7ad9a83bc97b8b1060",
-      "required": false
-    },
-    {
-      "name": "VP9",
-      "trash_id": "ae4cfaa9283a4f2150ac3da08e388723",
-      "required": false
-    },
-    {
-      "name": "x264",
-      "trash_id": "2899d84dc9372de3408e6d8cc18e9666",
-      "required": false
-    },
-    {
-      "name": "x265",
-      "trash_id": "9170d55c319f4fe40da8711ba9d8050d",
-      "required": false
-    },
-    {
-      "name": "x266",
-      "trash_id": "390455c22a9cac81a738f6cbad705c3c",
+      "name": "WiTH BSL",
+      "trash_id": "e205c5ba6be76b472903f4aec97fdb4b",
       "required": false
     }
   ],
@@ -108,7 +53,13 @@
       "[SQP] SQP-1 (1080p)": "0896c29d74de619df168d23b98104b22",
       "[SQP] SQP-1 (2160p)": "5128baeb2b081b72126bc8482b2a86a0",
       "[SQP] SQP-1 WEB (1080p)": "90a3370d2d30cbaf08d9c23b856a12c8",
-      "[SQP] SQP-1 WEB (2160p)": "e91c9adaca0231493f4af0d571b907f9"
+      "[SQP] SQP-1 WEB (2160p)": "e91c9adaca0231493f4af0d571b907f9",
+      "[SQP] SQP-2": "c3933358ba2356bafc41524f81471069",
+      "[SQP] SQP-3": "2cf36c1f0106ffac993be003ade51865",
+      "[SQP] SQP-3 (Audio)": "0ada8e60cc3ddf2733b65de10f4a6c72",
+      "[SQP] SQP-4": "013f89e6da27519fe56cf482702a2db9",
+      "[SQP] SQP-4 (MA Hybrid)": "7526db7ac0a1f764793fb181864d0222",
+      "[SQP] SQP-5": "a7bb1539fd147256b21b1098f3dc2016"
     }
   }
 }

--- a/docs/json/radarr/cf-groups/optional-misc-sqp.json
+++ b/docs/json/radarr/cf-groups/optional-misc-sqp.json
@@ -64,17 +64,17 @@
       "required": false
     },
     {
-      "name": "WiTH AD",
+      "name": "WiTH.AD",
       "trash_id": "127bdbadcf3e4463a8c707759fbaad75",
       "required": false
     },
     {
-      "name": "WiTH ASL",
+      "name": "WiTH.ASL",
       "trash_id": "09c60ba54fadb511c6986a7edec4da4b",
       "required": false
     },
     {
-      "name": "WiTH BSL",
+      "name": "WiTH.BSL",
       "trash_id": "e205c5ba6be76b472903f4aec97fdb4b",
       "required": false
     },

--- a/docs/json/radarr/cf-groups/optional-misc-sqp.json
+++ b/docs/json/radarr/cf-groups/optional-misc-sqp.json
@@ -64,21 +64,6 @@
       "required": false
     },
     {
-      "name": "WiTH AD",
-      "trash_id": "127bdbadcf3e4463a8c707759fbaad75",
-      "required": false
-    },
-    {
-      "name": "WiTH ASL",
-      "trash_id": "09c60ba54fadb511c6986a7edec4da4b",
-      "required": false
-    },
-    {
-      "name": "WiTH BSL",
-      "trash_id": "e205c5ba6be76b472903f4aec97fdb4b",
-      "required": false
-    },
-    {
       "name": "x265",
       "trash_id": "9170d55c319f4fe40da8711ba9d8050d",
       "required": false

--- a/docs/json/radarr/cf-groups/optional-misc-sqp.json
+++ b/docs/json/radarr/cf-groups/optional-misc-sqp.json
@@ -1,7 +1,7 @@
 {
   "name": "[Optional] Miscellaneous SQP",
   "trash_id": "c4492eebd0c2ddc14c2c91623aa7f95d",
-  "trash_description": "Optional Custom Formats make sure to read the individual descriptions that you can find in the guide.",
+  "trash_description": "Optional Custom Formats make sure to read the individual descriptions that you can find in the guide.<br>PLEASE DON'T USE THE ADD ALL OPTION FOR THIS GROUP!!!",
   "custom_formats": [
     {
       "name": "Bad Dual Groups",
@@ -61,6 +61,21 @@
     {
       "name": "VP9",
       "trash_id": "ae4cfaa9283a4f2150ac3da08e388723",
+      "required": false
+    },
+    {
+      "name": "WiTH AD",
+      "trash_id": "127bdbadcf3e4463a8c707759fbaad75",
+      "required": false
+    },
+    {
+      "name": "WiTH ASL",
+      "trash_id": "09c60ba54fadb511c6986a7edec4da4b",
+      "required": false
+    },
+    {
+      "name": "WiTH BSL",
+      "trash_id": "e205c5ba6be76b472903f4aec97fdb4b",
       "required": false
     },
     {

--- a/docs/json/radarr/cf-groups/optional-misc-sqp.json
+++ b/docs/json/radarr/cf-groups/optional-misc-sqp.json
@@ -64,17 +64,17 @@
       "required": false
     },
     {
-      "name": "WiTH.AD",
+      "name": "WiTH AD",
       "trash_id": "127bdbadcf3e4463a8c707759fbaad75",
       "required": false
     },
     {
-      "name": "WiTH.ASL",
+      "name": "WiTH ASL",
       "trash_id": "09c60ba54fadb511c6986a7edec4da4b",
       "required": false
     },
     {
-      "name": "WiTH.BSL",
+      "name": "WiTH BSL",
       "trash_id": "e205c5ba6be76b472903f4aec97fdb4b",
       "required": false
     },

--- a/docs/json/radarr/cf-groups/optional-misc.json
+++ b/docs/json/radarr/cf-groups/optional-misc.json
@@ -64,17 +64,17 @@
       "required": false
     },
     {
-      "name": "WiTH AD",
+      "name": "WiTH.AD",
       "trash_id": "127bdbadcf3e4463a8c707759fbaad75",
       "required": false
     },
     {
-      "name": "WiTH ASL",
+      "name": "WiTH.ASL",
       "trash_id": "09c60ba54fadb511c6986a7edec4da4b",
       "required": false
     },
     {
-      "name": "WiTH BSL",
+      "name": "WiTH.BSL",
       "trash_id": "e205c5ba6be76b472903f4aec97fdb4b",
       "required": false
     },

--- a/docs/json/radarr/cf-groups/optional-misc.json
+++ b/docs/json/radarr/cf-groups/optional-misc.json
@@ -1,7 +1,7 @@
 {
   "name": "[Optional] Miscellaneous",
   "trash_id": "9337080378236ce4c0b183e35790d2a7",
-  "trash_description": "Optional Custom Formats make sure to read the individual descriptions that you can find in the guide.",
+  "trash_description": "Optional Custom Formats make sure to read the individual descriptions that you can find in the guide.<br>PLEASE DON'T USE THE ADD ALL OPTION FOR THIS GROUP!!!",
   "custom_formats": [
     {
       "name": "Bad Dual Groups",
@@ -61,6 +61,21 @@
     {
       "name": "VP9",
       "trash_id": "ae4cfaa9283a4f2150ac3da08e388723",
+      "required": false
+    },
+    {
+      "name": "WiTH AD",
+      "trash_id": "127bdbadcf3e4463a8c707759fbaad75",
+      "required": false
+    },
+    {
+      "name": "WiTH ASL",
+      "trash_id": "09c60ba54fadb511c6986a7edec4da4b",
+      "required": false
+    },
+    {
+      "name": "WiTH BSL",
+      "trash_id": "e205c5ba6be76b472903f4aec97fdb4b",
       "required": false
     },
     {

--- a/docs/json/radarr/cf-groups/optional-misc.json
+++ b/docs/json/radarr/cf-groups/optional-misc.json
@@ -64,17 +64,17 @@
       "required": false
     },
     {
-      "name": "WiTH.AD",
+      "name": "WiTH AD",
       "trash_id": "127bdbadcf3e4463a8c707759fbaad75",
       "required": false
     },
     {
-      "name": "WiTH.ASL",
+      "name": "WiTH ASL",
       "trash_id": "09c60ba54fadb511c6986a7edec4da4b",
       "required": false
     },
     {
-      "name": "WiTH.BSL",
+      "name": "WiTH BSL",
       "trash_id": "e205c5ba6be76b472903f4aec97fdb4b",
       "required": false
     },

--- a/docs/json/radarr/cf/with-ad.json
+++ b/docs/json/radarr/cf/with-ad.json
@@ -1,6 +1,6 @@
 {
   "trash_id": "127bdbadcf3e4463a8c707759fbaad75",
-  "trash_regex": "https://regex101.com/r/7nyTS8/1",
+  "trash_regex": "https://regex101.com/r/U7fmvU/1",
   "name": "WiTH AD",
   "includeCustomFormatWhenRenaming": true,
   "specifications": [

--- a/docs/json/radarr/cf/with-ad.json
+++ b/docs/json/radarr/cf/with-ad.json
@@ -1,6 +1,6 @@
 {
   "trash_id": "127bdbadcf3e4463a8c707759fbaad75",
-  "trash_regex": "https://regex101.com/r/U7fmvU/1",
+  "trash_regex": "https://regex101.com/r/YWHIIr/1",
   "name": "WiTH AD",
   "includeCustomFormatWhenRenaming": true,
   "specifications": [

--- a/docs/json/radarr/cf/with-ad.json
+++ b/docs/json/radarr/cf/with-ad.json
@@ -1,6 +1,6 @@
 {
   "trash_id": "127bdbadcf3e4463a8c707759fbaad75",
-  "trash_regex": "https://regex101.com/r/GCIcFI",
+  "trash_regex": "https://regex101.com/r/7nyTS8/1",
   "name": "WiTH.AD",
   "includeCustomFormatWhenRenaming": true,
   "specifications": [
@@ -10,7 +10,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\b((FRENCH|MULTi|WiTH)[ .-]AD)\\b"
+        "value": "\\b((FRENCH|MULTi|WiTH)[ ._-](AD|Audio[ ._-]Description))\\b"
       }
     }
   ]

--- a/docs/json/radarr/cf/with-ad.json
+++ b/docs/json/radarr/cf/with-ad.json
@@ -10,7 +10,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\b((FRENCH|MULTi|WiTH|([AB]SL[ ._-]and))[ ._-](AD|Audio[ ._-]Description))\\b"
+        "value": "\\b((FRENCH|MULTi|WiTH|((BA?|A)SL[ ._-]and))[ ._-](AD|Audio[ ._-]Description))\\b"
       }
     }
   ]

--- a/docs/json/radarr/cf/with-ad.json
+++ b/docs/json/radarr/cf/with-ad.json
@@ -1,7 +1,7 @@
 {
   "trash_id": "127bdbadcf3e4463a8c707759fbaad75",
   "trash_regex": "https://regex101.com/r/7nyTS8/1",
-  "name": "WiTH.AD",
+  "name": "WiTH AD",
   "includeCustomFormatWhenRenaming": true,
   "specifications": [
     {

--- a/docs/json/radarr/cf/with-ad.json
+++ b/docs/json/radarr/cf/with-ad.json
@@ -10,7 +10,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\b((FRENCH|MULTi|WiTH)[ ._-](AD|Audio[ ._-]Description))\\b"
+        "value": "\\b((FRENCH|MULTi|WiTH|([AB]SL[ ._-]and))[ ._-](AD|Audio[ ._-]Description))\\b"
       }
     }
   ]

--- a/docs/json/radarr/cf/with-asl.json
+++ b/docs/json/radarr/cf/with-asl.json
@@ -1,6 +1,11 @@
 {
   "trash_id": "09c60ba54fadb511c6986a7edec4da4b",
   "trash_regex": "https://regex101.com/r/DuHsnc/1",
+  "trash_scores": {
+    "default": -10000,
+    "german": -35000,
+    "german-anime": -35000
+  },
   "name": "WiTH ASL",
   "includeCustomFormatWhenRenaming": true,
   "specifications": [

--- a/docs/json/radarr/cf/with-asl.json
+++ b/docs/json/radarr/cf/with-asl.json
@@ -1,0 +1,17 @@
+{
+  "trash_id": "09c60ba54fadb511c6986a7edec4da4b",
+  "trash_regex": "https://regex101.com/r/DuHsnc/1",
+  "name": "WiTH.ASL",
+  "includeCustomFormatWhenRenaming": true,
+  "specifications": [
+    {
+      "name": "American Sign Language",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": true,
+      "fields": {
+        "value": "\\b((WiTH)[ ._-](ASL))\\b"
+      }
+    }
+  ]
+}

--- a/docs/json/radarr/cf/with-asl.json
+++ b/docs/json/radarr/cf/with-asl.json
@@ -1,7 +1,7 @@
 {
   "trash_id": "09c60ba54fadb511c6986a7edec4da4b",
   "trash_regex": "https://regex101.com/r/DuHsnc/1",
-  "name": "WiTH.ASL",
+  "name": "WiTH ASL",
   "includeCustomFormatWhenRenaming": true,
   "specifications": [
     {

--- a/docs/json/radarr/cf/with-basl.json
+++ b/docs/json/radarr/cf/with-basl.json
@@ -1,6 +1,11 @@
 {
   "trash_id": "41e4baea7b10ddefc6609d52f742dacd",
   "trash_regex": "https://regex101.com/r/iCyLwn/1",
+  "trash_scores": {
+    "default": -10000,
+    "german": -35000,
+    "german-anime": -35000
+  },
   "name": "WiTH BASL",
   "includeCustomFormatWhenRenaming": true,
   "specifications": [

--- a/docs/json/radarr/cf/with-basl.json
+++ b/docs/json/radarr/cf/with-basl.json
@@ -1,0 +1,17 @@
+{
+  "trash_id": "41e4baea7b10ddefc6609d52f742dacd",
+  "trash_regex": "https://regex101.com/r/iCyLwn/1",
+  "name": "WiTH BASL",
+  "includeCustomFormatWhenRenaming": true,
+  "specifications": [
+    {
+      "name": "Black American Sign Language",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": true,
+      "fields": {
+        "value": "\\b(BASL)\\b"
+      }
+    }
+  ]
+}

--- a/docs/json/radarr/cf/with-bsl.json
+++ b/docs/json/radarr/cf/with-bsl.json
@@ -1,7 +1,7 @@
 {
   "trash_id": "e205c5ba6be76b472903f4aec97fdb4b",
   "trash_regex": "https://regex101.com/r/reTH59/1",
-  "name": "WiTH.BSL",
+  "name": "WiTH BSL",
   "includeCustomFormatWhenRenaming": true,
   "specifications": [
     {

--- a/docs/json/radarr/cf/with-bsl.json
+++ b/docs/json/radarr/cf/with-bsl.json
@@ -1,6 +1,11 @@
 {
   "trash_id": "e205c5ba6be76b472903f4aec97fdb4b",
   "trash_regex": "https://regex101.com/r/reTH59/1",
+  "trash_scores": {
+    "default": -10000,
+    "german": -35000,
+    "german-anime": -35000
+  },
   "name": "WiTH BSL",
   "includeCustomFormatWhenRenaming": true,
   "specifications": [

--- a/docs/json/radarr/cf/with-bsl.json
+++ b/docs/json/radarr/cf/with-bsl.json
@@ -1,0 +1,17 @@
+{
+  "trash_id": "e205c5ba6be76b472903f4aec97fdb4b",
+  "trash_regex": "https://regex101.com/r/reTH59/1",
+  "name": "WiTH.BSL",
+  "includeCustomFormatWhenRenaming": true,
+  "specifications": [
+    {
+      "name": "British Sign Language",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": true,
+      "fields": {
+        "value": "\\b((WiTH)[ ._-](BSL))\\b"
+      }
+    }
+  ]
+}

--- a/docs/json/sonarr/cf-groups/optional-accessibility.json
+++ b/docs/json/sonarr/cf-groups/optional-accessibility.json
@@ -15,7 +15,7 @@
     },
     {
       "name": "WiTH BASL",
-      "trash_id": "b40dc2e630723745aab9f1b94f4aab746",
+      "trash_id": "b40dc2e630723745aab9f1b94f4aab74",
       "required": false
     },
     {

--- a/docs/json/sonarr/cf-groups/optional-accessibility.json
+++ b/docs/json/sonarr/cf-groups/optional-accessibility.json
@@ -1,0 +1,48 @@
+{
+  "name": "[Optional] Accessibility",
+  "trash_id": "bad5bc85573a0134e1e1987c46f67e98",
+  "trash_description": "Optional Custom Formats make sure to read the individual descriptions that you can find in the guide.<br>PLEASE DON'T USE THE ADD ALL OPTION FOR THIS GROUP!!!",
+  "custom_formats": [
+    {
+      "name": "WiTH AD",
+      "trash_id": "44ccbcbc74506f208973e1463b11705f",
+      "required": false
+    },
+    {
+      "name": "WiTH ASL",
+      "trash_id": "c196536ea8122397c5854040d01f2aa7",
+      "required": false
+    },
+    {
+      "name": "WiTH BASL",
+      "trash_id": "b40dc2e630723745aab9f1b94f4aab746",
+      "required": false
+    },
+    {
+      "name": "WiTH BSL",
+      "trash_id": "0aef382c4ed4c5eb5d40109dfd351b72",
+      "required": false
+    }
+  ],
+  "quality_profiles": {
+    "include": {
+      "WEB-1080p": "72dae194fc92bf828f32cde7744e51a1",
+      "WEB-1080p (Alternative)": "9d142234e45d6143785ac55f5a9e8dc9",
+      "WEB-2160p": "d1498e7d189fbe6c7110ceaabb7473e6",
+      "WEB-2160p (Alternative)": "dfa5eaae7894077ad6449169b6eb03e0",
+      "WEB-2160p (Combined)": "c4cadd6b35b95f62c3d47a408e53e2f7",
+      "[Anime] Remux-1080p": "20e0fc959f1f1704bed501f23bdae76f",
+      "[French MULTi.VO] HD Bluray + WEB (1080p)": "4c48f506c1116a3a57ae33f12346bd15",
+      "[French MULTi.VO] UHD Bluray + WEB (2160p)": "6fa7364373e8f06206871d9c20a4fb3e",
+      "[French MULTi.VF] HD Bluray + WEB (1080p)": "58e8dc75731040612dd6f4ac0676bfd7",
+      "[French MULTi.VF] UHD Bluray + WEB (2160p)": "68c8b82ad2b7ea1941fce71eb56421c3",
+      "[French VOSTFR] HD Bluray + WEB (1080p)": "b34c968f58433a38e0e690d42a1dc37e",
+      "[French VOSTFR] UHD Bluray + WEB (2160p)": "d6252dce6af535107ed4b03e68052ae8",
+      "[German] HD Bluray + WEB": "dca7e5e9e99c703bcbdaaa471dd40e98",
+      "[German] HD Remux + WEB": "0dd5f085ed61a1e01f6d347779dfa1bc",
+      "[German] UHD Bluray + WEB": "3b0fa37fddaaefc931b75f2889d4b4f5",
+      "[German] UHD Bluray + WEB (Alternative)": "7324309a7d1e10dc0dc2cea6c70ed852",
+      "[German] UHD Remux + WEB": "08cececf1840290f6fd490b7d79e8642"
+    }
+  }
+}

--- a/docs/json/sonarr/cf-groups/optional-misc.json
+++ b/docs/json/sonarr/cf-groups/optional-misc.json
@@ -59,17 +59,17 @@
       "required": false
     },
     {
-      "name": "WiTH.AD",
+      "name": "WiTH AD",
       "trash_id": "44ccbcbc74506f208973e1463b11705f",
       "required": false
     },
     {
-      "name": "WiTH.ASL",
+      "name": "WiTH ASL",
       "trash_id": "c196536ea8122397c5854040d01f2aa7",
       "required": false
     },
     {
-      "name": "WiTH.BSL",
+      "name": "WiTH BSL",
       "trash_id": "0aef382c4ed4c5eb5d40109dfd351b72",
       "required": false
     },

--- a/docs/json/sonarr/cf-groups/optional-misc.json
+++ b/docs/json/sonarr/cf-groups/optional-misc.json
@@ -59,17 +59,17 @@
       "required": false
     },
     {
-      "name": "WiTH AD",
+      "name": "WiTH.AD",
       "trash_id": "44ccbcbc74506f208973e1463b11705f",
       "required": false
     },
     {
-      "name": "WiTH ASL",
+      "name": "WiTH.ASL",
       "trash_id": "c196536ea8122397c5854040d01f2aa7",
       "required": false
     },
     {
-      "name": "WiTH BSL",
+      "name": "WiTH.BSL",
       "trash_id": "0aef382c4ed4c5eb5d40109dfd351b72",
       "required": false
     },

--- a/docs/json/sonarr/cf-groups/optional-misc.json
+++ b/docs/json/sonarr/cf-groups/optional-misc.json
@@ -1,7 +1,7 @@
 {
   "name": "[Optional] Miscellaneous",
   "trash_id": "f4a0410a1df109a66d6e47dcadcce014",
-  "trash_description": "Optional Custom Formats make sure to read the individual descriptions that you can find in the guide.",
+  "trash_description": "Optional Custom Formats make sure to read the individual descriptions that you can find in the guide.<br>PLEASE DON'T USE THE ADD ALL OPTION FOR THIS GROUP!!!",
   "custom_formats": [
     {
       "name": "Bad Dual Groups",
@@ -56,6 +56,21 @@
     {
       "name": "VP9",
       "trash_id": "90501962793d580d011511155c97e4e5",
+      "required": false
+    },
+    {
+      "name": "WiTH AD",
+      "trash_id": "44ccbcbc74506f208973e1463b11705f",
+      "required": false
+    },
+    {
+      "name": "WiTH ASL",
+      "trash_id": "c196536ea8122397c5854040d01f2aa7",
+      "required": false
+    },
+    {
+      "name": "WiTH BSL",
+      "trash_id": "0aef382c4ed4c5eb5d40109dfd351b72",
       "required": false
     },
     {

--- a/docs/json/sonarr/cf/with-ad.json
+++ b/docs/json/sonarr/cf/with-ad.json
@@ -1,6 +1,6 @@
 {
   "trash_id": "44ccbcbc74506f208973e1463b11705f",
-  "trash_regex": "https://regex101.com/r/U7fmvU/1",
+  "trash_regex": "https://regex101.com/r/YWHIIr/1",
   "name": "WiTH AD",
   "includeCustomFormatWhenRenaming": true,
   "specifications": [

--- a/docs/json/sonarr/cf/with-ad.json
+++ b/docs/json/sonarr/cf/with-ad.json
@@ -1,7 +1,7 @@
 {
   "trash_id": "44ccbcbc74506f208973e1463b11705f",
   "trash_regex": "https://regex101.com/r/7nyTS8/1",
-  "name": "WiTH.AD",
+  "name": "WiTH AD",
   "includeCustomFormatWhenRenaming": true,
   "specifications": [
     {

--- a/docs/json/sonarr/cf/with-ad.json
+++ b/docs/json/sonarr/cf/with-ad.json
@@ -10,7 +10,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\b((FRENCH|MULTi|WiTH|([AB]SL[ ._-]and))[ ._-](AD|Audio[ ._-]Description))\\b"
+        "value": "\\b((FRENCH|MULTi|WiTH|((BA?|A)SL[ ._-]and))[ ._-](AD|Audio[ ._-]Description))\\b"
       }
     }
   ]

--- a/docs/json/sonarr/cf/with-ad.json
+++ b/docs/json/sonarr/cf/with-ad.json
@@ -1,6 +1,6 @@
 {
   "trash_id": "44ccbcbc74506f208973e1463b11705f",
-  "trash_regex": "https://regex101.com/r/7nyTS8/1",
+  "trash_regex": "https://regex101.com/r/U7fmvU/1",
   "name": "WiTH AD",
   "includeCustomFormatWhenRenaming": true,
   "specifications": [

--- a/docs/json/sonarr/cf/with-ad.json
+++ b/docs/json/sonarr/cf/with-ad.json
@@ -10,7 +10,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\b((FRENCH|MULTi|WiTH)[ ._-](AD|Audio[ ._-]Description))\\b"
+        "value": "\\b((FRENCH|MULTi|WiTH|([AB]SL[ ._-]and))[ ._-](AD|Audio[ ._-]Description))\\b"
       }
     }
   ]

--- a/docs/json/sonarr/cf/with-ad.json
+++ b/docs/json/sonarr/cf/with-ad.json
@@ -1,6 +1,6 @@
 {
   "trash_id": "44ccbcbc74506f208973e1463b11705f",
-  "trash_regex": "https://regex101.com/r/GCIcFI",
+  "trash_regex": "https://regex101.com/r/7nyTS8/1",
   "name": "WiTH.AD",
   "includeCustomFormatWhenRenaming": true,
   "specifications": [
@@ -10,7 +10,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\b((FRENCH|MULTi|WiTH)[ .-]AD)\\b"
+        "value": "\\b((FRENCH|MULTi|WiTH)[ ._-](AD|Audio[ ._-]Description))\\b"
       }
     }
   ]

--- a/docs/json/sonarr/cf/with-asl.json
+++ b/docs/json/sonarr/cf/with-asl.json
@@ -1,6 +1,11 @@
 {
   "trash_id": "c196536ea8122397c5854040d01f2aa7",
   "trash_regex": "https://regex101.com/r/DuHsnc/1",
+  "trash_scores": {
+    "default": -10000,
+    "german": -35000,
+    "german-anime": -35000
+  },
   "name": "WiTH ASL",
   "includeCustomFormatWhenRenaming": true,
   "specifications": [

--- a/docs/json/sonarr/cf/with-asl.json
+++ b/docs/json/sonarr/cf/with-asl.json
@@ -1,7 +1,7 @@
 {
   "trash_id": "c196536ea8122397c5854040d01f2aa7",
   "trash_regex": "https://regex101.com/r/DuHsnc/1",
-  "name": "WiTH.ASL",
+  "name": "WiTH ASL",
   "includeCustomFormatWhenRenaming": true,
   "specifications": [
     {

--- a/docs/json/sonarr/cf/with-asl.json
+++ b/docs/json/sonarr/cf/with-asl.json
@@ -1,0 +1,17 @@
+{
+  "trash_id": "c196536ea8122397c5854040d01f2aa7",
+  "trash_regex": "https://regex101.com/r/DuHsnc/1",
+  "name": "WiTH.ASL",
+  "includeCustomFormatWhenRenaming": true,
+  "specifications": [
+    {
+      "name": "American Sign Language",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": true,
+      "fields": {
+        "value": "\\b((WiTH)[ ._-](ASL))\\b"
+      }
+    }
+  ]
+}

--- a/docs/json/sonarr/cf/with-basl.json
+++ b/docs/json/sonarr/cf/with-basl.json
@@ -1,6 +1,11 @@
 {
   "trash_id": "b40dc2e630723745aab9f1b94f4aab74",
   "trash_regex": "https://regex101.com/r/iCyLwn/1",
+  "trash_scores": {
+    "default": -10000,
+    "german": -35000,
+    "german-anime": -35000
+  },
   "name": "WiTH BASL",
   "includeCustomFormatWhenRenaming": true,
   "specifications": [

--- a/docs/json/sonarr/cf/with-basl.json
+++ b/docs/json/sonarr/cf/with-basl.json
@@ -1,0 +1,17 @@
+{
+  "trash_id": "b40dc2e630723745aab9f1b94f4aab74",
+  "trash_regex": "https://regex101.com/r/iCyLwn/1",
+  "name": "WiTH BASL",
+  "includeCustomFormatWhenRenaming": true,
+  "specifications": [
+    {
+      "name": "Black American Sign Language",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": true,
+      "fields": {
+        "value": "\\b(BASL)\\b"
+      }
+    }
+  ]
+}

--- a/docs/json/sonarr/cf/with-bsl.json
+++ b/docs/json/sonarr/cf/with-bsl.json
@@ -1,6 +1,11 @@
 {
   "trash_id": "0aef382c4ed4c5eb5d40109dfd351b72",
   "trash_regex": "https://regex101.com/r/reTH59/1",
+  "trash_scores": {
+    "default": -10000,
+    "german": -35000,
+    "german-anime": -35000
+  },
   "name": "WiTH BSL",
   "includeCustomFormatWhenRenaming": true,
   "specifications": [

--- a/docs/json/sonarr/cf/with-bsl.json
+++ b/docs/json/sonarr/cf/with-bsl.json
@@ -1,0 +1,17 @@
+{
+  "trash_id": "0aef382c4ed4c5eb5d40109dfd351b72",
+  "trash_regex": "https://regex101.com/r/reTH59/1",
+  "name": "WiTH.BSL",
+  "includeCustomFormatWhenRenaming": true,
+  "specifications": [
+    {
+      "name": "British Sign Language",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": true,
+      "fields": {
+        "value": "\\b((WiTH)[ ._-](BSL))\\b"
+      }
+    }
+  ]
+}

--- a/docs/json/sonarr/cf/with-bsl.json
+++ b/docs/json/sonarr/cf/with-bsl.json
@@ -1,7 +1,7 @@
 {
   "trash_id": "0aef382c4ed4c5eb5d40109dfd351b72",
   "trash_regex": "https://regex101.com/r/reTH59/1",
-  "name": "WiTH.BSL",
+  "name": "WiTH BSL",
   "includeCustomFormatWhenRenaming": true,
   "specifications": [
     {

--- a/includes/cf-descriptions/with-ad.md
+++ b/includes/cf-descriptions/with-ad.md
@@ -9,5 +9,5 @@
 
 Audio description (AD), also referred to as a video description, described video, or visual description, is a form of narration used to provide information surrounding key visual elements in a media work (such as a film or television program, or theatrical performance) for the benefit of blind and visually impaired consumers.
 
-Some releases are now available with Audio Description, those are flagged `WiTH.AD` or just `AD`, and should not be confused with advertisements, as they are not.
+Some releases are now available with Audio Description, those are flagged `WiTH AD` or just `AD`, and should not be confused with advertisements, as they are not.
 <!-- markdownlint-enable MD036 MD041-->

--- a/includes/cf-descriptions/with-ad.md
+++ b/includes/cf-descriptions/with-ad.md
@@ -9,5 +9,5 @@
 
 Audio description (AD), also referred to as a video description, described video, or visual description, is a form of narration used to provide information surrounding key visual elements in a media work (such as a film or television program, or theatrical performance) for the benefit of blind and visually impaired consumers.
 
-Some releases are now available with Audio Description, those are flagged `WiTH AD` or just `AD`, and should not be confused with advertisements, as they are not.
+Some releases are now available with Audio Description. These are flagged `WiTH AD` or just `AD` and should not be confused with advertisements.
 <!-- markdownlint-enable MD036 MD041-->

--- a/includes/cf-descriptions/with-ad.md
+++ b/includes/cf-descriptions/with-ad.md
@@ -1,7 +1,11 @@
-<!-- markdownlint-disable MD041-->
+<!-- markdownlint-disable MD036 MD041-->
 **With Audio Description**<br>
+
+- Definition: An additional narration track for blind or visually impaired audiences that describes important visual details on screen, such as scenery, costumes, facial expressions, and action scenes.
+- Purpose: To make audio-visual content (TV, movies, theatre) accessible by describing what is not audible in the main soundtrack.
+- Difference: Unlike BSL and ASL, which are full, visual languages for communication, Audio Description is an audio-based accessibility feature.
 
 [From Wikipedia, the free encyclopedia](<https://en.wikipedia.org/wiki/Audio_description>){:target="\_blank" rel="noopener noreferrer"}
 
 Audio description (AD), also referred to as a video description, described video, or visual description, is a form of narration used to provide information surrounding key visual elements in a media work (such as a film or television program, or theatrical performance) for the benefit of blind and visually impaired consumers.
-<!-- markdownlint-enable MD041-->
+<!-- markdownlint-enable MD036 MD041-->

--- a/includes/cf-descriptions/with-ad.md
+++ b/includes/cf-descriptions/with-ad.md
@@ -8,4 +8,6 @@
 [From Wikipedia, the free encyclopedia](<https://en.wikipedia.org/wiki/Audio_description>){:target="\_blank" rel="noopener noreferrer"}
 
 Audio description (AD), also referred to as a video description, described video, or visual description, is a form of narration used to provide information surrounding key visual elements in a media work (such as a film or television program, or theatrical performance) for the benefit of blind and visually impaired consumers.
+
+Some releases are now available with Audio Description, those are flagged `WiTH.AD` or just `AD`, and should not be confused with advertisements, as they are not.
 <!-- markdownlint-enable MD036 MD041-->

--- a/includes/cf-descriptions/with-asl.md
+++ b/includes/cf-descriptions/with-asl.md
@@ -1,0 +1,9 @@
+<!-- markdownlint-disable MD036 MD041-->
+**ASL (American Sign Language)**<br>
+
+- Region: Used in the United States and English-speaking Canada.
+- Alphabet: A one-handed system.
+- Origins: Influenced heavily by French Sign Language (LSF).
+- Grammar: Often uses spatial organization to show relationships.
+- Features: Relies heavily on facial expressions to convey emotion and grammar.
+<!-- markdownlint-enable MD036 MD041-->

--- a/includes/cf-descriptions/with-basl.md
+++ b/includes/cf-descriptions/with-basl.md
@@ -1,7 +1,7 @@
 <!-- markdownlint-disable MD036 MD041-->
 **BASL (Black American Sign Language)**<br>
 
-is a distinct dialect of American Sign Language (ASL) used primarily by Black Deaf Americans, originating from segregated schools in the South. It is characterized by a larger signing space, increased use of two-handed signs, higher placement of signs (near the forehead), and greater emotional expressiveness compared to mainstream ASL.
+BASL (Black American Sign Language) is a distinct dialect of ASL (American Sign Language) used primarily by Black Deaf Americans, originating from segregated schools in the South. It is characterized by a larger signing space, increased use of two-handed signs, higher placement of signs (near the forehead), and greater emotional expressiveness compared to mainstream ASL.
 
 [From Wikipedia, the free encyclopedia](<https://en.wikipedia.org/wiki/Black_American_Sign_Language>){:target="\_blank" rel="noopener noreferrer"}
 <!-- markdownlint-enable MD036 MD041-->

--- a/includes/cf-descriptions/with-basl.md
+++ b/includes/cf-descriptions/with-basl.md
@@ -1,0 +1,7 @@
+<!-- markdownlint-disable MD036 MD041-->
+**BASL (Black American Sign Language)**<br>
+
+is a distinct dialect of American Sign Language (ASL) used primarily by Black Deaf Americans, originating from segregated schools in the South. It is characterized by a larger signing space, increased use of two-handed signs, higher placement of signs (near the forehead), and greater emotional expressiveness compared to mainstream ASL.
+
+[From Wikipedia, the free encyclopedia](<https://en.wikipedia.org/wiki/Black_American_Sign_Language>){:target="\_blank" rel="noopener noreferrer"}
+<!-- markdownlint-enable MD036 MD041-->

--- a/includes/cf-descriptions/with-bsl.md
+++ b/includes/cf-descriptions/with-bsl.md
@@ -1,0 +1,9 @@
+<!-- markdownlint-disable MD036 MD041-->
+**BSL (British Sign Language)**<br>
+
+- Region: Used in the United Kingdom (England, Scotland, Wales, and Northern Ireland).
+- Alphabet: Primarily a two-handed system.
+- Origins: Developed independently in the UK; part of the BANZSL language family (with Australian and New Zealand sign languages).
+- Grammar: Often follows a topic-comment structure.
+- Features: Heavily relies on body movement and hand shapes for nuance.
+<!-- markdownlint-enable MD036 MD041-->

--- a/includes/french-guide/radarr-french-audio-description-en.md
+++ b/includes/french-guide/radarr-french-audio-description-en.md
@@ -2,7 +2,7 @@
 ??? abstract "Audio Description - [Click to show/hide]"
 
     Some releases are now available with Audio Description, which is a way for visually impaired people to enjoy their media.
-    Those are flagged `WiTH.AD` or just `AD`, and not be confused with advertisements as they are not.
+    Those are flagged `WiTH AD` or just `AD`, and not be confused with advertisements as they are not.
 
     If you want to prefer those for any reason, please add the following CF with a score of `101`. You can still use it for information if you decide to not score it.
 

--- a/includes/french-guide/radarr-french-audio-description-en.md
+++ b/includes/french-guide/radarr-french-audio-description-en.md
@@ -2,7 +2,7 @@
 ??? abstract "Audio Description - [Click to show/hide]"
 
     Some releases are now available with Audio Description, which is a way for visually impaired people to enjoy their media.
-    Those are flagged `WiTH AD` or just `AD`, and not be confused with advertisements as they are not.
+    Those are flagged `WiTH AD` or just `AD`, and should not be confused with advertisements, as they are not.
 
     If you want to prefer those for any reason, please add the following CF with a score of `101`. You can still use it for information if you decide to not score it.
 

--- a/includes/french-guide/radarr-french-audio-description-fr.md
+++ b/includes/french-guide/radarr-french-audio-description-fr.md
@@ -2,7 +2,7 @@
 ??? abstract "Audio Description - [Click to show/hide]"
 
     Certaines releases sont maintenant disponibles avec un canal d'Audio Description, ceci afin de rendre un média accessible aux personnes aveugles ou malvoyantes.
-    Celles-ci sont marquées avec `WiTH.AD` ou `AD`, celles-ci ne doivent pas être confondues avec un média possédant des pubs (advertisements ou ads en anglais).
+    Celles-ci sont marquées avec `WiTH AD` ou `AD`, celles-ci ne doivent pas être confondues avec un média possédant des pubs (advertisements ou ads en anglais).
 
     Si vous souhaitez préférer ce type de releases, merci d'ajouter le CF suivant avec un score de `101`. Vous pouvez tout aussi l'utiliser mais à titre informatif sans le scorer.
 

--- a/includes/french-guide/sonarr-french-audio-description-en.md
+++ b/includes/french-guide/sonarr-french-audio-description-en.md
@@ -2,7 +2,7 @@
 ??? abstract "Audio Description - [Click to show/hide]"
 
     Some releases are now available with Audio Description, which is a way for visually impaired people to enjoy their media.
-    Those are flagged `WiTH.AD` or just `AD`, and not be confused with advertisements as they are not.
+    Those are flagged `WiTH AD` or just `AD`, and not be confused with advertisements as they are not.
 
     If you want to prefer those for any reason, please add the following CF with a score of `101`. You can still use it for information if you decide to not score it.
 

--- a/includes/french-guide/sonarr-french-audio-description-en.md
+++ b/includes/french-guide/sonarr-french-audio-description-en.md
@@ -2,7 +2,7 @@
 ??? abstract "Audio Description - [Click to show/hide]"
 
     Some releases are now available with Audio Description, which is a way for visually impaired people to enjoy their media.
-    Those are flagged `WiTH AD` or just `AD`, and not be confused with advertisements as they are not.
+    Those are flagged `WiTH AD` or just `AD`, and should not be confused with advertisements, as they are not.
 
     If you want to prefer those for any reason, please add the following CF with a score of `101`. You can still use it for information if you decide to not score it.
 

--- a/includes/french-guide/sonarr-french-audio-description-fr.md
+++ b/includes/french-guide/sonarr-french-audio-description-fr.md
@@ -2,7 +2,7 @@
 ??? abstract "Audio Description - [Click to show/hide]"
 
     Certaines releases sont maintenant disponibles avec un canal d'Audio Description, ceci afin de rendre un média accessible aux personnes aveugles ou malvoyantes.
-    Celles-ci sont marquées avec `WiTH.AD` ou `AD`, celles-ci ne doivent pas être confondues avec un média possédant des pubs (advertisements ou ads en anglais).
+    Celles-ci sont marquées avec `WiTH AD` ou `AD`, celles-ci ne doivent pas être confondues avec un média possédant des pubs (advertisements ou ads en anglais).
 
     Si vous souhaitez préférer ce type de releases, merci d'ajouter le CF suivant avec un score de `101`. Vous pouvez tout aussi l'utiliser mais à titre informatif sans le scorer.
 


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->

Add new Custom Format:

- `WiTH ASL` => American Sign Language
- `WiTH BASL` => Black American Sign Language
- `WiTH BSL` => British Sign Language

Updated:
- `WiTH AD` => Audio Description

The sign languages are assigned a default score of -10000 because they are burned into the video
The Audio Description Custom Formats are not scored, so users can choose whether they prefer them or not.
- If you prefer sign languages or the Audio Description, assign an appropriate score, such as 10, or another score if the profile specifies it.
- If you do **NOT** prefer them, assign a score of `-10000`.

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

- Add new Custom Formats `WiTH ASL`, `WiTH BASL` and `WiTH BSL`
- Update `WiTH AD` (also known as WiTH Audio Description)
- Add the new Custom Formats to the Radarr/Sonarr Custom Format Collection Page
- Include a brief description of what the Custom Formats match and their use cases
- Add the new Custom Formats to the Optional Misc groups for third-party synchronization apps

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Add new accessibility-focused custom formats for WiTH sign-language releases and refine the existing WiTH Audio Description format and documentation across Radarr and Sonarr guides.

New Features:
- Introduce WiTH ASL, WiTH BASL, and WiTH BSL custom formats for Radarr and Sonarr, including JSON definitions and descriptive docs.
- Add an Accessibility (Optional) section and table column grouping Audio Description and sign-language custom formats in the Radarr and Sonarr custom format collections.
- Create dedicated accessibility custom format groups for optional use in Radarr and Sonarr JSON group configurations.

Enhancements:
- Expand and clarify the WiTH Audio Description documentation, including improved explanations and updated naming from `WiTH.AD` to `WiTH AD` in French guide variants.