### PR TITLE
chore(gha): Skip changelog workflow on forks

### DIFF
--- a/.github/workflows/automatic-changelog.yml
+++ b/.github/workflows/automatic-changelog.yml
@@ -10,6 +10,7 @@ permissions:
 
 jobs:
   update-changelog:
+    if: ${{ !github.event.repository.fork }}
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
The automatic changelog workflow runs on a weekly schedule, but it fails on forks because `secrets.PAT` isn't available there. Forks don't need this workflow anyway since it auto-generates changelog entries and pushes directly to master.

Added a guard using `github.event.repository.fork` so the job is skipped on any fork automatically.