### PR TITLE
chore(gha): Only deploy PR previews when rendered content changes

### DIFF
--- a/.github/workflows/deploy-pr.yml
+++ b/.github/workflows/deploy-pr.yml
@@ -16,12 +16,11 @@ permissions:
   actions: read
 
 jobs:
-  build:
+  check:
     runs-on: ubuntu-latest
     if: github.event.repository.fork == false
     outputs:
-      url: ${{ steps.cloudflare.outputs.deployment-url }}
-      branch_url: ${{ steps.cloudflare.outputs.pages-deployment-alias-url }}
+      should_deploy: ${{ steps.pr_info.outputs.should_deploy }}
       pr_number: ${{ steps.pr_info.outputs.pr_number }}
       pr_sha: ${{ steps.pr_info.outputs.pr_sha }}
     steps:
@@ -33,19 +32,27 @@ jobs:
           name: pr_info
           path: ${{ github.workspace }}/pr_info
 
-      - name: Display structure of downloaded files
-        run: tree ${{ github.workspace }}
-
       - name: Read PR info
         id: pr_info
         run: |
-          echo "pr_number=$(cat ${{ github.workspace }}/pr_info/PR_NUMBER)" >> $GITHUB_OUTPUT
-          echo "pr_sha=$(cat ${{ github.workspace }}/pr_info/PR_SHA)" >> $GITHUB_OUTPUT
+          {
+            echo "pr_number=$(cat "${{ github.workspace }}/pr_info/PR_NUMBER")"
+            echo "pr_sha=$(cat "${{ github.workspace }}/pr_info/PR_SHA")"
+            echo "should_deploy=$(cat "${{ github.workspace }}/pr_info/SHOULD_DEPLOY")"
+          } >> "$GITHUB_OUTPUT"
 
+  build:
+    needs: check
+    if: needs.check.outputs.should_deploy == 'true'
+    runs-on: ubuntu-latest
+    outputs:
+      url: ${{ steps.cloudflare.outputs.deployment-url }}
+      branch_url: ${{ steps.cloudflare.outputs.pages-deployment-alias-url }}
+    steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: ${{ steps.pr_info.outputs.pr_sha }}
+          ref: ${{ needs.check.outputs.pr_sha }}
           fetch-depth: 0
           sparse-checkout: |
             docs
@@ -61,7 +68,7 @@ jobs:
       - name: Get pip cache directory
         id: pip-cache
         run: |
-          echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
+          echo "dir=$(pip cache dir)" >> "$GITHUB_OUTPUT"
 
       - name: Cache dependencies
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -88,13 +95,13 @@ jobs:
           command: >
             pages deploy site
             --project-name=trash-guides
-            --branch=pr-${{ steps.pr_info.outputs.pr_number }}
-            --commit-hash=${{ steps.pr_info.outputs.pr_sha }}
+            --branch=pr-${{ needs.check.outputs.pr_number }}
+            --commit-hash=${{ needs.check.outputs.pr_sha }}
 
   comment:
-    needs: build
+    needs: [check, build]
     runs-on: ubuntu-latest
-    if: always() && github.event.repository.fork == false
+    if: always() && needs.check.outputs.should_deploy == 'true'
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -113,10 +120,10 @@ jobs:
             STATUS_MESSAGE="Build failed!"
           fi
 
-          COMMENT_BODY="Deploying with ⚡ Cloudflare Pages<br><table><tr><td><strong>Latest commit:</strong></td><td><code>${{ needs.build.outputs.pr_sha }}</code></td></tr><tr><td><strong>Status:</strong></td><td>&nbsp;$STATUS_EMOJI&nbsp; $STATUS_MESSAGE</td></tr><tr><td><strong>Preview URL:</strong></td><td><a href='$PREVIEW_URL'>$PREVIEW_URL</a></td></tr><tr><td><strong>Branch Preview URL:</strong></td><td><a href='$BRANCH_PREVIEW_URL'>$BRANCH_PREVIEW_URL</a></td></tr></table>"
+          COMMENT_BODY="Deploying with ⚡ Cloudflare Pages<br><table><tr><td><strong>Latest commit:</strong></td><td><code>${{ needs.check.outputs.pr_sha }}</code></td></tr><tr><td><strong>Status:</strong></td><td>&nbsp;$STATUS_EMOJI&nbsp; $STATUS_MESSAGE</td></tr><tr><td><strong>Preview URL:</strong></td><td><a href='$PREVIEW_URL'>$PREVIEW_URL</a></td></tr><tr><td><strong>Branch Preview URL:</strong></td><td><a href='$BRANCH_PREVIEW_URL'>$BRANCH_PREVIEW_URL</a></td></tr></table>"
 
           ESCAPED_BODY=$(echo "$COMMENT_BODY" | jq -aRs .)
-          COMMENTS_URL="https://api.github.com/repos/${{ github.repository }}/issues/${{ needs.build.outputs.pr_number }}/comments"
+          COMMENTS_URL="https://api.github.com/repos/${{ github.repository }}/issues/${{ needs.check.outputs.pr_number }}/comments"
 
           curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
               -H "Accept: application/vnd.github+json" \

--- a/.github/workflows/deploy-pr.yml
+++ b/.github/workflows/deploy-pr.yml
@@ -35,10 +35,14 @@ jobs:
       - name: Read PR info
         id: pr_info
         run: |
+          # SHOULD_DEPLOY is absent from artifacts produced by the
+          # pre-path-filter trigger workflow; default to false so a
+          # legacy artifact skips the deploy instead of failing cat.
+          should_deploy=$(cat "${{ github.workspace }}/pr_info/SHOULD_DEPLOY" 2>/dev/null || true)
           {
             echo "pr_number=$(cat "${{ github.workspace }}/pr_info/PR_NUMBER")"
             echo "pr_sha=$(cat "${{ github.workspace }}/pr_info/PR_SHA")"
-            echo "should_deploy=$(cat "${{ github.workspace }}/pr_info/SHOULD_DEPLOY")"
+            echo "should_deploy=${should_deploy:-false}"
           } >> "$GITHUB_OUTPUT"
 
   build:

--- a/.github/workflows/trigger-pr-deploy.yml
+++ b/.github/workflows/trigger-pr-deploy.yml
@@ -16,11 +16,24 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.repository.fork == false
     steps:
+      - name: Filter rendered content changes
+        id: filter
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        with:
+          filters: |
+            rendered:
+              - 'docs/**'
+              - 'images/**'
+              - 'includes/**'
+              - 'overrides/**'
+              - 'mkdocs.yml'
+
       - name: Save PR info
         run: |
           mkdir -p ./pr_info
           echo ${{ github.event.pull_request.number }} > ./pr_info/PR_NUMBER
           echo ${{ github.event.pull_request.head.sha }} > ./pr_info/PR_SHA
+          echo ${{ steps.filter.outputs.rendered }} > ./pr_info/SHOULD_DEPLOY
 
       - name: Upload PR info
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1


### PR DESCRIPTION
## Summary

`Build PR & Deploy` rebuilds the whole mkdocs site and pushes it to Cloudflare on every PR, including ones that change nothing the site renders like workflows, schemas, or scripts. Those runs waste a build and leave a preview comment identical to production.

The decision is split across the two workflows in the chain. `Trigger PR Build` fires on `pull_request`, so it has the diff context; it runs `dorny/paths-filter` (pinned to `v4.0.1`) and writes the result into the existing `pr_info` artifact as `SHOULD_DEPLOY`. `Build PR & Deploy` is triggered by `workflow_run`, where path filters aren't available, so it gets a small `check` job that reads the flag. The `build` and `comment` jobs depend on `check` and only run when the flag is `true`.

The filter matches what feeds the rendered site: `docs/`, `images/`, `includes/`, `overrides/`, and `mkdocs.yml`. `docs/json/**` doesn't need its own entry because the `markdownextradata` plugin pulls it into pages, so `docs/**` already covers it.

Fork protection is unchanged. The `check` job keeps the `fork == false` guard, and because `build` and `comment` read `needs.check.outputs.*`, they skip when `check` is skipped on a fork.

## Why split it this way

`paths:` filters only work on `push` and `pull_request`, not `workflow_run`. Filtering inside `Build PR & Deploy` directly isn't an option, and rebuilding the changed file list there from the `workflow_run` payload is fragile. Deciding once in the workflow that has the diff, and carrying that decision in the artifact, avoids both problems.

## Test plan

- [x] `actionlint` clean on both workflows (its shellcheck integration also surfaced two pre-existing SC2086/SC2129 warnings in deploy-pr.yml, fixed here)
- [x] `pre-commit run` clean locally (yamllint, editorconfig)
- [x] Both workflows parse as valid YAML
- [ ] After merge: a docs-only PR still builds, deploys, and comments
- [ ] After merge: a workflow/schema/script-only PR runs `check`, skips `build` and `comment`, and posts no preview comment

## Summary by Sourcery

Gate PR preview builds and comments on whether the pull request changes rendered documentation content, instead of always deploying on every PR.

New Features:
- Introduce a SHOULD_DEPLOY flag passed between workflows via the existing pr_info artifact to control whether a PR preview is built and deployed.

Enhancements:
- Split the deploy-pr workflow into a check job that reads PR metadata and a build job that only runs when a preview should actually be deployed.
- Update the comment job in the deploy-pr workflow to depend on the check result and use its outputs instead of recomputing PR metadata.
- Pin and configure dorny/paths-filter in the trigger-pr-deploy workflow to detect changes to docs and other rendered site assets before triggering a deploy.
- Clean up shell usage in deploy-pr.yml to avoid unquoted variable expansions and related shellcheck warnings.

CI:
- Adjust GitHub Actions workflows so PR preview builds, deployments, and comments are skipped for changes that do not affect rendered site content.