### PR TITLE
fix(starr-anime): update PuddingSama regex to match old and new name

### DIFF
--- a/docs/json/radarr/cf/german-anime-bluray-tier-01.json
+++ b/docs/json/radarr/cf/german-anime-bluray-tier-01.json
@@ -21,7 +21,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "^(Pudding-sama)$"
+        "value": "^(Pudding[-]?[Ss]ama)$"
       }
     },
     {

--- a/docs/json/radarr/cf/german-anime-bluray-tier-01.json
+++ b/docs/json/radarr/cf/german-anime-bluray-tier-01.json
@@ -21,7 +21,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "^(Pudding[-]?[Ss]ama)$"
+        "value": "^(Pudding[-]?sama)$"
       }
     },
     {

--- a/docs/json/radarr/cf/german-anime-web-tier-01.json
+++ b/docs/json/radarr/cf/german-anime-web-tier-01.json
@@ -21,7 +21,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "^(Pudding-sama)$"
+        "value": "^(Pudding[-]?[Ss]ama)$"
       }
     },
     {

--- a/docs/json/radarr/cf/german-anime-web-tier-01.json
+++ b/docs/json/radarr/cf/german-anime-web-tier-01.json
@@ -21,7 +21,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "^(Pudding[-]?[Ss]ama)$"
+        "value": "^(Pudding[-]?sama)$"
       }
     },
     {

--- a/docs/json/sonarr/cf/german-anime-bluray-tier-01.json
+++ b/docs/json/sonarr/cf/german-anime-bluray-tier-01.json
@@ -21,7 +21,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "^(Pudding-sama)$"
+        "value": "^(Pudding[-]?[Ss]ama)$"
       }
     },
     {

--- a/docs/json/sonarr/cf/german-anime-bluray-tier-01.json
+++ b/docs/json/sonarr/cf/german-anime-bluray-tier-01.json
@@ -21,7 +21,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "^(Pudding[-]?[Ss]ama)$"
+        "value": "^(Pudding[-]?sama)$"
       }
     },
     {

--- a/docs/json/sonarr/cf/german-anime-web-tier-01.json
+++ b/docs/json/sonarr/cf/german-anime-web-tier-01.json
@@ -21,7 +21,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "^(Pudding-sama)$"
+        "value": "^(Pudding[-]?[Ss]ama)$"
       }
     },
     {

--- a/docs/json/sonarr/cf/german-anime-web-tier-01.json
+++ b/docs/json/sonarr/cf/german-anime-web-tier-01.json
@@ -21,7 +21,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "^(Pudding[-]?[Ss]ama)$"
+        "value": "^(Pudding[-]?sama)$"
       }
     },
     {


### PR DESCRIPTION
# Pull Request
## Purpose
Fix the name change of a releaser from Pudding-sama to PuddingSama

## Approach
Updated the regex from `^(Pudding-sama)$` to `^(Pudding[-]?sama)$` to match both the old and new name format. The `[Ss]` handles the capitalized S in the new name while keeping backward compatibility.

## Open Questions and Pre-Merge TODOs
<!-- none -->

## Requirements
- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Bug Fixes:
- Ensure Radarr and Sonarr German anime tier-01 profiles correctly match releases from the renamed PuddingSama releaser while retaining compatibility with the previous Pudding-sama name.