### PR TITLE
feat(starr): Recover the HLG CFs with a score of -10k

### DIFF
--- a/docs/Radarr/Radarr-collection-of-custom-formats.md
+++ b/docs/Radarr/Radarr-collection-of-custom-formats.md
@@ -664,6 +664,22 @@ We've made 3 guides related to this.
 
 ---
 
+### HLG
+
+??? question "Description - [Click to show/hide]"
+
+    {! include-markdown "../../includes/cf-descriptions/hlg.md" !}
+
+??? example "JSON - [Click to show/hide]"
+
+    ```json
+    [[% filter indent(width=4) %]][[% include 'json/radarr/cf/hlg.json' %]][[% endfilter %]]
+    ```
+
+<sub><sup>[TOP](#index)</sup></sub>
+
+---
+
 ## Streaming Services
 
 ---

--- a/docs/Sonarr/sonarr-collection-of-custom-formats.md
+++ b/docs/Sonarr/sonarr-collection-of-custom-formats.md
@@ -685,6 +685,22 @@ Special thanks to everyone who has helped in the creation and testing of these C
 
 ---
 
+### HLG
+
+??? question "Description - [Click to show/hide]"
+
+    {! include-markdown "../../includes/cf-descriptions/hlg.md" !}
+
+??? example "JSON - [Click to show/hide]"
+
+    ```json
+    [[% filter indent(width=4) %]][[% include 'json/sonarr/cf/hlg.json' %]][[% endfilter %]]
+    ```
+
+<sub><sup>[TOP](#index)</sup></sub>
+
+---
+
 ## Streaming Services
 
 ---

--- a/docs/json/radarr/cf/hlg.json
+++ b/docs/json/radarr/cf/hlg.json
@@ -17,15 +17,6 @@
       }
     },
     {
-      "name": "Not DV",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": true,
-      "required": true,
-      "fields": {
-        "value": "\\b(dv|dovi|dolby[ .]?v(ision)?)\\b"
-      }
-    },
-    {
       "name": "Not HDR10+",
       "implementation": "ReleaseTitleSpecification",
       "negate": true,

--- a/docs/json/radarr/cf/hlg.json
+++ b/docs/json/radarr/cf/hlg.json
@@ -1,0 +1,56 @@
+{
+  "trash_id": "9364dd386c9b4a1100dde8264690add7",
+  "trash_description": "This Custom Format matches HLG releases. The default score can be used to prevent downloading HLG releases on devices that can't play them properly.",
+  "trash_scores": {
+    "default": -10000
+  },
+  "name": "HLG",
+  "includeCustomFormatWhenRenaming": false,
+  "specifications": [
+    {
+      "name": "HLG",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": true,
+      "fields": {
+        "value": "\\b(HLG)\\b"
+      }
+    },
+    {
+      "name": "Not DV",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": true,
+      "required": true,
+      "fields": {
+        "value": "\\b(dv|dovi|dolby[ .]?v(ision)?)\\b"
+      }
+    },
+    {
+      "name": "Not HDR10+",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": true,
+      "required": true,
+      "fields": {
+        "value": "\\bHDR10(\\+|P(lus)?\\b)"
+      }
+    },
+    {
+      "name": "Not HDR10",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": true,
+      "required": true,
+      "fields": {
+        "value": "\\bHDR10(?!\\+|Plus)\\b"
+      }
+    },
+    {
+      "name": "Not PQ",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": true,
+      "required": true,
+      "fields": {
+        "value": "\\b(PQ)\\b"
+      }
+    }
+  ]
+}

--- a/docs/json/sonarr/cf/hlg.json
+++ b/docs/json/sonarr/cf/hlg.json
@@ -17,15 +17,6 @@
       }
     },
     {
-      "name": "Not DV",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": true,
-      "required": true,
-      "fields": {
-        "value": "\\b(dv|dovi|dolby[ .]?v(ision)?)\\b"
-      }
-    },
-    {
       "name": "Not HDR10+",
       "implementation": "ReleaseTitleSpecification",
       "negate": true,

--- a/docs/json/sonarr/cf/hlg.json
+++ b/docs/json/sonarr/cf/hlg.json
@@ -1,0 +1,56 @@
+{
+  "trash_id": "17e889ce13117940092308f48b48b45b",
+  "trash_description": "This Custom Format matches HLG releases. The default score can be used to prevent downloading HLG releases on devices that can't play them properly.",
+  "trash_scores": {
+    "default": -10000
+  },
+  "name": "HLG",
+  "includeCustomFormatWhenRenaming": false,
+  "specifications": [
+    {
+      "name": "HLG",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": true,
+      "fields": {
+        "value": "\\b(HLG)\\b"
+      }
+    },
+    {
+      "name": "Not DV",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": true,
+      "required": true,
+      "fields": {
+        "value": "\\b(dv|dovi|dolby[ .]?v(ision)?)\\b"
+      }
+    },
+    {
+      "name": "Not HDR10+",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": true,
+      "required": true,
+      "fields": {
+        "value": "\\bHDR10(\\+|P(lus)?\\b)"
+      }
+    },
+    {
+      "name": "Not HDR10",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": true,
+      "required": true,
+      "fields": {
+        "value": "\\bHDR10(?!\\+|Plus)\\b"
+      }
+    },
+    {
+      "name": "Not PQ",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": true,
+      "required": true,
+      "fields": {
+        "value": "\\b(PQ)\\b"
+      }
+    }
+  ]
+}

--- a/includes/cf-descriptions/hlg.md
+++ b/includes/cf-descriptions/hlg.md
@@ -1,9 +1,9 @@
-<!-- markdownlint-disable MD041-->
-_This Custom Format will only match on_ `DV HLG`
+<!-- markdownlint-disable MD036 MD041-->
+**HLG**
 
-**HLG**<br>
+This Custom Format matches HLG releases. The default score can be used to prevent downloading HLG releases on devices that can't play them properly, e.g., the picture appears very dark and murky, making it unwatchable.
 
-HLG or HLG10 is an HDR format created by NHK (JP) and the BBC that can be used for both video and still images. This format is backward compatible with SDR UHD TV, but not with older SDR displays that do not implement the Rec. 2020 color standards.
+HLG or HLG10 is an HDR format developed by NHK (JP) and the BBC, suitable for both video and still images. This format is backwards compatible with SDR UHD TVs but not with older SDR displays that do not support Rec. 2020 color standards.
 
-You will find this mainly with cable, satellite, and over-the-air TV broadcast series and movies from the likes of BBC and National Geographic.
-<!-- markdownlint-enable MD041-->
+You will mainly see this with cable, satellite, and over-the-air TV broadcasts from networks like the BBC and National Geographic.
+<!-- markdownlint-enable MD036 MD041-->


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->

This Custom Format matches HLG releases. The default score can be used to prevent downloading HLG releases on devices that can't play them properly, e.g., the picture appears very dark and murky, making it unwatchable, as reported in #2741 

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

Recovered the HLG CFs with a score of -10k

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Add support documentation and configuration for an HLG custom format in both Radarr and Sonarr.

New Features:
- Introduce HLG custom format JSON definitions for Radarr and Sonarr to allow targeted scoring of HLG releases.

Documentation:
- Document the HLG custom format in the Radarr and Sonarr custom format collections with collapsible description and JSON sections.
- Clarify and expand the shared HLG custom format description, including usage context and compatibility notes.