### PR TITLE
ci(validation): Validate SourceSpecification values per app

### DIFF
--- a/.github/workflows/custom-format-validation.yml
+++ b/.github/workflows/custom-format-validation.yml
@@ -53,3 +53,6 @@ jobs:
 
       - name: Validate custom format consistency
         run: python scripts/validate-custom-formats.py
+
+      - name: Validate SourceSpecification per-app values
+        run: python scripts/validate-source-specifications.py

--- a/schemas/radarr-cf.schema.json
+++ b/schemas/radarr-cf.schema.json
@@ -28,7 +28,7 @@
           { "$ref": "specs/edition-spec.json" },
           { "$ref": "specs/language-spec.json" },
           { "$ref": "specs/indexer-flag-spec.json" },
-          { "$ref": "specs/source-spec.json" },
+          { "$ref": "specs/radarr-source-spec.json" },
           { "$ref": "specs/resolution-spec.json" },
           { "$ref": "specs/quality-modifier-spec.json" },
           { "$ref": "specs/size-spec.json" },

--- a/schemas/sonarr-cf.schema.json
+++ b/schemas/sonarr-cf.schema.json
@@ -27,7 +27,7 @@
           { "$ref": "specs/release-title-spec.json" },
           { "$ref": "specs/language-spec.json" },
           { "$ref": "specs/indexer-flag-spec.json" },
-          { "$ref": "specs/source-spec.json" },
+          { "$ref": "specs/sonarr-source-spec.json" },
           { "$ref": "specs/resolution-spec.json" },
           { "$ref": "specs/size-spec.json" },
           { "$ref": "specs/release-group-spec.json" },

--- a/schemas/specs/radarr-source-spec.json
+++ b/schemas/specs/radarr-source-spec.json
@@ -1,26 +1,18 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
+  "description": "Radarr QualitySource: 1=CAM, 2=TELESYNC, 3=TELECINE, 4=WORKPRINT, 5=DVD, 6=TV, 7=WEBDL, 8=WEBRIP, 9=BLURAY",
   "allOf": [
-    { "$ref": "../base-cf.schema.json#/defs/baseSpecification" },
+    { "$ref": "source-spec.json" },
     {
       "properties": {
-        "implementation": {
-          "const": "SourceSpecification"
-        },
         "fields": {
-          "type": "object",
           "properties": {
             "value": {
-              "description": "Radarr QualitySource: 1=CAM, 2=TELESYNC, 3=TELECINE, 4=WORKPRINT, 5=DVD, 6=TV, 7=WEBDL, 8=WEBRIP, 9=BLURAY",
-              "type": "integer",
               "enum": [1, 2, 3, 4, 5, 6, 7, 8, 9]
             }
-          },
-          "required": ["value"],
-          "additionalProperties": false
+          }
         }
-      },
-      "required": ["implementation", "fields"]
+      }
     }
   ]
 }

--- a/schemas/specs/radarr-source-spec.json
+++ b/schemas/specs/radarr-source-spec.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "allOf": [
+    { "$ref": "../base-cf.schema.json#/defs/baseSpecification" },
+    {
+      "properties": {
+        "implementation": {
+          "const": "SourceSpecification"
+        },
+        "fields": {
+          "type": "object",
+          "properties": {
+            "value": {
+              "description": "Radarr QualitySource: 1=CAM, 2=TELESYNC, 3=TELECINE, 4=WORKPRINT, 5=DVD, 6=TV, 7=WEBDL, 8=WEBRIP, 9=BLURAY",
+              "type": "integer",
+              "enum": [1, 2, 3, 4, 5, 6, 7, 8, 9]
+            }
+          },
+          "required": ["value"],
+          "additionalProperties": false
+        }
+      },
+      "required": ["implementation", "fields"]
+    }
+  ]
+}

--- a/schemas/specs/sonarr-source-spec.json
+++ b/schemas/specs/sonarr-source-spec.json
@@ -1,26 +1,18 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
+  "description": "Sonarr QualitySource: 1=Television, 2=TelevisionRaw, 3=Web (WEBDL), 4=WebRip, 5=DVD, 6=Bluray, 7=BlurayRaw (Remux)",
   "allOf": [
-    { "$ref": "../base-cf.schema.json#/defs/baseSpecification" },
+    { "$ref": "source-spec.json" },
     {
       "properties": {
-        "implementation": {
-          "const": "SourceSpecification"
-        },
         "fields": {
-          "type": "object",
           "properties": {
             "value": {
-              "description": "Sonarr QualitySource: 1=Television, 2=TelevisionRaw, 3=Web (WEBDL), 4=WebRip, 5=DVD, 6=Bluray, 7=BlurayRaw (Remux)",
-              "type": "integer",
               "enum": [1, 2, 3, 4, 5, 6, 7]
             }
-          },
-          "required": ["value"],
-          "additionalProperties": false
+          }
         }
-      },
-      "required": ["implementation", "fields"]
+      }
     }
   ]
 }

--- a/schemas/specs/sonarr-source-spec.json
+++ b/schemas/specs/sonarr-source-spec.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "allOf": [
+    { "$ref": "../base-cf.schema.json#/defs/baseSpecification" },
+    {
+      "properties": {
+        "implementation": {
+          "const": "SourceSpecification"
+        },
+        "fields": {
+          "type": "object",
+          "properties": {
+            "value": {
+              "description": "Sonarr QualitySource: 1=Television, 2=TelevisionRaw, 3=Web (WEBDL), 4=WebRip, 5=DVD, 6=Bluray, 7=BlurayRaw (Remux)",
+              "type": "integer",
+              "enum": [1, 2, 3, 4, 5, 6, 7]
+            }
+          },
+          "required": ["value"],
+          "additionalProperties": false
+        }
+      },
+      "required": ["implementation", "fields"]
+    }
+  ]
+}

--- a/schemas/specs/source-spec.json
+++ b/schemas/specs/source-spec.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "description": "Base SourceSpecification: general structural compliance shared by Radarr and Sonarr. Per-app variants (radarr-source-spec.json, sonarr-source-spec.json) extend this with the appropriate QualitySource enum.",
+  "description": "Generic SourceSpecification: structural compliance plus the union of valid QualitySource values across Radarr (1..9) and Sonarr (1..7). Used directly by guide-only CFs (which are app-agnostic). Per-app variants (radarr-source-spec.json, sonarr-source-spec.json) compose this and tighten the enum to that app's range.",
   "allOf": [
     { "$ref": "../base-cf.schema.json#/defs/baseSpecification" },
     {
@@ -12,7 +12,8 @@
           "type": "object",
           "properties": {
             "value": {
-              "type": "integer"
+              "type": "integer",
+              "enum": [1, 2, 3, 4, 5, 6, 7, 8, 9]
             }
           },
           "required": ["value"],

--- a/schemas/specs/source-spec.json
+++ b/schemas/specs/source-spec.json
@@ -1,5 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
+  "description": "Base SourceSpecification: general structural compliance shared by Radarr and Sonarr. Per-app variants (radarr-source-spec.json, sonarr-source-spec.json) extend this with the appropriate QualitySource enum.",
   "allOf": [
     { "$ref": "../base-cf.schema.json#/defs/baseSpecification" },
     {
@@ -11,8 +12,7 @@
           "type": "object",
           "properties": {
             "value": {
-              "type": "integer",
-              "enum": [1, 2, 3, 4, 5, 6, 7, 8, 9]
+              "type": "integer"
             }
           },
           "required": ["value"],

--- a/scripts/validate-source-specifications.py
+++ b/scripts/validate-source-specifications.py
@@ -1,15 +1,34 @@
 #!/usr/bin/env python3
 """Validate SourceSpecification value semantics per app.
 
-Radarr and Sonarr both accept integer values 1-9 for SourceSpecification,
-but the underlying enums differ. A CF authored for Sonarr that uses Radarr's
-WEBDL value (7) will silently match the wrong source in Sonarr (BlurayRaw),
-and vice versa. JSON Schema can't catch this because both ranges overlap;
-the only signal is which folder the CF lives in.
+Radarr's QualitySource enum spans 1-9; Sonarr's spans 1-7. The per-app
+JSON schemas (schemas/specs/{radarr,sonarr}-source-spec.json) enforce the
+integer range. This script adds a second layer of enforcement: for spec
+*names* that have an unambiguous expected value per app, it confirms the
+value matches. Example: a spec named "WEBDL" must be value 7 under
+radarr/cf/ and value 3 under sonarr/cf/. When the wrong value happens to
+match the other app's encoding, the error includes a hint pointing at
+the likely copy-paste source.
 
-This script enforces the mapping for spec names that have an unambiguous
-expected value per app. Specs whose names don't match a known label are
-ignored (the schema's 1-9 enum still applies to those).
+The mapping tables below were verified against:
+  Radarr/Radarr  src/NzbDrone.Core/Qualities/QualitySource.cs
+  Sonarr/Sonarr  src/NzbDrone.Core/Qualities/QualitySource.cs
+
+Known limitations (intentional):
+
+  The `name` field on a SourceSpecification is editorial -- maintainers
+  choose it as a human label, not the C# enum identifier. A few labels
+  in this repo are intentionally ambiguous:
+
+    - Sonarr CFs often use name="WEB" with value=1 (Sonarr's
+      Television source) to catch indexers that misclassify streaming
+      content as TV-sourced. "WEB" is therefore NOT in the Sonarr
+      table; the schema's 1-7 enum is the only check that applies.
+
+  Only labels with a single, unambiguous expected value per app are
+  enforced. If a future label becomes ambiguous (the maintainer reuses
+  it for a different value), drop it from the table here rather than
+  adding exceptions per file.
 
 Exit code 0 on success, 1 on any failure.
 """

--- a/scripts/validate-source-specifications.py
+++ b/scripts/validate-source-specifications.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Validate SourceSpecification value semantics per app.
+
+Radarr and Sonarr both accept integer values 1-9 for SourceSpecification,
+but the underlying enums differ. A CF authored for Sonarr that uses Radarr's
+WEBDL value (7) will silently match the wrong source in Sonarr (BlurayRaw),
+and vice versa. JSON Schema can't catch this because both ranges overlap;
+the only signal is which folder the CF lives in.
+
+This script enforces the mapping for spec names that have an unambiguous
+expected value per app. Specs whose names don't match a known label are
+ignored (the schema's 1-9 enum still applies to those).
+
+Exit code 0 on success, 1 on any failure.
+"""
+
+import json
+import re
+import sys
+from pathlib import Path
+
+BASE = Path("docs/json")
+
+# name -> expected fields.value, per app.
+# Keys are normalized (uppercased, non-alphanumerics stripped).
+RADARR_SOURCE = {
+    "CAM": 1,
+    "TELESYNC": 2,
+    "TS": 2,
+    "TELECINE": 3,
+    "TC": 3,
+    "WORKPRINT": 4,
+    "WP": 4,
+    "DVD": 5,
+    "TV": 6,
+    "WEBDL": 7,
+    "WEBRIP": 8,
+    "BLURAY": 9,
+}
+
+SONARR_SOURCE = {
+    "TELEVISION": 1,
+    "TELEVISIONRAW": 2,
+    "WEBDL": 3,
+    "WEBRIP": 4,
+    "DVD": 5,
+    "BLURAY": 6,
+    "BLURAYRAW": 7,
+    "REMUX": 7,
+    "BLURAYREMUX": 7,
+}
+
+EXPECTED = {"radarr": RADARR_SOURCE, "sonarr": SONARR_SOURCE}
+
+
+def normalize(name: str) -> str:
+    return re.sub(r"[^A-Z0-9]", "", name.upper())
+
+
+def check_file(app: str, path: Path) -> list[str]:
+    errors: list[str] = []
+    try:
+        with open(path) as f:
+            data = json.load(f)
+    except (OSError, json.JSONDecodeError) as e:
+        return [f"[{app}] cf/{path.name}: failed to parse: {e}"]
+
+    table = EXPECTED[app]
+    other_app = "sonarr" if app == "radarr" else "radarr"
+    other_table = EXPECTED[other_app]
+
+    for spec in data.get("specifications", []):
+        if spec.get("implementation") != "SourceSpecification":
+            continue
+        spec_name = spec.get("name", "")
+        value = spec.get("fields", {}).get("value")
+        key = normalize(spec_name)
+        expected = table.get(key)
+        if expected is None:
+            # Unknown label — skip (schema enum still bounds value to 1-9).
+            continue
+        if value == expected:
+            continue
+
+        msg = (
+            f"[{app}] cf/{path.name}: SourceSpecification '{spec_name}'"
+            f" has value {value}, expected {expected} for {app}"
+        )
+        # Helpful hint when the value matches the *other* app's mapping.
+        if other_table.get(key) == value:
+            msg += (
+                f" (value {value} is the {other_app} encoding for"
+                f" '{spec_name}' — looks like a copy-paste from"
+                f" {other_app}/cf/)"
+            )
+        errors.append(msg)
+
+    return errors
+
+
+def main() -> int:
+    all_errors: list[str] = []
+    for app in ("radarr", "sonarr"):
+        cf_dir = BASE / app / "cf"
+        if not cf_dir.is_dir():
+            continue
+        for f in sorted(cf_dir.glob("*.json")):
+            all_errors.extend(check_file(app, f))
+
+    if all_errors:
+        print(f"\nFound {len(all_errors)} SourceSpecification error(s):\n")
+        for err in all_errors:
+            print(f"  ERROR: {err}")
+        return 1
+
+    print("All SourceSpecification values match the expected per-app mapping.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Radarr and Sonarr both persist `SourceSpecification.fields.value` as integers, but their underlying `QualitySource` enums differ. A value of 7 means `WEBDL` in Radarr and `BlurayRaw` in Sonarr. JSON Schema alone couldn't catch a copy-paste between folders since the integer ranges overlap; the only signal is which folder a CF lives in.

This change adds two layers of enforcement:

- **Schema layer.** `specs/source-spec.json` becomes the generic base: structural compliance plus the union enum 1..9. `specs/radarr-source-spec.json` and `specs/sonarr-source-spec.json` compose it via `allOf` and tighten the enum to that app's range (Radarr keeps 1..9, Sonarr narrows to 1..7). The per-app CF schemas reference their app-specific variant; guide-only CFs keep referencing the generic base.
- **Python layer.** `scripts/validate-source-specifications.py` catches semantic mismatches the schema can't see: a spec named "WEBDL" must be value 7 under `radarr/cf/` and value 3 under `sonarr/cf/`. When the value matches the other app's encoding, the error includes a hint pointing at the likely copy-paste source.

The mapping tables were verified against `src/NzbDrone.Core/Qualities/QualitySource.cs` at HEAD in both upstream repos:

| Source | Radarr | Sonarr |
|---|---|---|
| Television / TV | 6 | 1 |
| TelevisionRaw | — | 2 |
| WEBDL / Web | 7 | 3 |
| WEBRIP | 8 | 4 |
| DVD | 5 | 5 |
| BLURAY | 9 | 6 |
| BlurayRaw / Remux | — | 7 |
| CAM | 1 | — |
| TELESYNC | 2 | — |
| TELECINE | 3 | — |
| WORKPRINT | 4 | — |

## Known limitation (please confirm desired outcome)

The spec `name` field is editorial — maintainers choose it as a human label, not the C# enum identifier. Some labels in this repo are intentionally ambiguous:

- Several Sonarr CFs use `name: "WEB"` with `value: 1` (Sonarr's `Television` source) to catch indexers that misclassify streaming releases as TV-sourced. "WEB" is therefore **not** in the Sonarr name table; only the schema's 1..7 enum applies to those.

The validator only enforces labels with a single unambiguous expected value per app. If this is wrong and "WEB" should always mean value=3 in Sonarr, the 15 existing CFs (abema, anime-web-tier-01..06, bglobal, bilibili, cr, french-adn, french-wkn, funi, hidive, vrv) would need their value corrected. Happy to do that in a follow-up if preferred.

## Test plan

- [x] `check-jsonschema` passes against `docs/json/{radarr,sonarr,guide-only}/cf/*.json` with the new per-app schemas.
- [x] `scripts/validate-source-specifications.py` exits 0 on the current repo.
- [x] Negative test: a synthetic Sonarr CF with `name: "WEBDL", value: 7` produces an error with the cross-app hint.
- [ ] CI green on this PR.

## Summary by Sourcery

Add per-application validation for SourceSpecification values in custom format definitions and enforce it in CI.

Enhancements:
- Introduce per-app SourceSpecification schemas for Radarr and Sonarr that specialize the shared base schema and constrain allowed value ranges.

CI:
- Extend the custom format validation workflow to run a new SourceSpecification value semantics validator script.

Tests:
- Add a Python script that validates SourceSpecification name-to-value mappings per app across Radarr and Sonarr custom format JSON files.