### PR TITLE
feat(sonarr): add W4K to German Scene

### DIFF
--- a/docs/json/sonarr/cf/german-scene.json
+++ b/docs/json/sonarr/cf/german-scene.json
@@ -365,6 +365,15 @@
       "fields": {
         "value": "^(bi0hazard)$"
       }
+    },
+    {
+      "name": "W4K",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(W4K)$"
+      }
     }
   ]
 }


### PR DESCRIPTION
# Pull Request

## Purpose

This adds the release group `W4K` to the `German Scene` Sonarr Custom Format

## Reasoning

This was suggested in the UsenetDE Discord Server which maintains the German Guide.
Discord Thread: [Link](https://discord.com/channels/1204644340882870332/1328003974372130890/threads/1509182018641072188)
Discord Message: [Link](https://discord.com/channels/1204644340882870332/1509182018641072188/1509182018641072188)

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Enhancements:
- Extend the German Scene Sonarr custom format to recognize releases from the W4K group.