### PR TITLE
fix(downloaders): Normalize fclones version comparison

### DIFF
--- a/includes/downloaders/mover-tuning-end.sh
+++ b/includes/downloaders/mover-tuning-end.sh
@@ -204,7 +204,7 @@ install_fclones_binary() {
     LATEST_VERSION=$($GITHUB_API_CMD 2>/dev/null | grep -Po '"tag_name": "\K.*?(?=")') || true
     if [[ -z "$LATEST_VERSION" ]]; then
         log "⚠ Could not fetch latest release, using default version $DEFAULT_VERSION (continuing anyway)"
-    LATEST_VERSION="v$DEFAULT_VERSION"
+        LATEST_VERSION="v$DEFAULT_VERSION"
     else
         log "Latest fclones release: $LATEST_VERSION"
     fi

--- a/includes/downloaders/mover-tuning-end.sh
+++ b/includes/downloaders/mover-tuning-end.sh
@@ -3,12 +3,12 @@ set -euo pipefail # Exit on error, undefined variables, and pipe failures
 
 # =====================================
 # Script: qBittorrent Cache Mover - End
-# Version: 1.3.1
-# Updated: 20260411
+# Version: 1.3.3
+# Updated: 20260614
 # =====================================
 
 # Script version and update check URLs
-readonly SCRIPT_VERSION="1.3.1"
+readonly SCRIPT_VERSION="1.3.3"
 readonly SCRIPT_RAW_URL="https://raw.githubusercontent.com/TRaSH-Guides/Guides/refs/heads/master/includes/downloaders/mover-tuning-end.sh"
 
 # Get the directory where the script is located
@@ -204,20 +204,21 @@ install_fclones_binary() {
     LATEST_VERSION=$($GITHUB_API_CMD 2>/dev/null | grep -Po '"tag_name": "\K.*?(?=")') || true
     if [[ -z "$LATEST_VERSION" ]]; then
         log "⚠ Could not fetch latest release, using default version $DEFAULT_VERSION (continuing anyway)"
-        LATEST_VERSION="$DEFAULT_VERSION"
+    LATEST_VERSION="v$DEFAULT_VERSION"
     else
         log "Latest fclones release: $LATEST_VERSION"
     fi
 
+    # Remove leading 'v' for version comparison and filename
+    local VERSION_NO_V="${LATEST_VERSION#v}"
+
     # Compare and install if missing or outdated
-    if [[ "$CURRENT_VERSION" != "$LATEST_VERSION" ]]; then
+    if [[ "$CURRENT_VERSION" != "$VERSION_NO_V" ]]; then
         log "Installing/updating fclones to $LATEST_VERSION..."
 
         local TMP_DIR
         TMP_DIR=$(mktemp -d)
 
-        # Remove leading 'v' from filename
-        local VERSION_NO_V="${LATEST_VERSION#v}"
         local DOWNLOAD_URL="https://github.com/pkolaczk/fclones/releases/download/$LATEST_VERSION/fclones-$VERSION_NO_V-linux-glibc-x86_64.tar.gz"
 
         if ! wget -O "$TMP_DIR/fclones.tar.gz" "$DOWNLOAD_URL" 2>/dev/null; then


### PR DESCRIPTION
# Pull Request

## Purpose

Fixes an issue in the qBittorrent Cache Mover end script where the installed `fclones` version could be treated as outdated even when it matched the latest GitHub release.

The installed binary reports versions without a leading `v`, for example:

```text
0.35.0
```

GitHub release tags include the leading `v`, for example:

```text
v0.35.0
```

Because the script compared these values directly, it could reinstall `fclones` unnecessarily even when the installed version was already current.

## Approach

* Keep the GitHub release tag value for the download URL.
* Strip a leading `v` into a normalized version value.
* Compare the installed binary version against the normalized version.
* Continue using the original tag value for the GitHub release download path.

This avoids unnecessary reinstalls while preserving the correct download URL format.

## Open Questions and Pre-Merge TODOs

None.

## Requirements

* [x] These changes meet the standards for [[contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md)](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
* [x] I have read the [[code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md)](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Normalize fclones version comparison in the qBittorrent Cache Mover end script to avoid unnecessary reinstalls and bump the script version metadata.

Bug Fixes:
- Ensure fclones version checks handle GitHub tags with a leading 'v' so the installed binary is not treated as outdated when it matches the latest release.

Enhancements:
- Update the qBittorrent Cache Mover end script version and metadata to reflect the latest changes.