### PR TITLE
chore(ci): harden GitHub Actions workflows with zizmor

### DIFF
--- a/.github/workflows/automatic-changelog.yml
+++ b/.github/workflows/automatic-changelog.yml
@@ -14,7 +14,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout
+      # PAT is required to push commits back to the repository.
+      - name: Checkout # zizmor: ignore[artipacked]
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
@@ -28,7 +29,7 @@ jobs:
 
       - name: Run git log
         run: |
-          git log --no-merges --perl-regexp --author='^(?!.*(\[bot\]|actions@github\.com)).*$' --grep='^(feat|fix|docs|style|refactor|perf|test|build|revert|update)(\((?!mkdocs|pr-naming-check).*?\))?:(?! Update CONTRIBUTORS.md)' --since="${{ env.LAST_EDIT_TIME }}" --pretty="%s" > log_output.txt
+          git log --no-merges --perl-regexp --author='^(?!.*(\[bot\]|actions@github\.com)).*$' --grep='^(feat|fix|docs|style|refactor|perf|test|build|revert|update)(\((?!mkdocs|pr-naming-check).*?\))?:(?! Update CONTRIBUTORS.md)' --since="${LAST_EDIT_TIME}" --pretty="%s" > log_output.txt
 
       - name: Check if there are new commits
         run: |

--- a/.github/workflows/automatic-changelog.yml
+++ b/.github/workflows/automatic-changelog.yml
@@ -49,9 +49,10 @@ jobs:
         if: env.NEW_COMMITS == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.PAT }}
+          PAT: ${{ secrets.PAT }}
         run: |
           git config --global user.email "actions@github.com"
           git config --global user.name "GitHub Actions"
           git diff
           git commit -am "chore(changelog): Update updates.txt" || exit 0
-          git push https://x-access-token:${{ secrets.PAT }}@github.com/${{ github.repository }}.git HEAD:master
+          git push "https://x-access-token:${PAT}@github.com/${GITHUB_REPOSITORY}.git" HEAD:master

--- a/.github/workflows/automatic-changelog.yml
+++ b/.github/workflows/automatic-changelog.yml
@@ -48,7 +48,6 @@ jobs:
       - name: Commit and push if it's not up to date
         if: env.NEW_COMMITS == 'true'
         env:
-          GITHUB_TOKEN: ${{ secrets.PAT }}
           PAT: ${{ secrets.PAT }}
         run: |
           git config --global user.email "actions@github.com"

--- a/.github/workflows/conflicts.yml
+++ b/.github/workflows/conflicts.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [master]
   # pull_request_target is safe here; this workflow never checks out PR code.
-  pull_request_target:
+  pull_request_target: # zizmor: ignore[dangerous-triggers]
     types: [synchronize]
 
 jobs:

--- a/.github/workflows/custom-format-validation.yml
+++ b/.github/workflows/custom-format-validation.yml
@@ -20,6 +20,9 @@ on:
       - docs/json/sonarr/conflicts.json
       - schemas/**/*.json
 
+permissions:
+  contents: read
+
 jobs:
   validate-json:
     runs-on: ubuntu-latest
@@ -27,6 +30,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Setup python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0

--- a/.github/workflows/deploy-pr.yml
+++ b/.github/workflows/deploy-pr.yml
@@ -102,14 +102,8 @@ jobs:
     runs-on: ubuntu-latest
     if: always() && needs.check.outputs.should_deploy == 'true'
     permissions:
-      contents: read
       pull-requests: write
     steps:
-      - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
-
       - name: Comment PR
         env:
           PREVIEW_URL: ${{ needs.build.outputs.url }}
@@ -136,4 +130,4 @@ jobs:
               -H "Accept: application/vnd.github+json" \
               -X POST \
               -d "{\"body\": $ESCAPED_BODY }" \
-              $COMMENTS_URL
+              "$COMMENTS_URL"

--- a/.github/workflows/deploy-pr.yml
+++ b/.github/workflows/deploy-pr.yml
@@ -117,6 +117,7 @@ jobs:
           BUILD_STATUS: ${{ needs.build.result }}
           PR_SHA: ${{ needs.check.outputs.pr_sha }}
           PR_NUMBER: ${{ needs.check.outputs.pr_number }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           if [ "$BUILD_STATUS" == "success" ]; then
             STATUS_EMOJI="✅"
@@ -131,7 +132,7 @@ jobs:
           ESCAPED_BODY=$(echo "$COMMENT_BODY" | jq -aRs .)
           COMMENTS_URL="https://api.github.com/repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments"
 
-          curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+          curl -H "Authorization: token ${GITHUB_TOKEN}" \
               -H "Accept: application/vnd.github+json" \
               -X POST \
               -d "{\"body\": $ESCAPED_BODY }" \

--- a/.github/workflows/deploy-pr.yml
+++ b/.github/workflows/deploy-pr.yml
@@ -1,24 +1,26 @@
 name: Build PR & Deploy
 
-on:
+# workflow_run is intentional; this workflow deploys PR previews triggered by a
+# separate unprivileged workflow to safely access secrets.
+on: # zizmor: ignore[dangerous-triggers]
   workflow_run:
     workflows: ["Trigger PR Build"]
     types:
       - completed
 
+permissions: {}
+
 concurrency:
   group: pull-request-builds
   cancel-in-progress: false
-
-permissions:
-  contents: write
-  pull-requests: write
-  actions: read
 
 jobs:
   check:
     runs-on: ubuntu-latest
     if: github.event.repository.fork == false
+    permissions:
+      contents: read
+      actions: read
     outputs:
       should_deploy: ${{ steps.pr_info.outputs.should_deploy }}
       pr_number: ${{ steps.pr_info.outputs.pr_number }}
@@ -49,6 +51,8 @@ jobs:
     needs: check
     if: needs.check.outputs.should_deploy == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       url: ${{ steps.cloudflare.outputs.deployment-url }}
       branch_url: ${{ steps.cloudflare.outputs.pages-deployment-alias-url }}
@@ -56,6 +60,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          persist-credentials: false
           ref: ${{ needs.check.outputs.pr_sha }}
           fetch-depth: 0
           sparse-checkout: |
@@ -64,23 +69,13 @@ jobs:
             includes
             overrides
 
-      - name: Setup python
+      # Only workflow_run from repo-owned workflows triggers this job; fork PRs cannot poison the cache.
+      - name: Setup python # zizmor: ignore[cache-poisoning]
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: 3.x
-
-      - name: Get pip cache directory
-        id: pip-cache
-        run: |
-          echo "dir=$(pip cache dir)" >> "$GITHUB_OUTPUT"
-
-      - name: Cache dependencies
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: ${{ steps.pip-cache.outputs.dir }}
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
+          cache: pip
+          cache-dependency-path: docs/requirements.txt
 
       - name: Install dependencies
         run: pip install -r docs/requirements.txt
@@ -106,16 +101,23 @@ jobs:
     needs: [check, build]
     runs-on: ubuntu-latest
     if: always() && needs.check.outputs.should_deploy == 'true'
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Comment PR
+        env:
+          PREVIEW_URL: ${{ needs.build.outputs.url }}
+          BRANCH_PREVIEW_URL: ${{ needs.build.outputs.branch_url }}
+          BUILD_STATUS: ${{ needs.build.result }}
+          PR_SHA: ${{ needs.check.outputs.pr_sha }}
+          PR_NUMBER: ${{ needs.check.outputs.pr_number }}
         run: |
-          PREVIEW_URL=${{ needs.build.outputs.url }}
-          BRANCH_PREVIEW_URL=${{ needs.build.outputs.branch_url }}
-          BUILD_STATUS=${{ needs.build.result }}
-
           if [ "$BUILD_STATUS" == "success" ]; then
             STATUS_EMOJI="✅"
             STATUS_MESSAGE="Deploy successful!"
@@ -124,10 +126,10 @@ jobs:
             STATUS_MESSAGE="Build failed!"
           fi
 
-          COMMENT_BODY="Deploying with ⚡ Cloudflare Pages<br><table><tr><td><strong>Latest commit:</strong></td><td><code>${{ needs.check.outputs.pr_sha }}</code></td></tr><tr><td><strong>Status:</strong></td><td>&nbsp;$STATUS_EMOJI&nbsp; $STATUS_MESSAGE</td></tr><tr><td><strong>Preview URL:</strong></td><td><a href='$PREVIEW_URL'>$PREVIEW_URL</a></td></tr><tr><td><strong>Branch Preview URL:</strong></td><td><a href='$BRANCH_PREVIEW_URL'>$BRANCH_PREVIEW_URL</a></td></tr></table>"
+          COMMENT_BODY="Deploying with ⚡ Cloudflare Pages<br><table><tr><td><strong>Latest commit:</strong></td><td><code>${PR_SHA}</code></td></tr><tr><td><strong>Status:</strong></td><td>&nbsp;$STATUS_EMOJI&nbsp; $STATUS_MESSAGE</td></tr><tr><td><strong>Preview URL:</strong></td><td><a href='$PREVIEW_URL'>$PREVIEW_URL</a></td></tr><tr><td><strong>Branch Preview URL:</strong></td><td><a href='$BRANCH_PREVIEW_URL'>$BRANCH_PREVIEW_URL</a></td></tr></table>"
 
           ESCAPED_BODY=$(echo "$COMMENT_BODY" | jq -aRs .)
-          COMMENTS_URL="https://api.github.com/repos/${{ github.repository }}/issues/${{ needs.check.outputs.pr_number }}/comments"
+          COMMENTS_URL="https://api.github.com/repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments"
 
           curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
               -H "Accept: application/vnd.github+json" \

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,6 +31,7 @@ jobs:
         with:
           python-version: 3.x
           cache: pip
+          cache-dependency-path: docs/requirements.txt
 
       - name: Install dependencies
         run: pip install -r docs/requirements.txt

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,9 @@ name: Build and Deploy Docs
 on:
   push:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Deploy docs
@@ -14,6 +17,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          persist-credentials: false
           fetch-depth: 0
           sparse-checkout: |
             docs
@@ -21,23 +25,12 @@ jobs:
             includes
             overrides
 
-      - name: Setup python
+      # Only trusted pushes to master trigger this workflow; fork PRs cannot poison the cache.
+      - name: Setup python # zizmor: ignore[cache-poisoning]
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: 3.x
-
-      - name: Get pip cache directory
-        id: pip-cache
-        run: |
-          echo "dir=$(pip cache dir)" >> "$GITHUB_OUTPUT"
-
-      - name: Cache dependencies
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: ${{ steps.pip-cache.outputs.dir }}
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
+          cache: pip
 
       - name: Install dependencies
         run: pip install -r docs/requirements.txt

--- a/.github/workflows/hold-merge.yml
+++ b/.github/workflows/hold-merge.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     types: [synchronize, opened, reopened, labeled, unlabeled]
 
+permissions: {}
+
 jobs:
   do-not-merge:
     if: contains(github.event.*.labels.*.name, 'Do Not Merge')

--- a/.github/workflows/metadata-validation.yml
+++ b/.github/workflows/metadata-validation.yml
@@ -12,6 +12,9 @@ on:
       - metadata.schema.json
       - .github/workflows/metadata-validation.yml
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     runs-on: ubuntu-latest
@@ -19,6 +22,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - name: Setup python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:

--- a/.github/workflows/mkdocs_bug_prevent.yml
+++ b/.github/workflows/mkdocs_bug_prevent.yml
@@ -19,10 +19,13 @@ jobs:
 
       - name: Find JSON Files Changed in Commit
         id: find_json_files
+        env:
+          BEFORE_SHA: ${{ github.event.before }}
+          CURRENT_SHA: ${{ github.sha }}
         run: |
           # Get the list of JSON files changed in the commit
-          JSON_FILES=$(git diff --name-only ${{ github.event.before }} ${{ github.sha }} | grep '\.json$' || true)
-          echo "json_files=$JSON_FILES" >> $GITHUB_ENV
+          JSON_FILES=$(git diff --name-only "$BEFORE_SHA" "$CURRENT_SHA" | grep '\.json$' || true)
+          echo "json_files=$JSON_FILES" >> "$GITHUB_ENV"
 
       - name: Check JSON Files for MkDocs Macro Issues
         run: |

--- a/.github/workflows/mkdocs_bug_prevent.yml
+++ b/.github/workflows/mkdocs_bug_prevent.yml
@@ -8,11 +8,14 @@ jobs:
   check-mkdocs:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       pull-requests: write
 
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Find JSON Files Changed in Commit
         id: find_json_files

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -5,12 +5,17 @@ on:
   push:
     branches: [master]
 
+permissions:
+  contents: read
+
 jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0

--- a/.github/workflows/quality-profile-validation.yml
+++ b/.github/workflows/quality-profile-validation.yml
@@ -26,6 +26,9 @@ on:
       - docs/json/sonarr/cf-groups/**
       - scripts/validate-quality-profiles.py
 
+permissions:
+  contents: read
+
 jobs:
   validate-quality-profiles:
     runs-on: ubuntu-latest
@@ -33,6 +36,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Setup python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0

--- a/.github/workflows/trigger-pr-deploy.yml
+++ b/.github/workflows/trigger-pr-deploy.yml
@@ -8,8 +8,8 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
+  pull-requests: read
 
 jobs:
   build:
@@ -29,11 +29,15 @@ jobs:
               - 'mkdocs.yml'
 
       - name: Save PR info
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_SHA: ${{ github.event.pull_request.head.sha }}
+          SHOULD_DEPLOY: ${{ steps.filter.outputs.rendered }}
         run: |
           mkdir -p ./pr_info
-          echo ${{ github.event.pull_request.number }} > ./pr_info/PR_NUMBER
-          echo ${{ github.event.pull_request.head.sha }} > ./pr_info/PR_SHA
-          echo ${{ steps.filter.outputs.rendered }} > ./pr_info/SHOULD_DEPLOY
+          echo "$PR_NUMBER" > ./pr_info/PR_NUMBER
+          echo "$PR_SHA" > ./pr_info/PR_SHA
+          echo "$SHOULD_DEPLOY" > ./pr_info/SHOULD_DEPLOY
 
       - name: Upload PR info
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/update_contributors.yml
+++ b/.github/workflows/update_contributors.yml
@@ -11,7 +11,8 @@ jobs:
   update_contributors:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
+      # PAT is required to push commits back to the repository.
+      - name: Checkout code # zizmor: ignore[artipacked]
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           token: ${{ secrets.PAT }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -89,3 +89,8 @@ repos:
     hooks:
       - id: editorconfig-checker
         name: EditorConfig Lint
+
+  - repo: https://github.com/zizmorcore/zizmor-pre-commit
+    rev: v1.25.0
+    hooks:
+      - id: zizmor


### PR DESCRIPTION
# Pull Request

## Purpose

This PR adds [zizmor](https://docs.zizmor.sh/) as a pre-commit hook and addresses the security findings it reports against the GitHub Actions workflows in this repo.

zizmor is a static analysis tool for GitHub Actions workflows. It catches common security misconfigurations (credential leaks, template injection, overly broad permissions, etc.) before they ship. Adding it to pre-commit means future workflow changes get checked automatically.

## Approach

**Fixes applied:**

- Added `persist-credentials: false` to checkout steps that don't need git push access. This prevents the GitHub token from being persisted in the local git config, reducing the attack surface if an action later accesses the `.git` directory.
- Added explicit `permissions:` blocks to workflows that previously relied on the default (broad) token permissions. Each job now requests only what it actually needs.
- Moved the `deploy-pr.yml` permissions from workflow-level to job-level so the build job (read-only) doesn't inherit write permissions meant for the comment job.
- Replaced manual `actions/cache` + pip cache directory steps with `setup-python`'s built-in `cache: pip` in the deploy workflows. Same caching behavior, less boilerplate.
- Converted template expressions (`${{ ... }}`) in `run:` blocks to environment variables where possible. This prevents potential code injection if an interpolated value ever contains shell metacharacters. Specifically:
  - `deploy-pr.yml` comment step now uses `env:` block instead of inline interpolation
  - `automatic-changelog.yml` uses `${LAST_EDIT_TIME}` (shell expansion) instead of `${{ env.LAST_EDIT_TIME }}` (template expansion)

**Intentional suppressions (with inline justification comments):**

- `artipacked` on the two checkouts that use `secrets.PAT`: these workflows need credentials persisted to push commits back to the repo.
- `dangerous-triggers` on `deploy-pr.yml`: the `workflow_run` trigger is the standard secure pattern for accessing secrets in PR preview deployments.
- `cache-poisoning` on the deploy workflows: only trusted pushes to master (or repo-owned workflow_run triggers) can write to the cache; fork PRs cannot poison it.

**Pre-commit hook:**

Added zizmor v1.25.0 via the [zizmorcore/zizmor-pre-commit](https://github.com/zizmorcore/zizmor-pre-commit) repo. It runs on `.github/workflows/*.yml` files.

## Open Questions and Pre-Merge TODOs

- [ ] Verify the deploy workflows still cache pip correctly with `cache: pip` on `setup-python` (this is functionally equivalent to the old manual approach, just less code)

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Harden GitHub Actions workflows by tightening permissions, reducing credential exposure, and integrating automated security scanning for workflow configs.

New Features:
- Add zizmor static analysis as a pre-commit hook to automatically scan GitHub Actions workflows for security issues.

Enhancements:
- Add explicit, least-privilege permissions to multiple workflows and jobs that previously relied on default token permissions.
- Disable credential persistence for checkout steps that do not require push access to reduce token exposure risk.
- Simplify Python dependency caching in deploy workflows by using setup-python's built-in pip cache instead of manual cache steps.
- Refine workflow scripting by replacing GitHub expression interpolation in shell commands with environment variables to mitigate potential injection risks.
- Clarify and adjust workflow_run and caching behavior with documented, intentional security rule suppressions where required.
- Set an explicit empty permissions block in the hold-merge workflow to prevent unintended token access.

CI:
- Strengthen CI security posture across workflows by standardizing permissions, token handling, and cache usage.

Deployment:
- Ensure deployment-related workflows request only necessary permissions and use safer token and caching configurations.