### PR TITLE
fix(starr): Asian Streaming Services CF `friDay` and `iQIY` to Avoid False Positives

### DIFF
--- a/docs/json/radarr/cf/friday.json
+++ b/docs/json/radarr/cf/friday.json
@@ -12,7 +12,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\b(friDay)\\b"
+        "value": "\\b(friDay)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)"
       }
     },
     {

--- a/docs/json/radarr/cf/iqiy.json
+++ b/docs/json/radarr/cf/iqiy.json
@@ -12,7 +12,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\b(IQIY|IQ|iQIYI)\\b"
+        "value": "\\b(IQIY|IQ|iQIYI)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)"
       }
     },
     {

--- a/docs/json/sonarr/cf/friday.json
+++ b/docs/json/sonarr/cf/friday.json
@@ -12,7 +12,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\b(friDay)\\b"
+        "value": "\\b(friDay)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)"
       }
     },
     {

--- a/docs/json/sonarr/cf/iqiy.json
+++ b/docs/json/sonarr/cf/iqiy.json
@@ -12,7 +12,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\b(IQIY|IQ|iQIYI)\\b"
+        "value": "\\b(IQIY|IQ|iQIYI)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)"
       }
     },
     {


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->

Improved regex to Avoid False Positives for Asian Streaming Services CF `friDay` and `iQIY

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

Improved regex to Avoid False Positives for Asian Streaming Services CF `friDay` and `iQIY

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Tighten custom format matching for Asian streaming services friDay and iQIYI in Radarr and Sonarr to reduce false positives.

Bug Fixes:
- Adjust friDay custom format definitions to avoid incorrectly matching unrelated releases.
- Adjust iQIYI custom format definitions to avoid incorrectly matching unrelated releases.