### PR TITLE
chore(build): Added labels for `Area: Guide` and `Area: Guide Sync` and cleaned up the backend label

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -37,19 +37,7 @@
           ["docs/json/radarr/cf/**", "docs/json/sonarr/cf/**"]
 "Area: Guide Sync":
   - changed-files:
-      - any-glob-to-any-file:
-          [
-            "docs/json/radarr/cf/**",
-            "docs/json/radarr/cf-groups/**",
-            "docs/json/radarr/naming/**",
-            "docs/json/radarr/quality-profiles/**",
-            "docs/json/radarr/quality-size/**",
-            "docs/json/sonarr/cf/**",
-            "docs/json/sonarr/cf-groups/**",
-            "docs/json/sonarr/naming/**",
-            "docs/json/sonarr/quality-profiles/**",
-            "docs/json/sonarr/quality-size/**",
-          ]
+      - any-glob-to-any-file: ["docs/json/**"]
 "Area: Starr Naming":
   - changed-files:
       - any-glob-to-any-file:

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -26,7 +26,6 @@
   - changed-files:
       - any-glob-to-any-file:
           [
-            "docs/json/sonarr/rp/**",
             "docs/json/sonarr/cf/**",
             "docs/json/sonarr/quality-size/**",
             "docs/json/sonarr/naming/**",
@@ -36,6 +35,23 @@
   - changed-files:
       - any-glob-to-any-file:
           ["docs/json/radarr/cf/**", "docs/json/sonarr/cf/**"]
+"Area: Guide Sync":
+  - changed-files:
+      - any-glob-to-any-file:
+          [
+            "docs/json/radarr/cf/**",
+            "docs/json/radarr/cf-groups/**",
+            "docs/json/radarr/naming/**",
+            "docs/json/radarr/quality-size/**",
+            "docs/json/radarr/quality-profiles/**",
+            "docs/json/radarr/quality-size/**",
+            "docs/json/sonarr/cf/**",
+            "docs/json/sonarr/cf-groups/**",
+            "docs/json/sonarr/naming/**",
+            "docs/json/sonarr/quality-size/**",
+            "docs/json/sonarr/quality-profiles/**",
+            "docs/json/sonarr/quality-size/**",
+          ]
 "Area: Starr Naming":
   - changed-files:
       - any-glob-to-any-file:
@@ -56,11 +72,30 @@
   - changed-files:
       - any-glob-to-any-file:
           [
+            ".vscode/**",
+            "overrides/**",
+            "scripts/**",
+            "!docs/assets/**",
+            "!docs/img/**",
+            "!docs/js/**",
+            "!docs/stylesheets/**",
+          ]
+"Area: Guide":
+  - changed-files:
+      - any-glob-to-any-file:
+          [
+            "includes/**",
             "docs/**/*.md",
             "!docs/Bazarr/**",
             "!docs/Downloaders/**",
+            "!docs/File-and-Folder-Structure/**",
+            "!docs/Glossary/**",
+            "!docs/Guide-Sync/**",
+            "!docs/Lidarr/**",
+            "!docs/Misc/**",
             "!docs/Plex/**",
             "!docs/Prowlarr/**",
             "!docs/Radarr/**",
+            "!docs/Recyclarr/**",
             "!docs/Sonarr/**",
           ]

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -73,10 +73,11 @@
             ".vscode/**",
             "overrides/**",
             "scripts/**",
-            "!docs/assets/**",
-            "!docs/img/**",
-            "!docs/js/**",
-            "!docs/stylesheets/**",
+            "docs/assets/**",
+            "docs/img/**",
+            "docs/js/**",
+            "docs/stylesheets/**",
+          ]
           ]
 "Area: Guide":
   - changed-files:

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -78,23 +78,21 @@
             "docs/js/**",
             "docs/stylesheets/**",
           ]
-          ]
 "Area: Guide":
   - changed-files:
       - any-glob-to-any-file:
           [
             "includes/**",
-            "docs/**/*.md",
-            "!docs/Bazarr/**",
-            "!docs/Downloaders/**",
-            "!docs/File-and-Folder-Structure/**",
-            "!docs/Glossary/**",
-            "!docs/Guide-Sync/**",
-            "!docs/Lidarr/**",
-            "!docs/Misc/**",
-            "!docs/Plex/**",
-            "!docs/Prowlarr/**",
-            "!docs/Radarr/**",
-            "!docs/Recyclarr/**",
-            "!docs/Sonarr/**",
+            "docs/Bazarr/**",
+            "docs/Downloaders/**",
+            "docs/File-and-Folder-Structure/**",
+            "docs/Glossary/**",
+            "docs/Guide-Sync/**",
+            "docs/Lidarr/**",
+            "docs/Misc/**",
+            "docs/Plex/**",
+            "docs/Prowlarr/**",
+            "docs/Radarr/**",
+            "docs/Recyclarr/**",
+            "docs/Sonarr/**",
           ]

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -42,13 +42,11 @@
             "docs/json/radarr/cf/**",
             "docs/json/radarr/cf-groups/**",
             "docs/json/radarr/naming/**",
-            "docs/json/radarr/quality-size/**",
             "docs/json/radarr/quality-profiles/**",
             "docs/json/radarr/quality-size/**",
             "docs/json/sonarr/cf/**",
             "docs/json/sonarr/cf-groups/**",
             "docs/json/sonarr/naming/**",
-            "docs/json/sonarr/quality-size/**",
             "docs/json/sonarr/quality-profiles/**",
             "docs/json/sonarr/quality-size/**",
           ]


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->

Added labels for `Area: Guide` and `Area: Guide Sync` and cleaned up the backend label

- Currently, the backend label also matches changes in the guide documents. With these updates, any changes to the written guide should be labeled `Area: Guide`, not `Area: Backend`.
- Any changes in the JSON folder are now marked with `Area: Guide Sync`.

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

Added labels for `Area: Guide` and `Area: Guide Sync` and cleaned up the backend label

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Build:
- Update labeler rules to add Area: Guide and Area: Guide Sync labels and exclude guide docs and tooling from the backend label.