### PR TITLE
feat(starr): Change the default score for the CF `WiTH AD` to `-10k`

### DIFF
--- a/docs/json/radarr/cf/with-ad.json
+++ b/docs/json/radarr/cf/with-ad.json
@@ -1,6 +1,11 @@
 {
   "trash_id": "127bdbadcf3e4463a8c707759fbaad75",
   "trash_regex": "https://regex101.com/r/YWHIIr/1",
+  "trash_scores": {
+    "default": -10000,
+    "german": -35000,
+    "german-anime": -35000
+  },
   "name": "WiTH AD",
   "includeCustomFormatWhenRenaming": true,
   "specifications": [

--- a/docs/json/sonarr/cf/with-ad.json
+++ b/docs/json/sonarr/cf/with-ad.json
@@ -1,6 +1,11 @@
 {
   "trash_id": "44ccbcbc74506f208973e1463b11705f",
   "trash_regex": "https://regex101.com/r/YWHIIr/1",
+  "trash_scores": {
+    "default": -10000,
+    "german": -35000,
+    "german-anime": -35000
+  },
   "name": "WiTH AD",
   "includeCustomFormatWhenRenaming": true,
   "specifications": [


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->

After some research, we noticed that releases with Audio Description often have that track set as the default audio track. We had expected it to be added as a second audio track instead, allowing the user to choose.
In general, releases with Audio Description receive the same score, and if a release with Audio Description is released earlier, it will not upgrade to one without Audio Description. To prevent this, we decided to give this CF a default score of -10k for the larger user base.

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

Changed the default score for the CF `WiTH AD` to `-10k`

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Enhancements:
- Lower the default score of the `WiTH AD` custom format in both Radarr and Sonarr JSON configs to reduce selection preference for audio-description releases.