### PR TITLE
feat(guide): Update French VFQ CFs

### DIFF
--- a/docs/json/radarr/cf/french-vfq.json
+++ b/docs/json/radarr/cf/french-vfq.json
@@ -10,7 +10,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\b(VFQ|\\d{3,4}p[ .]CAN|(?<=MULTi[ .])FR(A|ENCH))\\b"
+        "value": "\\b(VFQ|\\d{3,4}p[ .]CAN?|(?<=MULTi[ .])FR(A|ENCH)|CAN?)\\b"
       }
     },
     {

--- a/docs/json/radarr/cf/french-vfq.json
+++ b/docs/json/radarr/cf/french-vfq.json
@@ -10,7 +10,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\b(VFQ|\\d{3,4}p[ .]CAN?|(?<=MULTi[ .])FR(A|ENCH)|CAN?)\\b"
+        "value": "\\b(VFQ|\\d{3,4}p[ .]CAN?|(?<=MULTi[ .])(FR(A|ENCH)|CAN?))\\b"
       }
     },
     {

--- a/docs/json/sonarr/cf/french-vfq.json
+++ b/docs/json/sonarr/cf/french-vfq.json
@@ -10,7 +10,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\b(VFQ|\\d{3,4}p[ .]CAN|(?<=MULTi[ .])FR(A|ENCH))\\b"
+        "value": "\\b(VFQ|\\d{3,4}p[ .]CAN?|(?<=MULTi[ .])FR(A|ENCH)|CAN?)\\b"
       }
     },
     {

--- a/docs/json/sonarr/cf/french-vfq.json
+++ b/docs/json/sonarr/cf/french-vfq.json
@@ -10,7 +10,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\b(VFQ|\\d{3,4}p[ .]CAN?|(?<=MULTi[ .])FR(A|ENCH)|CAN?)\\b"
+        "value": "\\b(VFQ|\\d{3,4}p[ .]CAN?|(?<=MULTi[ .])(FR(A|ENCH)|CAN?))\\b"
       }
     },
     {


### PR DESCRIPTION
# Pull Request

## Purpose

Update both Radarr and Sonarr json to recognise MULTi.CA as VFQ

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

New Features:
- Add MULTi.CA recognition to French VFQ custom formats for Radarr and Sonarr.