### PR TITLE
fix(starr): Move R&H from LQ to LQ (Release Title)

### DIFF
--- a/docs/json/radarr/cf/lq-release-title.json
+++ b/docs/json/radarr/cf/lq-release-title.json
@@ -91,6 +91,15 @@
       }
     },
     {
+      "name": "R&H",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(R&H)\\b"
+      }
+    },
+    {
       "name": "READ NOTE",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,

--- a/docs/json/radarr/cf/lq.json
+++ b/docs/json/radarr/cf/lq.json
@@ -684,15 +684,6 @@
       }
     },
     {
-      "name": "R&H",
-      "implementation": "ReleaseGroupSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "^(R&H)$"
-      }
-    },
-    {
       "name": "RARBG",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,

--- a/docs/json/sonarr/cf/lq-release-title.json
+++ b/docs/json/sonarr/cf/lq-release-title.json
@@ -45,6 +45,15 @@
       }
     },
     {
+      "name": "R&H",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(R&H)\\b"
+      }
+    },
+    {
       "name": "TeeWee",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,

--- a/docs/json/sonarr/cf/lq.json
+++ b/docs/json/sonarr/cf/lq.json
@@ -198,15 +198,6 @@
       }
     },
     {
-      "name": "R&H",
-      "implementation": "ReleaseGroupSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "^(R&H)$"
-      }
-    },
-    {
       "name": "SasukeducK",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,


### PR DESCRIPTION
# Pull Request

## Purpose

The arrs parse the R&H release group name not properly, so moving it to LQ (Release Title) to make sure they get caught by the CF.


## Requirements

- [x ] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [ x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Update Radarr and Sonarr LQ classification to detect R&H releases via release title instead of the previous configuration.

Enhancements:
- Adjust Radarr LQ and LQ (Release Title) custom format JSON to move R&H matching from general LQ to release-title-based detection.
- Adjust Sonarr LQ and LQ (Release Title) custom format JSON to move R&H matching from general LQ to release-title-based detection.