### PR TITLE
fix(gha): switch to eps1lon action and fix fork PR failures

### DIFF
--- a/.github/workflows/conflicts.yml
+++ b/.github/workflows/conflicts.yml
@@ -2,19 +2,20 @@ name: Label Conflicts
 
 on:
   push:
-  pull_request:
+    branches: [master]
+  # pull_request_target is safe here; this workflow never checks out PR code.
+  pull_request_target:
+    types: [synchronize]
 
 jobs:
   triage:
     runs-on: ubuntu-latest
+    if: github.event.repository.fork == false
     permissions:
       pull-requests: write
     steps:
       - name: Label merge conflicts
-        uses: mschilde/auto-label-merge-conflicts@3fdaf1c8b3f8e5b0f88753d9cb3c9c779370b3ef # v2.0
-        if: github.event.repository.fork == false
+        uses: eps1lon/actions-label-merge-conflict@1df065ebe6e3310545d4f4c4e862e43bdca146f0 # v3.0.3
         with:
-          CONFLICT_LABEL_NAME: "Status: Conflicted"
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          MAX_RETRIES: 5
-          WAIT_MS: 5000
+          dirtyLabel: "Status: Conflicted"
+          repoToken: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The Label Conflicts workflow was failing on fork-based PRs (like #2740) because GitHub restricts `GITHUB_TOKEN` to read-only on `pull_request` events from forks, regardless of what the workflow declares.

The `mschilde/auto-label-merge-conflicts` action scans all open PRs for merge conflicts on every run. When it found a conflicted PR and tried to call the `addLabelsToLabelable` GraphQL mutation, it hit:

```
addLabelsToLabelable request failed: GraphqlError: Resource not accessible by integration
```

Previous runs on the same branch "passed" only because no PRs had conflicts at the time, so the mutation was never called.

Changes:

- Replaced `mschilde/auto-label-merge-conflicts` (dormant since 2020) with `eps1lon/actions-label-merge-conflict@v3.0.3`, which is actively maintained and handles this case
- Scoped `push` trigger to `master` only (feature branch pushes can't create conflicts in other PRs)
- Added `pull_request_target: [synchronize]` so the conflict label gets removed when authors rebase (safe because the workflow never checks out PR code)
- Removed the redundant `pull_request` trigger that caused the fork failures

## Summary by Sourcery

Update the merge-conflict labeling workflow to use a maintained action and avoid fork-related permission failures.

CI:
- Replace the deprecated auto-label merge conflicts action with eps1lon/actions-label-merge-conflict in the conflicts workflow.
- Restrict the conflicts workflow push trigger to the master branch and handle PR updates via pull_request_target synchronize events.
- Adjust workflow conditions and inputs to prevent failures on fork-based pull requests while preserving conflict labeling behavior.