### PR TITLE
chore(ci): Validate SourceSpecification values per app

### DIFF
--- a/.github/workflows/custom-format-validation.yml
+++ b/.github/workflows/custom-format-validation.yml
@@ -53,3 +53,6 @@ jobs:
 
       - name: Validate custom format consistency
         run: python scripts/validate-custom-formats.py
+
+      - name: Validate SourceSpecification per-app values
+        run: python scripts/validate-source-specifications.py

--- a/schemas/specs/source-spec.json
+++ b/schemas/specs/source-spec.json
@@ -1,5 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
+  "description": "SourceSpecification with enum 1..9, the union of Radarr's QualitySource (1..9) and Sonarr's (1..7). All three CF schemas (radarr, sonarr, guide-only) reference this. The per-app range and name->value semantics live in scripts/validate-source-specifications.py.",
   "allOf": [
     { "$ref": "../base-cf.schema.json#/defs/baseSpecification" },
     {

--- a/scripts/validate-source-specifications.py
+++ b/scripts/validate-source-specifications.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Validate SourceSpecification value semantics per app.
+
+Radarr's QualitySource enum spans 1-9; Sonarr's spans 1-7. The shared
+schemas/specs/source-spec.json enforces the union (1-9) at the JSON
+Schema layer. This script enforces the per-app rules:
+
+    1. Range. Sonarr values must be 1-7; values 8 and 9 don't exist
+        in Sonarr's enum. Radarr's 1-9 matches the schema, so this is
+        a no-op there.
+    2. Name->value semantics. For spec *names* with an unambiguous
+        expected value per app, the value must match. Example: a spec
+        named "WEBDL" must be value 7 under radarr/cf/ and value 3
+        under sonarr/cf/. When the wrong value happens to match the
+        other app's encoding, the error includes a hint pointing at
+        the likely copy-paste source.
+
+The mapping tables below were verified against:
+    Radarr/Radarr  src/NzbDrone.Core/Qualities/QualitySource.cs
+    Sonarr/Sonarr  src/NzbDrone.Core/Qualities/QualitySource.cs
+
+Known limitations (intentional):
+
+    The `name` field on a SourceSpecification is editorial -- maintainers
+    choose it as a human label, not the C# enum identifier. A few labels
+    in this repo are intentionally ambiguous:
+
+        - Sonarr CFs often use name="WEB" with value=1 (Sonarr's
+            Television source) to catch indexers that misclassify
+            streaming content as TV-sourced. "WEB" is therefore NOT in
+            the Sonarr table; the schema's 1-7 enum is the only check
+            that applies.
+
+    Only labels with a single, unambiguous expected value per app are
+    enforced. If a future label becomes ambiguous (the maintainer reuses
+    it for a different value), drop it from the table here rather than
+    adding exceptions per file.
+
+Exit code 0 on success, 1 on any failure.
+"""
+
+import json
+import re
+import sys
+from pathlib import Path
+
+BASE = Path("docs/json")
+
+# name -> expected fields.value, per app.
+# Keys are normalized (uppercased, non-alphanumerics stripped).
+RADARR_SOURCE = {
+    "CAM": 1,
+    "TELESYNC": 2,
+    "TS": 2,
+    "TELECINE": 3,
+    "TC": 3,
+    "WORKPRINT": 4,
+    "WP": 4,
+    "DVD": 5,
+    "TV": 6,
+    "WEBDL": 7,
+    "WEBRIP": 8,
+    "BLURAY": 9,
+}
+
+SONARR_SOURCE = {
+    "TELEVISION": 1,
+    "TELEVISIONRAW": 2,
+    "WEBDL": 3,
+    "WEBRIP": 4,
+    "DVD": 5,
+    "BLURAY": 6,
+    "BLURAYRAW": 7,
+    "REMUX": 7,
+    "BLURAYREMUX": 7,
+}
+
+EXPECTED = {"radarr": RADARR_SOURCE, "sonarr": SONARR_SOURCE}
+
+# Per-app valid integer ranges for SourceSpecification.fields.value.
+# The shared JSON schema only enforces the union (1..9); per-app bounds
+# live here so the schema stays simple.
+VALID_VALUES = {
+    "radarr": set(range(1, 10)),
+    "sonarr": set(range(1, 8)),
+}
+
+
+def normalize(name: str) -> str:
+    return re.sub(r"[^A-Z0-9]", "", name.upper())
+
+
+def check_file(app: str, path: Path) -> list[str]:
+    errors: list[str] = []
+    try:
+        with open(path) as f:
+            data = json.load(f)
+    except (OSError, json.JSONDecodeError) as e:
+        return [f"[{app}] cf/{path.name}: failed to parse: {e}"]
+
+    table = EXPECTED[app]
+    other_app = "sonarr" if app == "radarr" else "radarr"
+    other_table = EXPECTED[other_app]
+
+    valid = VALID_VALUES[app]
+
+    for spec in data.get("specifications", []):
+        if spec.get("implementation") != "SourceSpecification":
+            continue
+        spec_name = spec.get("name", "")
+        value = spec.get("fields", {}).get("value")
+
+        # Per-app range check. The shared JSON schema accepts the union
+        # 1..9; this catches values valid in the other app but not here
+        # (e.g. value=8 or 9 in a Sonarr CF).
+        if value not in valid:
+            errors.append(
+                f"[{app}] cf/{path.name}: SourceSpecification"
+                f" '{spec_name}' has value {value}, which is outside"
+                f" {app}'s QualitySource range {sorted(valid)}"
+            )
+            continue
+
+        key = normalize(spec_name)
+        expected = table.get(key)
+        if expected is None:
+            # Unknown label — range check above is the only constraint.
+            continue
+        if value == expected:
+            continue
+
+        msg = (
+            f"[{app}] cf/{path.name}: SourceSpecification '{spec_name}'"
+            f" has value {value}, expected {expected} for {app}"
+        )
+        # Helpful hint when the value matches the *other* app's mapping.
+        if other_table.get(key) == value:
+            msg += (
+                f" (value {value} is the {other_app} encoding for"
+                f" '{spec_name}' — looks like a copy-paste from"
+                f" {other_app}/cf/)"
+            )
+        errors.append(msg)
+
+    return errors
+
+
+def main() -> int:
+    all_errors: list[str] = []
+    for app in ("radarr", "sonarr"):
+        cf_dir = BASE / app / "cf"
+        if not cf_dir.is_dir():
+            continue
+        for f in sorted(cf_dir.glob("*.json")):
+            all_errors.extend(check_file(app, f))
+
+    if all_errors:
+        print(f"\nFound {len(all_errors)} SourceSpecification error(s):\n")
+        for err in all_errors:
+            print(f"  ERROR: {err}")
+        return 1
+
+    print("All SourceSpecification values match the expected per-app mapping.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Radarr and Sonarr both store `SourceSpecification.fields.value` as integers, but their `QualitySource` enums don't line up. A value of 7 is `WEBDL` in Radarr and `BlurayRaw` in Sonarr. JSON Schema alone can't catch a swap between folders because the integer ranges overlap; the only signal is which folder the CF lives in.

`schemas/specs/source-spec.json` holds the shared structural rules and enum 1..9, which is Radarr's full range and a superset of Sonarr's 1..7. All three CF schemas (radarr, sonarr, guide-only) reference it.

`scripts/validate-source-specifications.py` enforces the per-app rules the schema can't express. First, the range: Sonarr values 8 and 9 don't exist in Sonarr's enum, so a Sonarr CF using those will fail here even though it passes the shared schema. Second, the name-to-value semantics: a spec named "WEBDL" has to be value 7 under `radarr/cf/` and value 3 under `sonarr/cf/`. When the wrong value matches the other app's encoding, the error says so and names the likely copy-paste source.

Mapping tables verified against `src/NzbDrone.Core/Qualities/QualitySource.cs` at HEAD in both upstream repos:

| Source | Radarr | Sonarr |
|---|---|---|
| Television / TV | 6 | 1 |
| TelevisionRaw | — | 2 |
| WEBDL / Web | 7 | 3 |
| WEBRIP | 8 | 4 |
| DVD | 5 | 5 |
| BLURAY | 9 | 6 |
| BlurayRaw / Remux | — | 7 |
| CAM | 1 | — |
| TELESYNC | 2 | — |
| TELECINE | 3 | — |
| WORKPRINT | 4 | — |

## Known limitation (please confirm)

The spec `name` field doesn't track the C# enum identifier, and the repo already relies on that: Sonarr CFs use `name: "WEBDL"` for value 3, whose enum identifier is actually `Web`. So the validator keys off names only where a name maps to one unambiguous value per app.

One name is deliberately excluded: `WEB`. 15 Sonarr CFs (abema, anime-web-tier-01..06, bglobal, bilibili, cr, french-adn, french-wkn, funi, hidive, vrv) carry a `name: "WEB"` spec with `value: 1`, which is Sonarr's `Television` source. In all 15, that spec sits alongside separate `WEBDL` (3) and `WEBRIP` (4) specs in the same file, so `WEB` = 1 is an additional third source matcher, not a mistyped WEBDL. Since `WEB` legitimately means value 1 here, it stays out of the name table and only the range check (1..7) applies to it.

I'm flagging this so a maintainer can confirm the `WEB` = `Television` (1) matcher is intended. If it isn't, that's a content fix across those 15 files, which I can take in a follow-up. I haven't assumed why the matcher exists, only that the file structure shows it's deliberate.

## Test plan

- [x] `check-jsonschema` passes against `docs/json/{radarr,sonarr,guide-only}/cf/*.json`
- [x] `scripts/validate-source-specifications.py` exits 0 on the current repo
- [x] `pre-commit run --all-files` clean locally
- [x] Negative test: synthetic Sonarr CF with `name: "BLURAY", value: 9` produces a range error
- [x] Negative test: synthetic Sonarr CF with `name: "WEBDL", value: 7` produces a name-mismatch error with the cross-app hint
- [ ] CI green on this PR

## Summary by Sourcery

Add a dedicated validation step to enforce per-app SourceSpecification value semantics for Radarr and Sonarr custom formats.

Enhancements:
- Introduce a Python validator that checks SourceSpecification values against per-app allowed ranges and name-to-value mappings for Radarr and Sonarr custom formats.

CI:
- Extend the custom-format-validation workflow to run SourceSpecification per-app value validation in CI.