### PR TITLE
feat(starr): Add RlsGrp `EniaHD` to `Bad Dual Groups`

### DIFF
--- a/docs/json/radarr/cf/bad-dual-groups.json
+++ b/docs/json/radarr/cf/bad-dual-groups.json
@@ -64,6 +64,15 @@
       }
     },
     {
+      "name": "EniaHD",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(EniaHD)$"
+      }
+    },
+    {
       "name": "EXTREME",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,

--- a/docs/json/sonarr/cf/bad-dual-groups.json
+++ b/docs/json/sonarr/cf/bad-dual-groups.json
@@ -73,6 +73,15 @@
       }
     },
     {
+      "name": "EniaHD",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(EniaHD)$"
+      }
+    },
+    {
       "name": "EXTREME",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->

Release Group `EniaHD` do dual language releases which list Russian (and sometimes Ukranian) as the first (and default) audio track instead of the original audio.

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

Added RlsGrp `EniaHD` to `Bad Dual Groups`

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

New Features:
- Extend Radarr and Sonarr bad dual group definitions to include the EniaHD release group.