### PR TITLE
feat(starr): Add RlsGrp `CYPHER`, `MLH`, and `XiQUEXiQUE` to the Bad Dual Groups

### DIFF
--- a/docs/json/radarr/cf/bad-dual-groups.json
+++ b/docs/json/radarr/cf/bad-dual-groups.json
@@ -66,6 +66,15 @@
       }
     },
     {
+      "name": "CYPHER",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(CYPHER)$"
+      }
+    },
+    {
       "name": "EniaHD",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,
@@ -135,6 +144,15 @@
       "required": false,
       "fields": {
         "value": "^(MGE\\b.*)$"
+      }
+    },
+    {
+      "name": "MLH",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(MLH)$"
       }
     },
     {
@@ -261,6 +279,15 @@
       "required": false,
       "fields": {
         "value": "^(WTV)$"
+      }
+    },
+    {
+      "name": "XiQUEXiQUE",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(XiQUEXiQUE)$"
       }
     },
     {

--- a/docs/json/sonarr/cf/bad-dual-groups.json
+++ b/docs/json/sonarr/cf/bad-dual-groups.json
@@ -29,6 +29,33 @@
       }
     },
     {
+      "name": "CYPHER",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(CYPHER)$"
+      }
+    },
+    {
+      "name": "MLH",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(MLH)$"
+      }
+    },
+    {
+      "name": "XiQUEXiQUE",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(XiQUEXiQUE)$"
+      }
+    },
+    {
       "name": "BiOMA",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,

--- a/includes/cf-descriptions/bad-dual-groups.md
+++ b/includes/cf-descriptions/bad-dual-groups.md
@@ -1,5 +1,5 @@
-<!-- markdownlint-disable MD041-->
-**Bad Dual/Multi groups**<br>
+<!-- markdownlint-disable MD036 MD041-->
+**Bad Dual/Multi groups**
 
-These release groups do not use the original language of the media as the first audio track. Since ffprobe relies on the first audio track to determine the primary language of the release, incorrect ordering can lead to parsing issues. This may result in failed imports, misidentified files, or even download loops. To ensure proper handling, the original language should always be the first audio track in the release.
-<!-- markdownlint-enable MD041-->
+These release groups often do not set the original language of the media as the first audio track. Since ffprobe relies on the first audio track to determine the release's primary language, incorrect ordering can cause parsing errors. This may lead to failed imports, misidentified files, or download loops. To ensure proper processing, the original language should always be the first audio track in the release.
+<!-- markdownlint-enable MD036 MD041-->


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->

Added RlsGrp `CYPHER`, `MLH`, and `XiQUEXiQUE` to the Bad Dual Groups

These release groups often do not set the original language of the media as the first audio track. Since ffprobe relies on the first audio track to determine the release's primary language, incorrect ordering can cause parsing errors. This may lead to failed imports, misidentified files, or download loops. To ensure proper processing, the original language should always be the first audio track in the release.

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

Added RlsGrp `CYPHER`, `MLH`, and `XiQUEXiQUE` to the Bad Dual Groups

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Add additional release groups to the Bad Dual/Multi groups custom format for Radarr and Sonarr and update its accompanying description.

New Features:
- Include CYPHER, MLH, and XiQUEXiQUE as bad dual/multi release groups in the Radarr and Sonarr custom format configuration.

Enhancements:
- Adjust markdownlint configuration comments for the Bad Dual/Multi groups documentation section.

Documentation:
- Clarify the Bad Dual/Multi groups description to better explain how incorrect audio track ordering affects language detection and processing.