### PR TITLE
chore(guide-sync): add CODEOWNERS for sync tool contract files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,22 @@
+# Sync tool maintainers must review changes to specifications, schemas,
+# metadata, validation scripts, and structural contracts that sync tools
+# depend on.
+#
+# Preferred: create a @TRaSH-Guides/sync-tool-maintainers team and replace
+# the individual usernames below.
+#
+# @TRaSH-Guides/sync-tool-maintainers
+
+# JSON schemas define the structure sync tools parse
+/schemas/ @rcdailey @austinwbest @ProphetSe7en @BlackDark
+
+# Metadata tells sync tools where to find data
+/metadata.json @rcdailey @austinwbest @ProphetSe7en @BlackDark
+/metadata.schema.json @rcdailey @austinwbest @ProphetSe7en @BlackDark
+
+# Validation scripts enforce constraints on the data
+/scripts/ @rcdailey @austinwbest @ProphetSe7en @BlackDark
+
+# Pre-commit config wires schemas and validators into CI
+/.pre-commit-config.yaml @rcdailey @austinwbest @ProphetSe7en @BlackDark
+

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,22 +1,16 @@
 # Sync tool maintainers must review changes to specifications, schemas,
 # metadata, validation scripts, and structural contracts that sync tools
 # depend on.
-#
-# Preferred: create a @TRaSH-Guides/sync-tool-maintainers team and replace
-# the individual usernames below.
-#
-# @TRaSH-Guides/sync-tool-maintainers
 
 # JSON schemas define the structure sync tools parse
-/schemas/ @rcdailey @austinwbest @ProphetSe7en @BlackDark
+/schemas/ @TRaSH-Guides/sync-tool-maintainers
 
 # Metadata tells sync tools where to find data
-/metadata.json @rcdailey @austinwbest @ProphetSe7en @BlackDark
-/metadata.schema.json @rcdailey @austinwbest @ProphetSe7en @BlackDark
+/metadata.json @TRaSH-Guides/sync-tool-maintainers
+/metadata.schema.json @TRaSH-Guides/sync-tool-maintainers
 
 # Validation scripts enforce constraints on the data
-/scripts/ @rcdailey @austinwbest @ProphetSe7en @BlackDark
+/scripts/ @TRaSH-Guides/sync-tool-maintainers
 
 # Pre-commit config wires schemas and validators into CI
-/.pre-commit-config.yaml @rcdailey @austinwbest @ProphetSe7en @BlackDark
-
+/.pre-commit-config.yaml @TRaSH-Guides/sync-tool-maintainers


### PR DESCRIPTION
# Pull Request

## Purpose

PR #2628 introduced an AI-generated `cf-groups.schema.json` with a `minProperties: 1` constraint on `quality_profiles.include`. This was merged same-day with no sync tool developer review. The constraint turned out to be incorrect (none of the sync tools require non-empty includes), and it forced the creation of the Base Profile workaround and dummy profile references across ~84% of CF groups.

This adds a CODEOWNERS file so that changes to schemas, metadata, validation scripts, and pre-commit config require review from at least one sync tool maintainer. These are the files that define contracts sync tools parse and validate against. Individual guide data (CFs, profiles, groups) isn't covered since that's guide author territory.

## Approach

Covered paths:
- `/schemas/` - JSON schemas that define data structure
- `/metadata.json` and `/metadata.schema.json` - tells sync tools where to find data
- `/scripts/` - validation scripts that enforce constraints
- `/.pre-commit-config.yaml` - wires schemas and validators into CI

Note: I've listed four individual maintainers for now (@rcdailey, @austinwbest, @ProphetSe7en, @BlackDark). If TRaSH-Guides creates a `sync-tool-maintainers` team, the file can be updated to use `@TRaSH-Guides/sync-tool-maintainers` instead, which would be easier to maintain long term.

Also note that CODEOWNERS requires the listed users to have write access to the repo. If that's not currently the case for all four, that'd need to be set up.

## Open Questions and Pre-Merge TODOs

- [x] Do all four maintainers have write access to this repo? CODEOWNERS won't work without it.
- [x] Would a GitHub team (`@TRaSH-Guides/sync-tool-maintainers`) be preferred over individual usernames?

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Chores:
- Introduce a CODEOWNERS file covering schemas, metadata, validation scripts, and pre-commit configuration related to sync tool contracts.