### PR TITLE
fix(downloaders): Ensure pip is installed in the Python venv and used for pip installs

### DIFF
--- a/includes/downloaders/mover-tuning-end.sh
+++ b/includes/downloaders/mover-tuning-end.sh
@@ -435,7 +435,7 @@ process_qbit_instance() {
 
     # Determine Python command
     local python_cmd
-    if [[ -f "${QBIT_MOVER_PATH}.venv/bin/python3" ]]; then
+    if [[ -x "${QBIT_MOVER_PATH}.venv/bin/python3" ]] && "${QBIT_MOVER_PATH}.venv/bin/python3" -c "import qbittorrentapi" 2>/dev/null; then
         python_cmd="${QBIT_MOVER_PATH}.venv/bin/python3"
         log "✓ Using virtual environment"
     elif python3 -c "import qbittorrentapi" 2>/dev/null; then

--- a/includes/downloaders/mover-tuning-end.sh
+++ b/includes/downloaders/mover-tuning-end.sh
@@ -3,12 +3,12 @@ set -euo pipefail # Exit on error, undefined variables, and pipe failures
 
 # =====================================
 # Script: qBittorrent Cache Mover - End
-# Version: 1.3.3
+# Version: 1.3.4
 # Updated: 20260614
 # =====================================
 
 # Script version and update check URLs
-readonly SCRIPT_VERSION="1.3.3"
+readonly SCRIPT_VERSION="1.3.4"
 readonly SCRIPT_RAW_URL="https://raw.githubusercontent.com/TRaSH-Guides/Guides/refs/heads/master/includes/downloaders/mover-tuning-end.sh"
 
 # Get the directory where the script is located

--- a/includes/downloaders/mover-tuning-start.sh
+++ b/includes/downloaders/mover-tuning-start.sh
@@ -3,12 +3,12 @@ set -euo pipefail # Exit on error, undefined variables, and pipe failures
 
 # =======================================
 # Script: qBittorrent Cache Mover - Start
-# Version: 1.3.2
+# Version: 1.3.3
 # Updated: 20260614
 # =======================================
 
 # Script version and update check URLs
-readonly SCRIPT_VERSION="1.3.2"
+readonly SCRIPT_VERSION="1.3.3"
 readonly SCRIPT_RAW_URL="https://raw.githubusercontent.com/TRaSH-Guides/Guides/refs/heads/master/includes/downloaders/mover-tuning-start.sh"
 readonly CONFIG_RAW_URL="https://raw.githubusercontent.com/TRaSH-Guides/Guides/refs/heads/master/includes/downloaders/mover-tuning.cfg"
 

--- a/includes/downloaders/mover-tuning-start.sh
+++ b/includes/downloaders/mover-tuning-start.sh
@@ -358,27 +358,32 @@ run_auto_installer() {
         log "✓ Virtual environment exists"
     fi
 
-    # Activate virtual environment
-    # shellcheck source=/dev/null
-    source "${VENV_PATH}/bin/activate" || error "Failed to activate virtual environment"
+    # Check if Python is available in the virtual environment
+    local venv_python="${VENV_PATH}/bin/python3"
+    [[ -x "$venv_python" ]] || error "Virtual environment Python is missing or not executable: $venv_python"
 
-    # Upgrade pip if needed
     log "Checking pip version..."
-    if pip3 install --upgrade pip --quiet 2>&1 | grep -q "Successfully installed"; then
-        log "✓ Pip upgraded to $(pip3 --version | awk '{print $2}')"
+    # Ensure pip exists inside the venv.
+    if ! "$venv_python" -m pip --version >/dev/null 2>&1; then
+        log "pip missing from virtual environment; bootstrapping pip..."
+        "$venv_python" -m ensurepip --upgrade || error "Failed to bootstrap pip in virtual environment"
+    fi
+
+    # Upgrade pip
+    if "$venv_python" -m pip install --upgrade pip --quiet; then
+        log "✓ Pip is up to date $("$venv_python" -m pip --version | awk '{print $2}')"
         set_ownership "$VENV_PATH"
     else
         log "✓ Pip is up to date"
     fi
 
-    # Install/upgrade qbittorrent-api
-    if python3 -c "import qbittorrentapi" 2>/dev/null; then
-        log "✓ qbittorrent-api installed ($(pip3 show qbittorrent-api 2>/dev/null | awk '/Version:/ {print $2}'))"
+    # Install/upgrade qbittorrent-api using the same Python that will run mover.py.
+    if "$venv_python" -c "import qbittorrentapi" 2>/dev/null; then
+        log "✓ qbittorrent-api installed ($("$venv_python" -m pip show qbittorrent-api 2>/dev/null | awk '/Version:/ {print $2}'))"
 
-        # Check for updates
-        if pip3 install --dry-run --upgrade qbittorrent-api 2>&1 | grep -q "Would install"; then
+        if "$venv_python" -m pip install --dry-run --upgrade qbittorrent-api 2>&1 | grep -q "Would install"; then
             log "Upgrading qbittorrent-api..."
-            pip3 install qbittorrent-api --upgrade --quiet || log "⚠ Warning: Failed to upgrade qbittorrent-api"
+            "$venv_python" -m pip install qbittorrent-api --upgrade --quiet || log "⚠ Warning: Failed to upgrade qbittorrent-api"
             set_ownership "$VENV_PATH"
             log "✓ qbittorrent-api upgraded"
         else
@@ -386,12 +391,14 @@ run_auto_installer() {
         fi
     else
         log "Installing qbittorrent-api..."
-        pip3 install qbittorrent-api --quiet || error "Failed to install qbittorrent-api"
+        "$venv_python" -m pip install qbittorrent-api --quiet || error "Failed to install qbittorrent-api"
         set_ownership "$VENV_PATH"
+
+        # Verify install with the same interpreter used by mover.py.
+        "$venv_python" -c "import qbittorrentapi" 2>/dev/null || error "qbittorrent-api installed, but cannot be imported by venv Python"
+
         log "✓ qbittorrent-api installed"
     fi
-
-    deactivate
 
     # Download mover.py if needed
     if [[ ! -f "$MOVER_SCRIPT" ]]; then
@@ -494,10 +501,12 @@ process_qbit_instance() {
 
     # Determine Python command
     local python_cmd
-    if [[ -f "${VENV_PATH}/bin/python3" ]]; then
+    if [[ -x "${VENV_PATH}/bin/python3" ]] && "${VENV_PATH}/bin/python3" -c "import qbittorrentapi" 2>/dev/null; then
         python_cmd="${VENV_PATH}/bin/python3"
+        log "✓ Using virtual environment"
     elif python3 -c "import qbittorrentapi" 2>/dev/null; then
         python_cmd="python3"
+        log "✓ Using system Python"
     else
         log "✗ qbittorrent-api not found for $name"
         return 1

--- a/includes/downloaders/mover-tuning-start.sh
+++ b/includes/downloaders/mover-tuning-start.sh
@@ -363,41 +363,56 @@ run_auto_installer() {
     [[ -x "$venv_python" ]] || error "Virtual environment Python is missing or not executable: $venv_python"
 
     log "Checking pip version..."
-    # Ensure pip exists inside the venv.
+    # Ensure pip exists inside the virtual environment
     if ! "$venv_python" -m pip --version >/dev/null 2>&1; then
-        log "pip missing from virtual environment; bootstrapping pip..."
-        "$venv_python" -m ensurepip --upgrade || error "Failed to bootstrap pip in virtual environment"
+        log "⚠ pip not found in virtual environment; attempting to bootstrap with ensurepip..."
+        if ! "$venv_python" -m ensurepip --upgrade; then
+            if python3 -c "import qbittorrentapi" 2>/dev/null; then
+                log "⚠ Warning: Failed to bootstrap pip in virtual environment; system Python has qbittorrent-api, continuing"
+            else
+                error "Failed to bootstrap pip in virtual environment and qbittorrent-api is not available in system Python"
+            fi
+        fi
     fi
 
-    # Upgrade pip
-    if "$venv_python" -m pip install --upgrade pip --quiet; then
-        log "✓ Pip is up to date $("$venv_python" -m pip --version | awk '{print $2}')"
-        set_ownership "$VENV_PATH"
-    else
-        log "✓ Pip is up to date"
-    fi
-
-    # Install/upgrade qbittorrent-api using the same Python that will run mover.py.
-    if "$venv_python" -c "import qbittorrentapi" 2>/dev/null; then
-        log "✓ qbittorrent-api installed ($("$venv_python" -m pip show qbittorrent-api 2>/dev/null | awk '/Version:/ {print $2}'))"
-
-        if "$venv_python" -m pip install --dry-run --upgrade qbittorrent-api 2>&1 | grep -q "Would install"; then
-            log "Upgrading qbittorrent-api..."
-            "$venv_python" -m pip install qbittorrent-api --upgrade --quiet || log "⚠ Warning: Failed to upgrade qbittorrent-api"
-            set_ownership "$VENV_PATH"
-            log "✓ qbittorrent-api upgraded"
+    if "$venv_python" -m pip --version >/dev/null 2>&1; then
+        # Upgrade pip
+        if "$venv_python" -m pip install --dry-run --upgrade pip 2>&1 | grep -q "Would install"; then
+            log "Upgrading pip..."
+            if "$venv_python" -m pip install --upgrade pip --quiet; then
+                set_ownership "$VENV_PATH"
+                log "✓ Pip upgraded to $("$venv_python" -m pip --version | awk '{print $2}')"
+            else
+                log "⚠ Warning: Failed to upgrade pip; continuing with existing version ($("$venv_python" -m pip --version | awk '{print $2}'))"
+            fi
         else
-            log "✓ qbittorrent-api is up to date"
+            log "✓ Pip is up to date ($("$venv_python" -m pip --version | awk '{print $2}'))"
+        fi
+
+        # Install/upgrade qbittorrent-api using the same Python that will run mover.py.
+        if "$venv_python" -c "import qbittorrentapi" 2>/dev/null; then
+            log "✓ qbittorrent-api installed ($("$venv_python" -m pip show qbittorrent-api 2>/dev/null | awk '/Version:/ {print $2}'))"
+
+            if "$venv_python" -m pip install --dry-run --upgrade qbittorrent-api 2>&1 | grep -q "Would install"; then
+                log "Upgrading qbittorrent-api..."
+                "$venv_python" -m pip install qbittorrent-api --upgrade --quiet || log "⚠ Warning: Failed to upgrade qbittorrent-api"
+                set_ownership "$VENV_PATH"
+                log "✓ qbittorrent-api upgraded"
+            else
+                log "✓ qbittorrent-api is up to date"
+            fi
+        else
+            log "Installing qbittorrent-api..."
+            "$venv_python" -m pip install qbittorrent-api --quiet || error "Failed to install qbittorrent-api"
+            set_ownership "$VENV_PATH"
+
+            # Verify install with the same interpreter used by mover.py.
+            "$venv_python" -c "import qbittorrentapi" 2>/dev/null || error "qbittorrent-api installed, but cannot be imported by venv Python"
+
+            log "✓ qbittorrent-api installed"
         fi
     else
-        log "Installing qbittorrent-api..."
-        "$venv_python" -m pip install qbittorrent-api --quiet || error "Failed to install qbittorrent-api"
-        set_ownership "$VENV_PATH"
-
-        # Verify install with the same interpreter used by mover.py.
-        "$venv_python" -c "import qbittorrentapi" 2>/dev/null || error "qbittorrent-api installed, but cannot be imported by venv Python"
-
-        log "✓ qbittorrent-api installed"
+        log "⚠ Skipping virtual environment package setup because pip is unavailable"
     fi
 
     # Download mover.py if needed


### PR DESCRIPTION
# Pull Request

## Purpose

Fixes an issue in the qBittorrent Cache Mover start/end scripts where an existing but incomplete Python virtual environment could be selected for running `mover.py`, while `pip3` could still resolve to the system Python environment.

This could result in `qbittorrent-api` being installed outside the virtual environment, while `mover.py` was later executed with the virtual environment Python and failed with:

```text
Requirements Error: qbittorrent-api not installed
```

## Approach

- Use the virtual environment Python explicitly for pip operations via `"$venv_python" -m pip`.
- Bootstrap pip inside the virtual environment with `ensurepip` if pip is missing.
- Verify that `qbittorrentapi` can be imported by the same Python interpreter that will run `mover.py`.
- Only select the virtual environment Python when it exists, is executable, and can import `qbittorrentapi`.
- Fall back to system Python only if it can import `qbittorrentapi`.

This avoids a mismatch where dependencies are installed with one Python interpreter but `mover.py` is run with another.

## Open Questions and Pre-Merge TODOs

None.

## Requirements

- [x] These changes meet the standards for [[contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md)](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [[code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md)](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Ensure the qBittorrent Cache Mover scripts consistently use a valid Python interpreter and its virtual environment for installing and running qbittorrent-api.

Bug Fixes:
- Prevent qbittorrent-api from being installed into the system Python when mover.py is executed with the virtual environment Python.
- Avoid using an incomplete or non-functional virtual environment by requiring an executable venv Python that can import qbittorrentapi before selection.

Enhancements:
- Bootstrap and upgrade pip inside the virtual environment using the venv's Python interpreter if pip is missing or outdated.
- Verify qbittorrent-api installation using the same Python interpreter that will run mover.py and log whether the virtual environment or system Python is used.
- Update mover start/end script version metadata to reflect the new behavior.