### PR TITLE
feat(starr): Add RlsGrp `MADSKY` to `WEB Tier 01`

### DIFF
--- a/docs/json/radarr/cf/web-tier-01.json
+++ b/docs/json/radarr/cf/web-tier-01.json
@@ -10,24 +10,6 @@
   "includeCustomFormatWhenRenaming": false,
   "specifications": [
     {
-      "name": "WEBDL",
-      "implementation": "SourceSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": 7
-      }
-    },
-    {
-      "name": "WEBRIP",
-      "implementation": "SourceSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": 8
-      }
-    },
-    {
       "name": "ABBIE",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,
@@ -145,6 +127,15 @@
       }
     },
     {
+      "name": "MADSKY",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(MADSKY)$"
+      }
+    },
+    {
       "name": "NOSiViD",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,
@@ -214,6 +205,24 @@
       "required": false,
       "fields": {
         "value": "^(ZoroSenpai)$"
+      }
+    },
+    {
+      "name": "WEBDL",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 7
+      }
+    },
+    {
+      "name": "WEBRIP",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 8
       }
     }
   ]

--- a/docs/json/radarr/cf/web-tier-02.json
+++ b/docs/json/radarr/cf/web-tier-02.json
@@ -10,24 +10,6 @@
   "includeCustomFormatWhenRenaming": false,
   "specifications": [
     {
-      "name": "WEBDL",
-      "implementation": "SourceSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": 7
-      }
-    },
-    {
-      "name": "WEBRIP",
-      "implementation": "SourceSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": 8
-      }
-    },
-    {
       "name": "dB",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,
@@ -124,6 +106,24 @@
       "required": false,
       "fields": {
         "value": "^(XEBEC|4KBEC|CEBEX)$"
+      }
+    },
+    {
+      "name": "WEBDL",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 7
+      }
+    },
+    {
+      "name": "WEBRIP",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 8
       }
     }
   ]

--- a/docs/json/radarr/cf/web-tier-03.json
+++ b/docs/json/radarr/cf/web-tier-03.json
@@ -10,24 +10,6 @@
   "includeCustomFormatWhenRenaming": false,
   "specifications": [
     {
-      "name": "WEBDL",
-      "implementation": "SourceSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": 7
-      }
-    },
-    {
-      "name": "WEBRIP",
-      "implementation": "SourceSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": 8
-      }
-    },
-    {
       "name": "BLOOM",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,
@@ -115,6 +97,24 @@
       "required": false,
       "fields": {
         "value": "^(SwAgLaNdEr)$"
+      }
+    },
+    {
+      "name": "WEBDL",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 7
+      }
+    },
+    {
+      "name": "WEBRIP",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 8
       }
     }
   ]

--- a/docs/json/sonarr/cf/web-tier-01.json
+++ b/docs/json/sonarr/cf/web-tier-01.json
@@ -99,6 +99,15 @@
       }
     },
     {
+      "name": "MADSKY",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(MADSKY)$"
+      }
+    },
+    {
       "name": "monkee",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,

--- a/docs/json/sonarr/cf/web-tier-03.json
+++ b/docs/json/sonarr/cf/web-tier-03.json
@@ -9,24 +9,6 @@
   "includeCustomFormatWhenRenaming": false,
   "specifications": [
     {
-      "name": "WEBDL",
-      "implementation": "SourceSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": 3
-      }
-    },
-    {
-      "name": "WEBRIP",
-      "implementation": "SourceSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": 4
-      }
-    },
-    {
       "name": "BLOOM",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,
@@ -105,6 +87,24 @@
       "required": false,
       "fields": {
         "value": "^(ViSiON)$"
+      }
+    },
+    {
+      "name": "WEBDL",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 3
+      }
+    },
+    {
+      "name": "WEBRIP",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 4
       }
     }
   ]


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->

Added RlsGrp `MADSKY` to `WEB Tier 01`

Provided justification:
- First MADSKY was on October 15, 2023, and is still releasing.
- They are also on the so-called Gentleman sign-up list.
- Do a better job than scene releases that are uploaded to the same tracker and should be tiered to surpass scene or other P2P groups of lesser quality.
- Includes all subtitles available from streaming services.
- Uses the highest quality streams per channel or region.
- Are providing 4k SDR, DV, and DV HDR content.
- According to the provided reports, they also do Hybrid releases.

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

- Added RlsGrp `MADSKY` to `WEB Tier 01`
- For consistency, the JSON sort order has been changed to: implementation followed by name.

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Add MADSKY to the top WEB release tier and align JSON sorting across related Radarr and Sonarr WEB tier custom format definitions.

New Features:
- Add MADSKY release group to the WEB Tier 01 custom format for both Radarr and Sonarr.

Enhancements:
- Normalize JSON sort order to implementation-then-name across Radarr and Sonarr WEB tier custom format JSON files.