### PR TITLE
feat(bindery): add setup guide and naming scheme

### DIFF
--- a/docs/Bindery/.pages
+++ b/docs/Bindery/.pages
@@ -1,0 +1,4 @@
+nav:
+  - Home: index.md
+  - Setup Guide: bindery-setup-guide.md
+  - Recommended Naming Scheme: bindery-recommended-naming-scheme.md

--- a/docs/Bindery/bindery-recommended-naming-scheme.md
+++ b/docs/Bindery/bindery-recommended-naming-scheme.md
@@ -1,0 +1,93 @@
+# Recommended Naming Scheme
+
+**Settings → General → Naming.**
+
+Bindery uses Go template syntax for naming. Two separate templates: one for ebooks, one for audiobooks.
+
+---
+
+## Ebook naming
+
+### Folder
+
+```
+{Author Name}/{Book Title} ({Year})
+```
+
+### File
+
+```
+{Author Name} - {Book Title} ({Year}){Quality}
+```
+
+**Example:** `Brandon Sanderson - The Way of Kings (2010).epub`
+
+If you store multiple formats per book, include quality to avoid collisions:
+
+```
+{Author Name} - {Book Title} ({Year}) [{Quality}]
+```
+
+**Example:** `Brandon Sanderson - The Way of Kings (2010) [EPUB].epub`
+
+---
+
+## Audiobook naming
+
+### Folder
+
+```
+{Author Name}/{Book Title} ({Year})
+```
+
+For multi-disc releases where files land in subdirectories, the folder structure is preserved from the downloaded archive. Bindery does not flatten multi-part audiobooks.
+
+### File
+
+```
+{Author Name} - {Book Title} ({Year}){Quality}
+```
+
+**Example:** `Brandon Sanderson - The Way of Kings (2010).m4b`
+
+---
+
+## Available tokens
+
+| Token | Example output |
+|---|---|
+| `{Author Name}` | `Brandon Sanderson` |
+| `{Author NameThe}` | `Sanderson, Brandon` |
+| `{Book Title}` | `The Way of Kings` |
+| `{Book TitleThe}` | `Way of Kings, The` |
+| `{Series}` | `The Stormlight Archive` |
+| `{Series Number}` | `1` |
+| `{Year}` | `2010` |
+| `{ISBN}` | `9780765326355` |
+| `{Quality}` | `EPUB` |
+| `{Quality Full}` | `EPUB Proper` |
+
+Tokens that are empty for a given book (e.g. `{Series}` on a standalone) are silently dropped including any surrounding brackets or parentheses.
+
+---
+
+## Quality profiles
+
+**Settings → Quality Profiles → Add.**
+
+Bindery ranks formats internally by quality. Recommended ordering for ebooks:
+
+```
+EPUB > AZW3 > MOBI > PDF > CBZ/CBR
+```
+
+For audiobooks:
+
+```
+M4B > FLAC > MP3 320 > MP3 VBR > MP3 128 > AAC
+```
+
+Set size limits to avoid grabbing split-chapter uploads that are missing parts. A single-file M4B for a full novel is typically 200–600 MB; multi-file MP3 sets vary widely.
+
+!!! tip "Usenet vs torrents"
+    Set a higher **Priority** value on Usenet indexers (**Settings → Indexers**) if you want Bindery to prefer Usenet releases over torrents when both are available for the same book. Priority is a direct scoring bonus — a difference of 25–50 points is enough to consistently prefer one protocol without overriding quality differences.

--- a/docs/Bindery/bindery-setup-guide.md
+++ b/docs/Bindery/bindery-setup-guide.md
@@ -1,0 +1,129 @@
+# Setup Guide
+
+## Docker Compose
+
+```yaml
+services:
+  bindery:
+    image: ghcr.io/vavallee/bindery:latest
+    container_name: bindery
+    restart: unless-stopped
+    ports:
+      - "8787:8787"
+    volumes:
+      - /path/to/config:/config
+      - /path/to/books:/books
+      - /path/to/downloads:/downloads
+    environment:
+      - PUID=1000
+      - PGID=1000
+      - TZ=America/New_York
+```
+
+Set `PUID`/`PGID` to match the user that owns your library and download directories (`id -u` / `id -g`). Mismatched UID is the most common cause of permission errors on import.
+
+!!! warning "Path consistency"
+    The path Bindery sees inside the container must match the path the download client sees. If qBittorrent maps downloads to `/downloads` and Bindery maps them to `/data/downloads`, import will fail. Use the same bind-mount path in both containers, or configure a path remap under **Settings → Download Clients → Remote Path Mappings**.
+
+---
+
+## First run
+
+Navigate to `http://localhost:8787`. The setup wizard creates the first admin account — pick a strong password, there's no second prompt.
+
+API key is under **Settings → General → Security**. You'll need it when adding Bindery as an app in other tools.
+
+---
+
+## Prowlarr
+
+**Settings → Indexers → Add Prowlarr instance.**
+
+| Field | Value |
+|---|---|
+| Host | Prowlarr hostname or container name (e.g. `prowlarr`) |
+| Port | `9696` |
+| API Key | Prowlarr API key (**Settings → General**) |
+| Sync Categories | `Books/EBook`, `Books/Comics`, `Books/Mags`, `Books/Technical`, `Audio/Audiobook` — uncheck anything you don't want |
+
+Hit **Test**, then **Save**. Bindery pulls the indexer list from Prowlarr automatically; individual indexers don't need to be added manually.
+
+!!! note "Container networking"
+    When both containers are on the same Docker network, use the service name as the hostname (`prowlarr`, not `localhost`). Add `networks` to your Compose file if they're not already on a shared network.
+
+---
+
+## Download client
+
+**Settings → Download Clients → Add.**
+
+=== "qBittorrent"
+
+    | Field | Value |
+    |---|---|
+    | Host | qBittorrent hostname or container name |
+    | Port | `8080` (default) |
+    | Username / Password | qBittorrent credentials |
+    | Category | `books` (optional but recommended — keeps Bindery grabs separate) |
+
+=== "SABnzbd"
+
+    | Field | Value |
+    |---|---|
+    | Host | SABnzbd hostname or container name |
+    | Port | `8080` (default) |
+    | API Key | **Config → General → API Key** in SABnzbd |
+    | Category | `books` |
+
+=== "NZBGet"
+
+    | Field | Value |
+    |---|---|
+    | Host | NZBGet hostname or container name |
+    | Port | `6789` (default) |
+    | Username / Password | NZBGet credentials |
+    | Category | `books` |
+
+=== "Transmission"
+
+    | Field | Value |
+    |---|---|
+    | Host | Transmission hostname or container name |
+    | Port | `9091` (default) |
+    | Username / Password | Transmission credentials (if RPC auth is enabled) |
+
+Hit **Test** before saving. Bindery fetches torrent/NZB content itself and sends it to the client directly — the download client never needs to reach the indexer URL, so Docker-internal hostnames work without extra configuration.
+
+---
+
+## Library path
+
+**Settings → General → Library Path.** Set this to the bind-mounted path where you want books to live (e.g. `/books`). This is the import destination, not the download directory.
+
+---
+
+## Adding authors
+
+**Authors → Add Author.** Search by name. Bindery pulls metadata from Hardcover (default) or OpenLibrary.
+
+- **Monitor** — which books to watch for: All, Future, Missing, Existing, or None.
+- **Quality Profile** — format and size preferences (EPUB, M4B, MP3, etc.).
+- **Search on add** — triggers an immediate indexer search for monitored missing books.
+
+Once an author is added, Bindery polls for new releases and grabs them automatically when they appear on your indexers.
+
+---
+
+## Common issues
+
+**Import fails with permission denied**
+: UID/GID mismatch. Verify `PUID`/`PGID` match the owner of `/books` and `/downloads` on the host.
+
+**Download client test fails when using container names**
+: The containers need to be on the same Docker network. Add a shared `networks` entry to your Compose file.
+
+**Prowlarr indexers not appearing after save**
+: Hit **Test** before saving — Bindery won't sync the indexer list without a successful connectivity check.
+
+**Books found but not importing**
+: Check the Activity log (**Activity → History**) for the specific failure reason. Common causes: path mismatch (see path consistency warning above), quality below profile minimum, or duplicate already in library.

--- a/docs/Bindery/bindery-setup-guide.md
+++ b/docs/Bindery/bindery-setup-guide.md
@@ -14,13 +14,12 @@ services:
       - /path/to/config:/config
       - /path/to/books:/books
       - /path/to/downloads:/downloads
+    user: "1000:1000"
     environment:
-      - PUID=1000
-      - PGID=1000
       - TZ=America/New_York
 ```
 
-Set `PUID`/`PGID` to match the user that owns your library and download directories (`id -u` / `id -g`). Mismatched UID is the most common cause of permission errors on import.
+Set `user` to the UID:GID that owns your library and download directories (`id -u`:`id -g`). Mismatched UID is the most common cause of permission errors on import.
 
 !!! warning "Path consistency"
     The path Bindery sees inside the container must match the path the download client sees. If qBittorrent maps downloads to `/downloads` and Bindery maps them to `/data/downloads`, import will fail. Use the same bind-mount path in both containers, or configure a path remap under **Settings → Download Clients → Remote Path Mappings**.
@@ -117,7 +116,7 @@ Once an author is added, Bindery polls for new releases and grabs them automatic
 ## Common issues
 
 **Import fails with permission denied**
-: UID/GID mismatch. Verify `PUID`/`PGID` match the owner of `/books` and `/downloads` on the host.
+: UID/GID mismatch. Verify the `user:` directive in your Compose file matches the owner of `/books` and `/downloads` on the host (`id -u`:`id -g`).
 
 **Download client test fails when using container names**
 : The containers need to be on the same Docker network. Add a shared `networks` entry to your Compose file.

--- a/docs/Bindery/bindery-setup-guide.md
+++ b/docs/Bindery/bindery-setup-guide.md
@@ -125,4 +125,4 @@ Once an author is added, Bindery polls for new releases and grabs them automatic
 : Hit **Test** before saving — Bindery won't sync the indexer list without a successful connectivity check.
 
 **Books found but not importing**
-: Check the Activity log (**Activity → History**) for the specific failure reason. Common causes: path mismatch (see path consistency warning above), quality below profile minimum, or duplicate already in library.
+: Check the Activity log (**Activity → History**) for the specific failure reason. Common causes: path mismatch (see path consistency warning above), quality below profile minimum, or a duplicate already in the library.

--- a/docs/Bindery/index.md
+++ b/docs/Bindery/index.md
@@ -1,0 +1,12 @@
+# Bindery
+
+Bindery is an automated book manager for Usenet and torrents — monitors authors, searches Newznab/Torznab indexers via Prowlarr, downloads via qBittorrent/SABnzbd/NZBGet/Transmission, and organizes your ebook and audiobook library.
+
+Source: [GitHub](https://github.com/vavallee/bindery){:target="\_blank" rel="noopener noreferrer"} · Docker: `ghcr.io/vavallee/bindery` / `vavallee/bindery`
+
+---
+
+## Available guides
+
+1. [Setup Guide](/Bindery/bindery-setup-guide/) — Docker Compose, first-run, Prowlarr, download client, adding authors.
+1. [Recommended Naming Scheme](/Bindery/bindery-recommended-naming-scheme/) — File and folder naming tokens for ebooks and audiobooks.


### PR DESCRIPTION
Adds a Bindery section covering Docker Compose setup, Prowlarr and download client configuration, author management, and recommended naming/quality profile settings.

Bindery is an automated book manager (ebooks + audiobooks) for Usenet and torrents — the closest equivalent to Radarr/Sonarr for books. It integrates with Prowlarr for indexers and supports qBittorrent, SABnzbd, NZBGet, and Transmission as download clients.

**Guides added:**
- `docs/Bindery/index.md` — section index
- `docs/Bindery/bindery-setup-guide.md` — Docker Compose, first-run, Prowlarr, download clients, common issues
- `docs/Bindery/bindery-recommended-naming-scheme.md` — naming tokens, quality profile ordering

No screenshots included in this PR — happy to add them if the section is accepted, or can follow up in a separate PR.

Source: https://github.com/vavallee/bindery

## Summary by Sourcery

Add documentation section for Bindery covering setup, configuration, and recommended naming and quality profiles for ebooks and audiobooks.

Documentation:
- Introduce a Bindery index page describing the application and linking to its guides.
- Add a Bindery setup guide covering Docker Compose deployment, initial configuration, Prowlarr and download client integration, library paths, and common troubleshooting issues.
- Add a Bindery naming guide detailing recommended folder/file naming schemes, available naming tokens, and quality profile recommendations for ebooks and audiobooks.