### PR TITLE
feat(sonarr): Change naming scheme from `{Series TitleYear}` to `{Series CleanTitleWithoutYear} {(Series Year)}`

### DIFF
--- a/docs/json/sonarr/naming/sonarr-naming.json
+++ b/docs/json/sonarr/naming/sonarr-naming.json
@@ -3,25 +3,25 @@
     "default": "Season {season:00}"
   },
   "series": {
-    "default": "{Series TitleYear}",
-    "plex-imdb": "{Series TitleYear} {imdb-{ImdbId}}",
-    "plex-tvdb": "{Series TitleYear} {tvdb-{TvdbId}}",
-    "emby-imdb": "{Series TitleYear} [imdb-{ImdbId}]",
-    "emby-tvdb": "{Series TitleYear} [tvdb-{TvdbId}]",
-    "jellyfin-tvdb": "{Series TitleYear} [tvdbid-{TvdbId}]"
+    "default": "{Series CleanTitleWithoutYear} ({Series Year})",
+    "plex-imdb": "{Series CleanTitleWithoutYear} ({Series Year}) {imdb-{ImdbId}}",
+    "plex-tvdb": "{Series CleanTitleWithoutYear} ({Series Year}) {tvdb-{TvdbId}}",
+    "emby-imdb": "{Series CleanTitleWithoutYear} ({Series Year}) [imdb-{ImdbId}]",
+    "emby-tvdb": "{Series CleanTitleWithoutYear} ({Series Year}) [tvdb-{TvdbId}]",
+    "jellyfin-tvdb": "{Series CleanTitleWithoutYear} ({Series Year}) [tvdbid-{TvdbId}]"
   },
   "episodes": {
     "standard": {
-      "default": "{Series TitleYear} - S{season:00}E{episode:00} - {Episode CleanTitle:90} {[Custom Formats]}{[Quality Full]}{[Mediainfo AudioCodec}{ Mediainfo AudioChannels]}{[MediaInfo VideoDynamicRangeType]}{[Mediainfo VideoCodec]}{-Release Group}",
+      "default": "{Series CleanTitleWithoutYear} ({Series Year}) - S{season:00}E{episode:00} - {Episode CleanTitle:90} {[Custom Formats]}{[Quality Full]}{[Mediainfo AudioCodec}{ Mediainfo AudioChannels]}{[MediaInfo VideoDynamicRangeType]}{[Mediainfo VideoCodec]}{-Release Group}",
       "original": "{Original Title}",
       "p2p-scene": "{Series.CleanTitleYear}.S{season:00}E{episode:00}{.Episode.CleanTitle}{.Custom.Formats}{.Quality.Full}{.Mediainfo.AudioCodec}{.Mediainfo.AudioChannels}{.MediaInfo.VideoDynamicRangeType}{.Mediainfo.VideoCodec}{-Release Group}"
     },
     "daily": {
-      "default": "{Series TitleYear} - {Air-Date} - {Episode CleanTitle:90} {[Custom Formats]}{[Quality Full]}{[Mediainfo AudioCodec}{ Mediainfo AudioChannels]}{[MediaInfo VideoDynamicRangeType]}{[Mediainfo VideoCodec]}{-Release Group}",
+      "default": "{Series CleanTitleWithoutYear} ({Series Year}) - {Air-Date} - {Episode CleanTitle:90} {[Custom Formats]}{[Quality Full]}{[Mediainfo AudioCodec}{ Mediainfo AudioChannels]}{[MediaInfo VideoDynamicRangeType]}{[Mediainfo VideoCodec]}{-Release Group}",
       "original": "{Original Title}"
     },
     "anime": {
-      "default": "{Series TitleYear} - S{season:00}E{episode:00} - {absolute:000} - {Episode CleanTitle:90} {[Custom Formats]}{[Quality Full]}{[Mediainfo AudioCodec}{ Mediainfo AudioChannels]}{MediaInfo AudioLanguages}{[MediaInfo VideoDynamicRangeType]}[{Mediainfo VideoCodec }{MediaInfo VideoBitDepth}bit]{-Release Group}"
+      "default": "{Series CleanTitleWithoutYear} ({Series Year}) - S{season:00}E{episode:00} - {absolute:000} - {Episode CleanTitle:90} {[Custom Formats]}{[Quality Full]}{[Mediainfo AudioCodec}{ Mediainfo AudioChannels]}{MediaInfo AudioLanguages}{[MediaInfo VideoDynamicRangeType]}[{Mediainfo VideoCodec }{MediaInfo VideoBitDepth}bit]{-Release Group}"
     }
   }
 }

--- a/docs/json/sonarr/naming/sonarr-naming.json
+++ b/docs/json/sonarr/naming/sonarr-naming.json
@@ -3,25 +3,25 @@
     "default": "Season {season:00}"
   },
   "series": {
-    "default": "{Series CleanTitleWithoutYear} ({Series Year})",
-    "plex-imdb": "{Series CleanTitleWithoutYear} ({Series Year}) {imdb-{ImdbId}}",
-    "plex-tvdb": "{Series CleanTitleWithoutYear} ({Series Year}) {tvdb-{TvdbId}}",
-    "emby-imdb": "{Series CleanTitleWithoutYear} ({Series Year}) [imdb-{ImdbId}]",
-    "emby-tvdb": "{Series CleanTitleWithoutYear} ({Series Year}) [tvdb-{TvdbId}]",
-    "jellyfin-tvdb": "{Series CleanTitleWithoutYear} ({Series Year}) [tvdbid-{TvdbId}]"
+    "default": "{Series CleanTitleWithoutYear} {(Series Year)}",
+    "plex-imdb": "{Series CleanTitleWithoutYear} {(Series Year)} {imdb-{ImdbId}}",
+    "plex-tvdb": "{Series CleanTitleWithoutYear} {(Series Year)} {tvdb-{TvdbId}}",
+    "emby-imdb": "{Series CleanTitleWithoutYear} {(Series Year)} [imdb-{ImdbId}]",
+    "emby-tvdb": "{Series CleanTitleWithoutYear} {(Series Year)} [tvdb-{TvdbId}]",
+    "jellyfin-tvdb": "{Series CleanTitleWithoutYear} {(Series Year)} [tvdbid-{TvdbId}]"
   },
   "episodes": {
     "standard": {
-      "default": "{Series CleanTitleWithoutYear} ({Series Year}) - S{season:00}E{episode:00} - {Episode CleanTitle:90} {[Custom Formats]}{[Quality Full]}{[Mediainfo AudioCodec}{ Mediainfo AudioChannels]}{[MediaInfo VideoDynamicRangeType]}{[Mediainfo VideoCodec]}{-Release Group}",
+      "default": "{Series CleanTitleWithoutYear} {(Series Year)} - S{season:00}E{episode:00} - {Episode CleanTitle:90} {[Custom Formats]}{[Quality Full]}{[Mediainfo AudioCodec}{ Mediainfo AudioChannels]}{[MediaInfo VideoDynamicRangeType]}{[Mediainfo VideoCodec]}{-Release Group}",
       "original": "{Original Title}",
       "p2p-scene": "{Series.CleanTitleYear}.S{season:00}E{episode:00}{.Episode.CleanTitle}{.Custom.Formats}{.Quality.Full}{.Mediainfo.AudioCodec}{.Mediainfo.AudioChannels}{.MediaInfo.VideoDynamicRangeType}{.Mediainfo.VideoCodec}{-Release Group}"
     },
     "daily": {
-      "default": "{Series CleanTitleWithoutYear} ({Series Year}) - {Air-Date} - {Episode CleanTitle:90} {[Custom Formats]}{[Quality Full]}{[Mediainfo AudioCodec}{ Mediainfo AudioChannels]}{[MediaInfo VideoDynamicRangeType]}{[Mediainfo VideoCodec]}{-Release Group}",
+      "default": "{Series CleanTitleWithoutYear} {(Series Year)} - {Air-Date} - {Episode CleanTitle:90} {[Custom Formats]}{[Quality Full]}{[Mediainfo AudioCodec}{ Mediainfo AudioChannels]}{[MediaInfo VideoDynamicRangeType]}{[Mediainfo VideoCodec]}{-Release Group}",
       "original": "{Original Title}"
     },
     "anime": {
-      "default": "{Series CleanTitleWithoutYear} ({Series Year}) - S{season:00}E{episode:00} - {absolute:000} - {Episode CleanTitle:90} {[Custom Formats]}{[Quality Full]}{[Mediainfo AudioCodec}{ Mediainfo AudioChannels]}{MediaInfo AudioLanguages}{[MediaInfo VideoDynamicRangeType]}[{Mediainfo VideoCodec }{MediaInfo VideoBitDepth}bit]{-Release Group}"
+      "default": "{Series CleanTitleWithoutYear} {(Series Year)} - S{season:00}E{episode:00} - {absolute:000} - {Episode CleanTitle:90} {[Custom Formats]}{[Quality Full]}{[Mediainfo AudioCodec}{ Mediainfo AudioChannels]}{MediaInfo AudioLanguages}{[MediaInfo VideoDynamicRangeType]}[{Mediainfo VideoCodec }{MediaInfo VideoBitDepth}bit]{-Release Group}"
     }
   }
 }


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->

Change the naming scheme from `{Series TitleYear}` to `{Series CleanTitleWithoutYear} ({Series Year})` to ensure consistency with the cleantitle used for Radarr.

> [!NOTE]
> "CleanTitle" means:
> - `&` becomes `and`
> - `/` becomes a space
> - Special characters `,<>\/;:'"|~!?@$%^*-_=(){}[]` (and backtick) are removed

This prevents issues caused by scripts or code that are not mindful when navigating through folders.
As long as you keep the year and include `{tvdb-{TvdbId}}` at the folder level, series detection should still work perfectly.

> [!CAUTION] 
> This could lead to a mass update with your current library if you trigger a mass rename on the files and folders in Sonarr.

Examples:

- Marvel's Axxxxx ox S.x.x.x.x.x. (2013) -> Marvels Axxxxx ox S.x.x.x.x.x. (2013)
- Sxx+Lxxx (2021) -> Sxx Lxxx (2021)
- Sxxxxxxx & Lxxx (2021) -> Sxxxxxxx and Lxxx (2021)
- DC's Lxxxxxx of Txxxxxxx (2016) -> DCs Lxxxxxx of Txxxxxxx (2016)

---

> [!NOTE]
> The Difference between the `CleanTitle` tokens
> {Series CleanTitleYear} => Show 2010
> {Series CleanTitleWithoutYear} ({Series Year}) => Show (2010)

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

Change naming scheme from `{Series TitleYear}` to `{Series CleanTitleWithoutYear} ({Series Year})`

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Enhancements:
- Align Sonarr series naming recommendation with Radarr by adopting CleanTitle-based folder names that separate title and year.