### PR TITLE
feat(starr-anime): resort German anime guides.

### DIFF
--- a/docs/json/radarr/quality-profiles/german-anime-hd-bluray-web.json
+++ b/docs/json/radarr/quality-profiles/german-anime-hd-bluray-web.json
@@ -11,36 +11,6 @@
   "minUpgradeFormatScore": 1,
   "language": "Any",
   "items": [
-    { "name": "Unknown", "allowed": false },
-    { "name": "WORKPRINT", "allowed": false },
-    { "name": "CAM", "allowed": false },
-    { "name": "TELESYNC", "allowed": false },
-    { "name": "TELECINE", "allowed": false },
-    { "name": "REGIONAL", "allowed": false },
-    { "name": "DVDSCR", "allowed": false },
-    { "name": "SDTV", "allowed": false },
-    { "name": "DVD", "allowed": false },
-    { "name": "DVD-R", "allowed": false },
-    {
-      "name": "WEB 480p",
-      "allowed": false,
-      "items": ["WEBDL-480p", "WEBRip-480p"]
-    },
-    { "name": "Bluray-480p", "allowed": false },
-    { "name": "Bluray-576p", "allowed": false },
-    { "name": "HDTV-720p", "allowed": false },
-    { "name": "HDTV-1080p", "allowed": false },
-    { "name": "Remux-1080p", "allowed": false },
-    { "name": "HDTV-2160p", "allowed": false },
-    {
-      "name": "WEB 2160p",
-      "allowed": false,
-      "items": ["WEBDL-2160p", "WEBRip-2160p"]
-    },
-    { "name": "Bluray-2160p", "allowed": false },
-    { "name": "Remux-2160p", "allowed": false },
-    { "name": "BR-DISK", "allowed": false },
-    { "name": "Raw-HD", "allowed": false },
     {
       "name": "Merged QPs",
       "allowed": true,
@@ -52,7 +22,37 @@
         "WEBRip-1080p",
         "Bluray-1080p"
       ]
-    }
+    },
+    { "name": "Raw-HD", "allowed": false },
+    { "name": "BR-DISK", "allowed": false },
+    { "name": "Remux-2160p", "allowed": false },
+    { "name": "Bluray-2160p", "allowed": false },
+    {
+      "name": "WEB 2160p",
+      "allowed": false,
+      "items": ["WEBDL-2160p", "WEBRip-2160p"]
+    },
+    { "name": "HDTV-2160p", "allowed": false },
+    { "name": "Remux-1080p", "allowed": false },
+    { "name": "HDTV-1080p", "allowed": false },
+    { "name": "HDTV-720p", "allowed": false },
+    { "name": "Bluray-576p", "allowed": false },
+    { "name": "Bluray-480p", "allowed": false },
+    {
+      "name": "WEB 480p",
+      "allowed": false,
+      "items": ["WEBDL-480p", "WEBRip-480p"]
+    },
+    { "name": "DVD-R", "allowed": false },
+    { "name": "DVD", "allowed": false },
+    { "name": "SDTV", "allowed": false },
+    { "name": "DVDSCR", "allowed": false },
+    { "name": "REGIONAL", "allowed": false },
+    { "name": "TELECINE", "allowed": false },
+    { "name": "TELESYNC", "allowed": false },
+    { "name": "CAM", "allowed": false },
+    { "name": "WORKPRINT", "allowed": false },
+    { "name": "Unknown", "allowed": false }
   ],
   "formatItems": {
     "German 1080p Booster": "3bc8df3a71baaac60a31ef696ea72d36",

--- a/docs/json/sonarr/quality-profiles/german-anime-hd-bluray-web.json
+++ b/docs/json/sonarr/quality-profiles/german-anime-hd-bluray-web.json
@@ -10,28 +10,6 @@
   "cutoffFormatScore": 35000,
   "minUpgradeFormatScore": 1,
   "items": [
-    { "name": "Unknown", "allowed": false },
-    { "name": "SDTV", "allowed": false },
-    {
-      "name": "WEB 480p",
-      "allowed": false,
-      "items": ["WEBDL-480p", "WEBRip-480p"]
-    },
-    { "name": "DVD", "allowed": false },
-    { "name": "Bluray-480p", "allowed": false },
-    { "name": "Bluray-576p", "allowed": false },
-    { "name": "HDTV-720p", "allowed": false },
-    { "name": "HDTV-1080p", "allowed": false },
-    { "name": "Raw-HD", "allowed": false },
-    { "name": "Bluray-1080p Remux", "allowed": false },
-    { "name": "HDTV-2160p", "allowed": false },
-    {
-      "name": "WEB 2160p",
-      "allowed": false,
-      "items": ["WEBDL-2160p", "WEBRip-2160p"]
-    },
-    { "name": "Bluray-2160p", "allowed": false },
-    { "name": "Bluray-2160p Remux", "allowed": false },
     {
       "name": "Merged QPs",
       "allowed": true,
@@ -43,7 +21,29 @@
         "WEBRip-1080p",
         "Bluray-1080p"
       ]
-    }
+    },
+    { "name": "Bluray-2160p Remux", "allowed": false },
+    { "name": "Bluray-2160p", "allowed": false },
+    {
+      "name": "WEB 2160p",
+      "allowed": false,
+      "items": ["WEBDL-2160p", "WEBRip-2160p"]
+    },
+    { "name": "HDTV-2160p", "allowed": false },
+    { "name": "Bluray-1080p Remux", "allowed": false },
+    { "name": "Raw-HD", "allowed": false },
+    { "name": "HDTV-1080p", "allowed": false },
+    { "name": "HDTV-720p", "allowed": false },
+    { "name": "Bluray-576p", "allowed": false },
+    { "name": "Bluray-480p", "allowed": false },
+    { "name": "DVD", "allowed": false },
+    {
+      "name": "WEB 480p",
+      "allowed": false,
+      "items": ["WEBDL-480p", "WEBRip-480p"]
+    },
+    { "name": "SDTV", "allowed": false },
+    { "name": "Unknown", "allowed": false }
   ],
   "formatItems": {
     "German 1080p Booster": "9aa0ca0d2d66b6f6ee51fc630f46cf6f",


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->

resort qualities so that the best quality is on top. Easier for users if they enable more qualities, so they don't have to resort the items manually in tools like clonarr.

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

## Open Questions and Pre-Merge TODOs

Maybe the documentation needs to  be updated, not checked

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Resort quality entries in the German anime HD Bluray/Web quality profiles for Radarr and Sonarr so that higher-quality options appear first.

Enhancements:
- Adjust ordering of qualities in the German anime HD Bluray/Web Radarr profile to prioritize best quality at the top.
- Adjust ordering of qualities in the German anime HD Bluray/Web Sonarr profile to prioritize best quality at the top.