### PR TITLE
feat(sonarr): Add NEW Custom Format `BW` (Black & White)

### DIFF
--- a/docs/Sonarr/sonarr-collection-of-custom-formats.md
+++ b/docs/Sonarr/sonarr-collection-of-custom-formats.md
@@ -103,10 +103,11 @@ Special thanks to everyone who has helped in the creation and testing of these C
 | [Remaster](#remaster) | [Bad Dual Groups](#bad-dual-groups)     | [Remux Tier 02](#remux-tier-02)         |
 |                       | [BR-DISK](#br-disk)                     | [HD Bluray Tier 01](#hd-bluray-tier-01) |
 |                       | [BR-DISK (BTN)](#br-disk-btn)           | [HD Bluray Tier 02](#hd-bluray-tier-02) |
-|                       | [Extras](#extras)                       | [WEB Tier 01](#web-tier-01)             |
-|                       | [LQ](#lq)                               | [WEB Tier 02](#web-tier-02)             |
-|                       | [LQ (Release Title)](#lq-release-title) | [WEB Tier 03](#web-tier-03)             |
-|                       | [No-RlsGroup](#no-rlsgroup)             | [WEB Scene](#web-scene)                 |
+|                       | [Black & White](#bw)                    | [WEB Tier 01](#web-tier-01)             |
+|                       | [Extras](#extras)                       | [WEB Tier 02](#web-tier-02)             |
+|                       | [LQ](#lq)                               | [WEB Tier 03](#web-tier-03)             |
+|                       | [LQ (Release Title)](#lq-release-title) | [WEB Scene](#web-scene)                 |
+|                       | [No-RlsGroup](#no-rlsgroup)             |                                         |
 |                       | [Obfuscated](#obfuscated)               |                                         |
 |                       | [Retags](#retags)                       |                                         |
 |                       | [Scene](#scene)                         |                                         |
@@ -2045,6 +2046,24 @@ Special thanks to everyone who has helped in the creation and testing of these C
 
     ```json
     [[% filter indent(width=4) %]][[% include 'json/sonarr/cf/br-disk-btn.json' %]][[% endfilter %]]
+    ```
+
+<sub><sup>[TOP](#index)</sup></sub>
+
+---
+
+### BW
+
+<sub>Black & White</sub>
+
+??? question "Description - [Click to show/hide]"
+
+    {! include-markdown "../../includes/cf-descriptions/bw.md" !}
+
+??? example "JSON - [Click to show/hide]"
+
+    ```json
+    [[% filter indent(width=4) %]][[% include 'json/sonarr/cf/bw.json' %]][[% endfilter %]]
     ```
 
 <sub><sup>[TOP](#index)</sup></sub>

--- a/docs/json/sonarr/cf-groups/unwanted-formats-french.json
+++ b/docs/json/sonarr/cf-groups/unwanted-formats-french.json
@@ -22,6 +22,11 @@
             "required": false
         },
         {
+            "name": "BW",
+            "trash_id": "21d9d08e39b05523ec36811ab06b8308",
+            "required": false
+        },
+        {
             "name": "Extras",
             "trash_id": "fbcb31d8dabd2a319072b84fc0b7249c",
             "required": false,

--- a/docs/json/sonarr/cf-groups/unwanted-formats-german.json
+++ b/docs/json/sonarr/cf-groups/unwanted-formats-german.json
@@ -22,6 +22,11 @@
             "required": false
         },
         {
+            "name": "BW",
+            "trash_id": "21d9d08e39b05523ec36811ab06b8308",
+            "required": false
+        },
+        {
             "name": "Extras",
             "trash_id": "fbcb31d8dabd2a319072b84fc0b7249c",
             "required": false,

--- a/docs/json/sonarr/cf-groups/unwanted-formats.json
+++ b/docs/json/sonarr/cf-groups/unwanted-formats.json
@@ -28,6 +28,11 @@
             "required": false
         },
         {
+            "name": "BW",
+            "trash_id": "21d9d08e39b05523ec36811ab06b8308",
+            "required": false
+        },
+        {
             "name": "Extras",
             "trash_id": "fbcb31d8dabd2a319072b84fc0b7249c",
             "required": false,

--- a/docs/json/sonarr/cf/bw.json
+++ b/docs/json/sonarr/cf/bw.json
@@ -1,0 +1,21 @@
+{
+  "trash_id": "21d9d08e39b05523ec36811ab06b8308",
+  "trash_scores": {
+    "default": -10000,
+    "german": -35000,
+    "german-anime": -35000
+  },
+  "name": "BW",
+  "includeCustomFormatWhenRenaming": true,
+  "specifications": [
+    {
+      "name": "Blackout/B&W/Black&Chrome",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "(?<=\\bS\\d+(E\\d+)?\\b).*\\b((B(lack)?[ ._-]?(out|(and|[n&])?[ ._-]?(W(hite)?|Chrome))))\\b(?!$)"
+      }
+    }
+  ]
+}

--- a/includes/cf-descriptions/bw.md
+++ b/includes/cf-descriptions/bw.md
@@ -1,0 +1,5 @@
+<!-- markdownlint-disable MD036 MD041-->
+**Black and White Versions**
+
+Some shows are released in both Color and Black & White versions. The default score for this Custom Format is set to -10000. Since Sonarr doesn’t support editions, and if you prefer the Black & White version, assign a positive score to this Custom Format. Sonarr will then prefer the Black & White releases, and the Custom Format will also be used in your naming scheme.
+<!-- markdownlint-enable MD036 MD041-->

--- a/includes/cf-descriptions/bw.md
+++ b/includes/cf-descriptions/bw.md
@@ -1,5 +1,5 @@
 <!-- markdownlint-disable MD036 MD041-->
-**Black and White Versions**
+**Black & White Versions**
 
-Some shows are released in both Color and Black & White versions. The default score for this Custom Format is set to -10000. Since Sonarr doesn’t support editions, and if you prefer the Black & White version, assign a positive score to this Custom Format. Sonarr will then prefer the Black & White releases, and the Custom Format will also be used in your naming scheme.
+Some shows are released in both Color and Black & White versions. Users who prefer the color version should keep the default negative score of -10000. Since Sonarr doesn’t support editions, if you prefer the Black & White version, assign a positive score (1-5 should be enough) to this Custom Format. Sonarr will then prefer the Black & White releases, and the Custom Format will also be used in your naming scheme.
 <!-- markdownlint-enable MD036 MD041-->


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->

Some shows are released in both Color and Black & White versions. The default score for this Custom Format is set to -10000. Since Sonarr doesn’t support editions, and if you prefer the Black & White version, assign a positive score to this Custom Format. Sonarr will then prefer the Black & White releases, and the Custom Format will also be used in your naming scheme.

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

- Added NEW Custom Format `BW`
- Added new Custom Format to the collection table
- Added new Custom Format to the unwanted groups

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Add documentation and configuration for a new Sonarr custom format representing Black & White releases.

New Features:
- Introduce a new Sonarr custom format `BW` for Black & White releases with associated JSON definition.

Enhancements:
- Add the new `BW` custom format to the Sonarr custom formats collection and index tables.
- Include the `BW` custom format in the unwanted formats custom format groups across supported locales.

Documentation:
- Document the new `BW` (Black & White) custom format, including description and usage guidance in the Sonarr custom formats guide.