### PR TITLE
fix(guide): Fix broken application versions in the guide

### DIFF
--- a/docs/Bazarr/index.md
+++ b/docs/Bazarr/index.md
@@ -8,7 +8,7 @@ For Support specific related to Bazarr we suggest you join their official [Disco
 
 ### Current Versions
 
-![version](https://img.shields.io/badge/dynamic/json?query=%24.version&url=https%3A%2F%2Fraw.githubusercontent.com%2Fhotio%2Fbazarr%2Frelease%2FVERSION.json&label=Latest%20Version&style=for-the-badge&color=4051B5){ .off-glb } ![version](https://img.shields.io/badge/dynamic/json?query=%24.version&url=https%3A%2F%2Fraw.githubusercontent.com%2Fhotio%2Fbazarr%2Fnightly%2FVERSION.json&label=Latest%20Version&style=for-the-badge&color=4051B5){ .off-glb }
+![version](https://img.shields.io/github/v/release/morpheus65535/bazarr?label=Latest%20Version&style=for-the-badge&color=4051B5){ .off-glb } ![version](https://img.shields.io/github/v/release/morpheus65535/bazarr?include_prereleases&label=Latest%20Version&style=for-the-badge&color=4051B5){ .off-glb }
 
 ## Available guides
 

--- a/docs/Bazarr/index.md
+++ b/docs/Bazarr/index.md
@@ -8,7 +8,7 @@ For Support specific related to Bazarr we suggest you join their official [Disco
 
 ### Current Versions
 
-![version](https://img.shields.io/github/v/release/morpheus65535/bazarr?label=Latest&style=for-the-badge&logo=github&color=4051B5){ .off-glb } ![version](https://img.shields.io/github/v/release/morpheus65535/bazarr?include_prereleases&label=Pre-release&style=for-the-badge&logo=github&color=4051B5){ .off-glb }
+![GitHub Release](https://img.shields.io/github/v/release/morpheus65535/bazarr?label=Latest&style=for-the-badge&logo=github&color=4051B5){ .off-glb } ![GitHub Release](https://img.shields.io/github/v/release/morpheus65535/bazarr?include_prereleases&label=Pre-release&style=for-the-badge&logo=github&color=4051B5){ .off-glb }
 
 ## Available guides
 

--- a/docs/Bazarr/index.md
+++ b/docs/Bazarr/index.md
@@ -8,7 +8,7 @@ For Support specific related to Bazarr we suggest you join their official [Disco
 
 ### Current Versions
 
-![version](https://img.shields.io/github/v/release/morpheus65535/bazarr?label=Latest%20Version&style=for-the-badge&color=4051B5){ .off-glb } ![version](https://img.shields.io/github/v/release/morpheus65535/bazarr?include_prereleases&label=Latest%20Version&style=for-the-badge&color=4051B5){ .off-glb }
+![version](https://img.shields.io/github/v/release/morpheus65535/bazarr?label=Latest&style=for-the-badge&logo=github&color=4051B5){ .off-glb } ![version](https://img.shields.io/github/v/release/morpheus65535/bazarr?include_prereleases&label=Pre-release&style=for-the-badge&logo=github&color=4051B5){ .off-glb }
 
 ## Available guides
 

--- a/docs/Downloaders/NZBGet/index.md
+++ b/docs/Downloaders/NZBGet/index.md
@@ -1,6 +1,6 @@
 # NZBGet
 
-[![GitHub Release](https://img.shields.io/github/v/release/nzbgetcom/nzbget?display_name=release&style=for-the-badge&logo=github&label=Lastest&color=4051B5){ .off-glb }](https://github.com/nzbgetcom/nzbget){:target="\_blank" rel="noopener noreferrer"}
+[![GitHub Release](https://img.shields.io/github/v/release/nzbgetcom/nzbget?display_name=release&style=for-the-badge&logo=github&label=Latest&color=4051B5){ .off-glb }](https://github.com/nzbgetcom/nzbget){:target="\_blank" rel="noopener noreferrer"}
 
 [:material-web: NZBGet Website](https://nzbget.com/){:target="\_blank" rel="noopener noreferrer"} - [:material-github: NZBGet Github](https://github.com/nzbgetcom/nzbget){:target="\_blank" rel="noopener noreferrer"} - [:fontawesome-brands-discord: NZBGet Discord](https://discord.gg/mV9Vn9sM7C){:target="\_blank" rel="noopener noreferrer"}
 

--- a/docs/Downloaders/NZBGet/index.md
+++ b/docs/Downloaders/NZBGet/index.md
@@ -1,6 +1,6 @@
 # NZBGet
 
-[![version](https://img.shields.io/badge/dynamic/json?query=%24.version&url=https%3A%2F%2Fraw.githubusercontent.com%2Fhotio%2Fnzbget%2Frelease%2FVERSION.json&label=Latest%20Version&style=for-the-badge&color=4051B5){ .off-glb }](https://github.com/nzbgetcom/nzbget){:target="\_blank" rel="noopener noreferrer"}
+[![GitHub Release](https://img.shields.io/github/v/release/nzbgetcom/nzbget?display_name=release&style=for-the-badge&logo=github&label=Lastest&color=4051B5){ .off-glb }](https://github.com/nzbgetcom/nzbget){:target="\_blank" rel="noopener noreferrer"}
 
 [:material-web: NZBGet Website](https://nzbget.com/){:target="\_blank" rel="noopener noreferrer"} - [:material-github: NZBGet Github](https://github.com/nzbgetcom/nzbget){:target="\_blank" rel="noopener noreferrer"} - [:fontawesome-brands-discord: NZBGet Discord](https://discord.gg/mV9Vn9sM7C){:target="\_blank" rel="noopener noreferrer"}
 

--- a/docs/Downloaders/SABnzbd/index.md
+++ b/docs/Downloaders/SABnzbd/index.md
@@ -1,6 +1,6 @@
 # SABnzbd
 
-[![version](https://img.shields.io/badge/dynamic/json?query=%24.version&url=https%3A%2F%2Fraw.githubusercontent.com%2Fhotio%2Fsabnzbd%2Frelease%2FVERSION.json&label=Latest%20Version&style=for-the-badge&color=4051B5){ .off-glb }](https://sabnzbd.org/){:target="\_blank" rel="noopener noreferrer"}
+[![GitHub Release](https://img.shields.io/github/v/release/sabnzbd/sabnzbd?display_name=release&style=for-the-badge&logo=github&label=Lastest&color=4051B5){ .off-glb }](https://sabnzbd.org/){:target="\_blank" rel="noopener noreferrer"}
 
 - [Basic-Setup](/Downloaders/SABnzbd/Basic-Setup/) - Basic set up of the most common settings.
 - [Path and Categories](/Downloaders/SABnzbd/Paths-and-Categories/) - How to set up the categories for SABnzbd, and how you can manage and organize your downloads in groups. Starr apps can use the categories in SABnzbd to keep track of downloads to monitor, rather than watching every download in your client.

--- a/docs/Downloaders/SABnzbd/index.md
+++ b/docs/Downloaders/SABnzbd/index.md
@@ -1,6 +1,6 @@
 # SABnzbd
 
-[![GitHub Release](https://img.shields.io/github/v/release/sabnzbd/sabnzbd?display_name=release&style=for-the-badge&logo=github&label=Lastest&color=4051B5){ .off-glb }](https://sabnzbd.org/){:target="\_blank" rel="noopener noreferrer"}
+[![GitHub Release](https://img.shields.io/github/v/release/sabnzbd/sabnzbd?display_name=release&style=for-the-badge&logo=github&label=Latest&color=4051B5){ .off-glb }](https://sabnzbd.org/){:target="\_blank" rel="noopener noreferrer"}
 
 - [Basic-Setup](/Downloaders/SABnzbd/Basic-Setup/) - Basic set up of the most common settings.
 - [Path and Categories](/Downloaders/SABnzbd/Paths-and-Categories/) - How to set up the categories for SABnzbd, and how you can manage and organize your downloads in groups. Starr apps can use the categories in SABnzbd to keep track of downloads to monitor, rather than watching every download in your client.

--- a/docs/Downloaders/index.md
+++ b/docs/Downloaders/index.md
@@ -32,6 +32,6 @@ Here you will find Guides for several Download Clients.
 
 ### ruTorrent
 
-[![version](https://img.shields.io/github/v/release/Novik/ruTorrent.svg?color=4051B5&style=for-the-badge&logo=github){ .off-glb }](https://github.com/Novik/ruTorrent){:target="\_blank" rel="noopener noreferrer"}
+[![GitHub Release](https://img.shields.io/github/v/release/Novik/ruTorrent.svg?color=4051B5&style=for-the-badge&logo=github){ .off-glb }](https://github.com/Novik/ruTorrent){:target="\_blank" rel="noopener noreferrer"}
 
 [ruTorrent Guides](/Downloaders/ruTorrent/)

--- a/docs/Downloaders/index.md
+++ b/docs/Downloaders/index.md
@@ -20,7 +20,7 @@ Here you will find Guides for several Download Clients.
 
 ### qBittorrent
 
-[![GitHub Release](https://img.shields.io/github/v/release/qbittorrent/qbittorrent?display_name=release&style=for-the-badge&logo=github&label=Lastest&color=4051B5){ .off-glb }](https://www.qbittorrent.org/){:target="\_blank" rel="noopener noreferrer"}
+[![GitHub Release](https://img.shields.io/github/v/release/qbittorrent/qbittorrent?display_name=release&style=for-the-badge&logo=github&label=Latest&color=4051B5){ .off-glb }](https://www.qbittorrent.org/){:target="\_blank" rel="noopener noreferrer"}
 
 [qBittorrent Guides](/Downloaders/qBittorrent/)
 

--- a/docs/Downloaders/index.md
+++ b/docs/Downloaders/index.md
@@ -6,13 +6,13 @@ Here you will find Guides for several Download Clients.
 
 ### NZBGet
 
-[![GitHub Release](https://img.shields.io/github/v/release/nzbgetcom/nzbget?display_name=release&style=for-the-badge&logo=github&label=Lastest&color=4051B5){ .off-glb }](https://github.com/nzbgetcom/nzbget){:target="\_blank" rel="noopener noreferrer"}
+[![GitHub Release](https://img.shields.io/github/v/release/nzbgetcom/nzbget?display_name=release&style=for-the-badge&logo=github&label=Latest&color=4051B5){ .off-glb }](https://github.com/nzbgetcom/nzbget){:target="\_blank" rel="noopener noreferrer"}
 
 [NZBGet Guides](/Downloaders/NZBGet/)
 
 ### SABnzbd
 
-
+[![GitHub Release](https://img.shields.io/github/v/release/sabnzbd/sabnzbd?display_name=release&style=for-the-badge&logo=github&label=Latest&color=4051B5){ .off-glb }](https://sabnzbd.org/){:target="\_blank" rel="noopener noreferrer"}
 
 [SABnzbd Guides](/Downloaders/SABnzbd/)
 

--- a/docs/Downloaders/index.md
+++ b/docs/Downloaders/index.md
@@ -6,13 +6,13 @@ Here you will find Guides for several Download Clients.
 
 ### NZBGet
 
-[![version](https://img.shields.io/badge/dynamic/json?query=%24.version&url=https%3A%2F%2Fraw.githubusercontent.com%2Fhotio%2Fnzbget%2Frelease%2FVERSION.json&label=Latest%20Version&style=for-the-badge&color=4051B5){ .off-glb }](https://github.com/nzbgetcom/nzbget){:target="\_blank" rel="noopener noreferrer"}
+[![GitHub Release](https://img.shields.io/github/v/release/nzbgetcom/nzbget?display_name=release&style=for-the-badge&logo=github&label=Lastest&color=4051B5){ .off-glb }](https://github.com/nzbgetcom/nzbget){:target="\_blank" rel="noopener noreferrer"}
 
 [NZBGet Guides](/Downloaders/NZBGet/)
 
 ### SABnzbd
 
-[![version](https://img.shields.io/badge/dynamic/json?query=%24.version&url=https%3A%2F%2Fraw.githubusercontent.com%2Fhotio%2Fsabnzbd%2Frelease%2FVERSION.json&label=Latest%20Version&style=for-the-badge&color=4051B5){ .off-glb }](https://sabnzbd.org/){:target="\_blank" rel="noopener noreferrer"}
+
 
 [SABnzbd Guides](/Downloaders/SABnzbd/)
 
@@ -20,7 +20,7 @@ Here you will find Guides for several Download Clients.
 
 ### qBittorrent
 
-[![version](https://img.shields.io/badge/dynamic/json?query=%24.version&url=https%3A%2F%2Fraw.githubusercontent.com%2Fhotio%2Fqbittorrent%2Frelease%2FVERSION.json&label=Latest%20Version&style=for-the-badge&color=4051B5){ .off-glb }](https://www.qbittorrent.org/){:target="\_blank" rel="noopener noreferrer"}
+[![GitHub Release](https://img.shields.io/github/v/release/qbittorrent/qbittorrent?display_name=release&style=for-the-badge&logo=github&label=Lastest&color=4051B5){ .off-glb }](https://www.qbittorrent.org/){:target="\_blank" rel="noopener noreferrer"}
 
 [qBittorrent Guides](/Downloaders/qBittorrent/)
 

--- a/docs/Downloaders/qBittorrent/index.md
+++ b/docs/Downloaders/qBittorrent/index.md
@@ -1,6 +1,6 @@
 # qBittorrent
 
-[![version](https://img.shields.io/badge/dynamic/json?query=%24.version&url=https%3A%2F%2Fraw.githubusercontent.com%2Fhotio%2Fqbittorrent%2Frelease%2FVERSION.json&label=Latest%20Version&style=for-the-badge&color=4051B5){ .off-glb }](https://www.qbittorrent.org/){:target="\_blank" rel="noopener noreferrer"}
+[![GitHub Release](https://img.shields.io/github/v/release/qbittorrent/qbittorrent?display_name=release&style=for-the-badge&logo=github&label=Lastest&color=4051B5){ .off-glb }](https://www.qbittorrent.org/){:target="\_blank" rel="noopener noreferrer"}
 
 - [Basic-Setup](/Downloaders/qBittorrent/Basic-Setup/) - Basic set up of the most common settings.
 - [Paths](/Downloaders/qBittorrent/Paths) - Where to set your root download location.

--- a/docs/Downloaders/qBittorrent/index.md
+++ b/docs/Downloaders/qBittorrent/index.md
@@ -1,6 +1,6 @@
 # qBittorrent
 
-[![GitHub Release](https://img.shields.io/github/v/release/qbittorrent/qbittorrent?display_name=release&style=for-the-badge&logo=github&label=Lastest&color=4051B5){ .off-glb }](https://www.qbittorrent.org/){:target="\_blank" rel="noopener noreferrer"}
+[![GitHub Release](https://img.shields.io/github/v/release/qbittorrent/qbittorrent?display_name=release&style=for-the-badge&logo=github&label=Latest&color=4051B5){ .off-glb }](https://www.qbittorrent.org/){:target="\_blank" rel="noopener noreferrer"}
 
 - [Basic-Setup](/Downloaders/qBittorrent/Basic-Setup/) - Basic set up of the most common settings.
 - [Paths](/Downloaders/qBittorrent/Paths) - Where to set your root download location.

--- a/docs/Plex/index.md
+++ b/docs/Plex/index.md
@@ -1,6 +1,6 @@
 # Plex
 
-![Dynamic JSON Badge](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fplex.tv%2Fapi%2Fdownloads%2F5.json&query=%24.computer.Windows.version&style=for-the-badge&logo=plex&label=Version&color=4051B5){ .off-glb }
+![Dynamic JSON Badge](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fplex.tv%2Fapi%2Fdownloads%2F5.json&query=%24.computer.Windows.version&style=for-the-badge&logo=plex&label=Latest%Version&color=4051B5){ .off-glb }
 
 ## The Following guides are available
 

--- a/docs/Plex/index.md
+++ b/docs/Plex/index.md
@@ -1,6 +1,6 @@
 # Plex
 
-![Dynamic JSON Badge](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fplex.tv%2Fapi%2Fdownloads%2F5.json&query=%24.computer.Windows.version&style=for-the-badge&logo=plex&label=Latest%Version&color=4051B5){ .off-glb }
+![Dynamic JSON Badge](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fplex.tv%2Fapi%2Fdownloads%2F5.json&query=%24.computer.Windows.version&style=for-the-badge&logo=plex&label=Latest%20Version&color=4051B5){ .off-glb }
 
 ## The Following guides are available
 

--- a/docs/Plex/index.md
+++ b/docs/Plex/index.md
@@ -1,6 +1,6 @@
 # Plex
 
-![version](https://img.shields.io/badge/dynamic/json?query=%24.version&url=https%3A%2F%2Fraw.githubusercontent.com%2Fhotio%2Fplex%2Frelease%2FVERSION.json&label=Latest%20Version&style=for-the-badge&color=4051B5){ .off-glb }
+![Dynamic JSON Badge](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fplex.tv%2Fapi%2Fdownloads%2F5.json&query=%24.computer.Windows.version&style=for-the-badge&logo=plex&label=Version&color=4051B5){ .off-glb }
 
 ## The Following guides are available
 


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->

Fix broken application versions in the guide

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

Fix broken application versions in the guide

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Update documentation badges to use reliable GitHub release and Plex API version sources.

Documentation:
- Replace dynamic hotio-based version badges with GitHub release badges for NZBGet, SABnzbd, qBittorrent, ruTorrent, and Bazarr guides.
- Update Plex guide version badge to use Plex’s official downloads API as the version source.