### PR TITLE
docs(sabnzbd): add python3 path check to script prerequisites

### DIFF
--- a/docs/Downloaders/SABnzbd/scripts/index.md
+++ b/docs/Downloaders/SABnzbd/scripts/index.md
@@ -11,6 +11,7 @@ If you have a script you want to share, don't hesitate to create a [PR](https://
 - You've created folder called `scripts` in the root directory of SABnzbd
 - You've set the `scripts` folder inside the SABnzbd settings under `Folder > User Folders > Scripts Folder`. ([More Infos](https://sabnzbd.org/wiki/configuration/4.3/folders))
 - Your script got sufficient rights to execute. ([More Infos](https://sabnzbd.org/wiki/configuration/4.5/scripts/post-processing-scripts))
+- You've checked the installation location for python3 using `which python3` to replace the path at the start of the script.
 
 ## Clean
 

--- a/docs/Downloaders/SABnzbd/scripts/index.md
+++ b/docs/Downloaders/SABnzbd/scripts/index.md
@@ -11,7 +11,7 @@ If you have a script you want to share, don't hesitate to create a [PR](https://
 - You've created folder called `scripts` in the root directory of SABnzbd
 - You've set the `scripts` folder inside the SABnzbd settings under `Folder > User Folders > Scripts Folder`. ([More Infos](https://sabnzbd.org/wiki/configuration/4.3/folders))
 - Your script got sufficient rights to execute. ([More Infos](https://sabnzbd.org/wiki/configuration/4.5/scripts/post-processing-scripts))
-- You've checked the installation location for python3 using `which python3` to replace the path at the start of the script.
+- You've checked the installation location for Python 3 using `which python3` to replace the path at the start of the script.
 
 ## Clean
 


### PR DESCRIPTION
Added instruction to check python3 path in Docker.

# Pull Request

## Purpose

Scripts don't run if python3 path is incorrect.

## Approach

This informs users that the python3 path is important for the scripts to run successfully and a basic step how to fix it.

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Document the Python 3 path requirement for SABnzbd scripts running in Docker.

Enhancements:
- Add guidance for verifying the Python 3 executable path in Docker-based SABnzbd installations so scripts can run successfully.

Documentation:
- Document how to check the container’s Python 3 path and update script shebangs accordingly.