### PR TITLE
chore(gha): Quote GITHUB_ENV and GITHUB_OUTPUT redirect targets

### DIFF
--- a/.github/workflows/automatic-changelog.yml
+++ b/.github/workflows/automatic-changelog.yml
@@ -23,7 +23,7 @@ jobs:
         run: |
           last_edit_time=$(git log -1 --pretty="format:%cI" docs/updates.txt)
           echo "Last edit time: $last_edit_time"
-          echo "LAST_EDIT_TIME=$last_edit_time" >> $GITHUB_ENV
+          echo "LAST_EDIT_TIME=$last_edit_time" >> "$GITHUB_ENV"
 
       - name: Run git log
         run: |
@@ -32,10 +32,10 @@ jobs:
       - name: Check if there are new commits
         run: |
           if [ -s log_output.txt ]; then
-            echo "NEW_COMMITS=true" >> $GITHUB_ENV
+            echo "NEW_COMMITS=true" >> "$GITHUB_ENV"
           else
             echo "No new commits since the last update of docs/updates.txt."
-            echo "NEW_COMMITS=false" >> $GITHUB_ENV
+            echo "NEW_COMMITS=false" >> "$GITHUB_ENV"
           fi
 
       - name: Run update script

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Get pip cache directory
         id: pip-cache
         run: |
-          echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
+          echo "dir=$(pip cache dir)" >> "$GITHUB_OUTPUT"
 
       - name: Cache dependencies
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5


### PR DESCRIPTION
## Summary

actionlint, through its shellcheck integration, flags SC2086 on unquoted redirect targets in two workflows. `automatic-changelog.yml` writes `>> $GITHUB_ENV` three times and `deploy.yml` writes `>> $GITHUB_OUTPUT` once. If a runner ever exposed those paths with a space in them, the unquoted form would word-split. Quoting is the standard fix and matches how the rest of the repo already writes these redirects.

After this change, both files are fully actionlint-clean.

## Scope

Only the redirect targets, a zero-behavior-change edit. `mkdocs_bug_prevent.yml` is left out even though it also reports SC2086: those hits are intentional word splitting on a list of filenames passed to `grep`, and quoting them naively would break the check. Doing that correctly means restructuring with an array and re-testing the JSON-scan logic, which belongs in its own PR.

## Test plan

- [x] `actionlint .github/workflows/automatic-changelog.yml .github/workflows/deploy.yml` exits 0
- [x] `pre-commit run` clean locally (yamllint, editorconfig)
- [x] No logic touched, only redirect-target quoting

## Summary by Sourcery

CI:
- Quote GITHUB_ENV and GITHUB_OUTPUT paths in workflow redirect commands to eliminate shellcheck SC2086 warnings without changing workflow behavior.