### PR TITLE
feat(downloaders): Add CA bundle support for qBittorrent

### DIFF
--- a/includes/downloaders/mover-tuning-end.sh
+++ b/includes/downloaders/mover-tuning-end.sh
@@ -83,6 +83,7 @@ get_instance_details() {
         INSTANCE_HOST="${HOSTS[$index]}"
         INSTANCE_USER="${USERS[$index]}"
         INSTANCE_PASSWORD="${PASSWORDS[$index]}"
+        INSTANCE_CA_BUNDLE="${CA_BUNDLES[$index]:-}"
     else
         # Legacy format: map index to old variables
         if [[ $index -eq 0 ]]; then
@@ -90,11 +91,13 @@ get_instance_details() {
             INSTANCE_HOST="${QBIT_HOST_1}"
             INSTANCE_USER="${QBIT_USER_1}"
             INSTANCE_PASSWORD="${QBIT_PASS_1}"
+            INSTANCE_CA_BUNDLE="${QBIT_CA_BUNDLE_1:-}"
         elif [[ $index -eq 1 ]]; then
             INSTANCE_NAME="${QBIT_NAME_2}"
             INSTANCE_HOST="${QBIT_HOST_2}"
             INSTANCE_USER="${QBIT_USER_2}"
             INSTANCE_PASSWORD="${QBIT_PASS_2}"
+            INSTANCE_CA_BUNDLE="${QBIT_CA_BUNDLE_2:-}"
         else
             error "Invalid instance index: $index"
         fi
@@ -387,6 +390,11 @@ validate_config() {
             [[ ${#NAMES[@]} -eq ${#HOSTS[@]} ]] || error "NAMES array length doesn't match HOSTS"
         fi
 
+        # CA_BUNDLES array is optional, but if present should match
+        if [[ -v CA_BUNDLES[@] ]] && [[ ${#CA_BUNDLES[@]} -gt 0 ]]; then
+            [[ ${#CA_BUNDLES[@]} -eq ${#HOSTS[@]} ]] || error "CA_BUNDLES array length doesn't match HOSTS"
+        fi
+
         log "✓ Using array-based configuration (${#HOSTS[@]} instance(s))"
     else
         # Validate legacy config
@@ -420,6 +428,7 @@ process_qbit_instance() {
     local host="$2"
     local user="$3"
     local password="$4"
+    local ca_bundle="${5:-}"
 
     log "Processing $name..."
 
@@ -434,6 +443,11 @@ process_qbit_instance() {
     else
         log "✗ qbittorrent-api not found"
         return 1
+fi
+
+    local ca_bundle_args=()
+    if [[ -n "$ca_bundle" ]]; then
+        ca_bundle_args=(--ca-bundle "$ca_bundle")
     fi
 
     # Execute mover script
@@ -443,7 +457,8 @@ process_qbit_instance() {
         --user "$user" \
         --password "$password" \
         --days_from "$DAYS_FROM" \
-        --days_to "$DAYS_TO"; then
+        --days_to "$DAYS_TO" \
+        "${ca_bundle_args[@]}"; then
         log "✓ Successfully resumed torrents for $name"
         notify "$name" "Resumed @ $(date +%H:%M:%S)"
         return 0
@@ -479,7 +494,7 @@ main() {
     for ((i=0; i<instance_count; i++)); do
         get_instance_details "$i"
 
-        process_qbit_instance "$INSTANCE_NAME" "$INSTANCE_HOST" "$INSTANCE_USER" "$INSTANCE_PASSWORD" || ((failed_instances++))
+        process_qbit_instance "$INSTANCE_NAME" "$INSTANCE_HOST" "$INSTANCE_USER" "$INSTANCE_PASSWORD" "$INSTANCE_CA_BUNDLE" || ((failed_instances++))
     done
 
     # Run duplicate finder if enabled

--- a/includes/downloaders/mover-tuning-end.sh
+++ b/includes/downloaders/mover-tuning-end.sh
@@ -49,7 +49,7 @@ notify() {
 # ================================
 detect_config_format() {
     # Check if array-based config is used
-    if [[ -v HOSTS[@] ]] && [[ ${#HOSTS[@]} -gt 0 ]]; then
+    if [[ -v HOSTS ]] && [[ ${#HOSTS[@]} -gt 0 ]]; then
         echo "array"
     else
         echo "legacy"
@@ -381,17 +381,17 @@ validate_config() {
 
     if [[ "$format" == "array" ]]; then
         # Validate array-based config
-        [[ ${#HOSTS[@]} -gt 0 ]] || error "HOSTS array is empty"
+        [[ -v HOSTS ]] && [[ ${#HOSTS[@]} -gt 0 ]] || error "HOSTS array is empty"
         [[ ${#USERS[@]} -eq ${#HOSTS[@]} ]] || error "USERS array length doesn't match HOSTS"
         [[ ${#PASSWORDS[@]} -eq ${#HOSTS[@]} ]] || error "PASSWORDS array length doesn't match HOSTS"
 
         # NAMES array is optional, but if present should match
-        if [[ -v NAMES[@] ]] && [[ ${#NAMES[@]} -gt 0 ]]; then
+        if [[ -v NAMES ]] && [[ ${#NAMES[@]} -gt 0 ]]; then
             [[ ${#NAMES[@]} -eq ${#HOSTS[@]} ]] || error "NAMES array length doesn't match HOSTS"
         fi
 
         # CA_BUNDLES array is optional, but if present should match
-        if [[ -v CA_BUNDLES[@] ]] && [[ ${#CA_BUNDLES[@]} -gt 0 ]]; then
+        if [[ -v CA_BUNDLES ]] && [[ ${#CA_BUNDLES[@]} -gt 0 ]]; then
             [[ ${#CA_BUNDLES[@]} -eq ${#HOSTS[@]} ]] || error "CA_BUNDLES array length doesn't match HOSTS"
         fi
 
@@ -443,7 +443,7 @@ process_qbit_instance() {
     else
         log "✗ qbittorrent-api not found"
         return 1
-fi
+    fi
 
     local ca_bundle_args=()
     if [[ -n "$ca_bundle" ]]; then

--- a/includes/downloaders/mover-tuning-start.sh
+++ b/includes/downloaders/mover-tuning-start.sh
@@ -62,7 +62,7 @@ set_ownership() {
 # ================================
 detect_config_format() {
     # Check if array-based config is used
-    if [[ -v HOSTS[@] ]] && [[ ${#HOSTS[@]} -gt 0 ]]; then
+    if [[ -v HOSTS ]] && [[ ${#HOSTS[@]} -gt 0 ]]; then
         echo "array"
     else
         echo "legacy"
@@ -458,7 +458,7 @@ validate_config() {
         fi
 
         # NAMES array is optional, but if present should match
-        if [[ -v NAMES[@] ]] && [[ ${#NAMES[@]} -gt 0 ]]; then
+        if [[ -v NAMES ]] && [[ ${#NAMES[@]} -gt 0 ]]; then
             if [[ ${#NAMES[@]} -ne ${#HOSTS[@]} ]]; then
                 notify "Configuration Error" "NAMES array length (${#NAMES[@]}) doesn't match HOSTS (${#HOSTS[@]})"
                 error "NAMES array length doesn't match HOSTS"
@@ -466,7 +466,7 @@ validate_config() {
         fi
 
         # CA_BUNDLES array is optional, but if present should match
-        if [[ -v CA_BUNDLES[@] ]] && [[ ${#CA_BUNDLES[@]} -gt 0 ]]; then
+        if [[ -v CA_BUNDLES ]] && [[ ${#CA_BUNDLES[@]} -gt 0 ]]; then
             if [[ ${#CA_BUNDLES[@]} -ne ${#HOSTS[@]} ]]; then
                 notify "Configuration Error" "CA_BUNDLES array length (${#CA_BUNDLES[@]}) doesn't match HOSTS (${#HOSTS[@]})"
                 error "CA_BUNDLES array length doesn't match HOSTS"

--- a/includes/downloaders/mover-tuning-start.sh
+++ b/includes/downloaders/mover-tuning-start.sh
@@ -3,12 +3,12 @@ set -euo pipefail # Exit on error, undefined variables, and pipe failures
 
 # =======================================
 # Script: qBittorrent Cache Mover - Start
-# Version: 1.3.0
-# Updated: 20260314
+# Version: 1.3.2
+# Updated: 20260614
 # =======================================
 
 # Script version and update check URLs
-readonly SCRIPT_VERSION="1.3.0"
+readonly SCRIPT_VERSION="1.3.2"
 readonly SCRIPT_RAW_URL="https://raw.githubusercontent.com/TRaSH-Guides/Guides/refs/heads/master/includes/downloaders/mover-tuning-start.sh"
 readonly CONFIG_RAW_URL="https://raw.githubusercontent.com/TRaSH-Guides/Guides/refs/heads/master/includes/downloaders/mover-tuning.cfg"
 
@@ -96,6 +96,7 @@ get_instance_details() {
         INSTANCE_HOST="${HOSTS[$index]}"
         INSTANCE_USER="${USERS[$index]}"
         INSTANCE_PASSWORD="${PASSWORDS[$index]}"
+        INSTANCE_CA_BUNDLE="${CA_BUNDLES[$index]:-}"
     else
         # Legacy format: map index to old variables
         if [[ $index -eq 0 ]]; then
@@ -103,11 +104,13 @@ get_instance_details() {
             INSTANCE_HOST="${QBIT_HOST_1}"
             INSTANCE_USER="${QBIT_USER_1}"
             INSTANCE_PASSWORD="${QBIT_PASS_1}"
+            INSTANCE_CA_BUNDLE="${QBIT_CA_BUNDLE_1:-}"
         elif [[ $index -eq 1 ]]; then
             INSTANCE_NAME="${QBIT_NAME_2}"
             INSTANCE_HOST="${QBIT_HOST_2}"
             INSTANCE_USER="${QBIT_USER_2}"
             INSTANCE_PASSWORD="${QBIT_PASS_2}"
+            INSTANCE_CA_BUNDLE="${QBIT_CA_BUNDLE_2:-}"
         else
             error "Invalid instance index: $index"
         fi
@@ -462,6 +465,14 @@ validate_config() {
             fi
         fi
 
+        # CA_BUNDLES array is optional, but if present should match
+        if [[ -v CA_BUNDLES[@] ]] && [[ ${#CA_BUNDLES[@]} -gt 0 ]]; then
+            if [[ ${#CA_BUNDLES[@]} -ne ${#HOSTS[@]} ]]; then
+                notify "Configuration Error" "CA_BUNDLES array length (${#CA_BUNDLES[@]}) doesn't match HOSTS (${#HOSTS[@]})"
+                error "CA_BUNDLES array length doesn't match HOSTS"
+            fi
+        fi
+
         log "✓ Using array-based configuration (${#HOSTS[@]} instance(s))"
     else
         # Validate legacy config
@@ -477,7 +488,7 @@ validate_config() {
 # PROCESS QBITTORRENT INSTANCE
 # ================================
 process_qbit_instance() {
-    local name="$1" host="$2" user="$3" password="$4"
+    local name="$1" host="$2" user="$3" password="$4" ca_bundle="${5:-}"
 
     log "Processing $name..."
 
@@ -492,6 +503,11 @@ process_qbit_instance() {
         return 1
     fi
 
+    local ca_bundle_args=()
+    if [[ -n "$ca_bundle" ]]; then
+        ca_bundle_args=(--ca-bundle "$ca_bundle")
+    fi
+
     # Run mover script
     if $python_cmd "$MOVER_SCRIPT" \
         --pause \
@@ -500,7 +516,8 @@ process_qbit_instance() {
         --password "$password" \
         --cache-mount "$CACHE_MOUNT" \
         --days_from "$DAYS_FROM" \
-        --days_to "$DAYS_TO" 2>&1 | while IFS= read -r line; do
+        --days_to "$DAYS_TO" \
+        "${ca_bundle_args[@]}" 2>&1 | while IFS= read -r line; do
             log "  $line"
         done; then
         log "✓ Successfully processed $name"
@@ -565,7 +582,7 @@ main() {
     for ((i=0; i<instance_count; i++)); do
         get_instance_details "$i"
 
-        process_qbit_instance "$INSTANCE_NAME" "$INSTANCE_HOST" "$INSTANCE_USER" "$INSTANCE_PASSWORD" || ((failed_instances++))
+        process_qbit_instance "$INSTANCE_NAME" "$INSTANCE_HOST" "$INSTANCE_USER" "$INSTANCE_PASSWORD" "$INSTANCE_CA_BUNDLE" || ((failed_instances++))
     done
 
     # Summary

--- a/includes/downloaders/mover-tuning.cfg
+++ b/includes/downloaders/mover-tuning.cfg
@@ -2,7 +2,7 @@
 # <----- Update and version settings ----->
 # =============================================
 
-readonly CONFIG_VERSION="1.3.0" # ONLY UPDATE THE VERSION NUMBER WHEN A CONFIGURATION FILE CHANGE HAS BEEN MADE
+readonly CONFIG_VERSION="1.3.1" # ONLY UPDATE THE VERSION NUMBER WHEN A CONFIGURATION FILE CHANGE HAS BEEN MADE
 readonly ENABLE_VERSION_CHECK=true # Set to false to disable all update checks and notifications (not recommended)
 
 # =============================================
@@ -27,6 +27,7 @@ readonly NAMES=("qBit-Movies" "qBit-TV" "qBit-Music")  # qBittorrent instance na
 readonly HOSTS=("192.168.2.200:8088" "192.168.2.200:8811" "192.168.2.200:8822")  # qBittorrent host:port
 readonly USERS=("admin" "admin" "admin")  # qBittorrent usernames
 readonly PASSWORDS=("qbt1-password" "qbt2-password" "qbt3-password")  # qBittorrent passwords
+readonly CA_BUNDLES=("/mnt/user/appdata/qbt-mover/qbit-movies-ca.crt" "/mnt/user/appdata/qbt-mover/qbit-tv-ca.crt" "")  # Path to CA bundle for SSL with self signed cert
 
 # Docker container management (OPTIONAL)
 # Stop containers before the mover runs and start them again afterwards.


### PR DESCRIPTION
# Pull Request

## Purpose

Adds optional CA bundle support for qBittorrent Cache Mover configurations.

This allows users with qBittorrent WebUI instances using HTTPS certificates signed by a private or self-managed CA to provide a CA bundle per qBittorrent instance.

The alternative use of global SSL environment variables can unintentionally affect unrelated commands in the shell scripts, such as Python package installation through `pip`.

## Approach

* Adds optional `CA_BUNDLES` array support alongside the existing `NAMES`, `HOSTS`, `USERS`, and `PASSWORDS` arrays.
* Allows each qBittorrent instance to define its own CA bundle path.
* Leaves entries empty when the system/default certificate store should be used.
* Validates that `CA_BUNDLES`, when configured, matches the number of `HOSTS`.
* Passes `--ca-bundle` to `mover.py` only when a CA bundle is configured for that instance.

This depends on `mover.py` supporting the new `--ca-bundle` option.

## Open Questions and Pre-Merge TODOs

* [x] Confirm the related [qbit_manage PR](https://github.com/StuffAnThings/qbit_manage/pull/1253) is merged or available before this change is released.

## Requirements

* [x] These changes meet the standards for [[contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md)](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
* [x] I have read the [[code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md)](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Add optional per-instance CA bundle configuration for qBittorrent cache mover scripts and update their versions to support passing CA bundle paths through to mover.py.

New Features:
- Allow configuring per-instance CA bundle paths via a new CA_BUNDLES array and corresponding legacy variables for qBittorrent mover configurations.
- Pass an optional --ca-bundle argument to mover.py for each qBittorrent instance when a CA bundle is defined, while defaulting to system certificates when omitted.

Enhancements:
- Validate that the CA_BUNDLES array, when set, matches the length of HOSTS to ensure consistent instance configuration.
- Bump mover-tuning start/end scripts and configuration versions to reflect the new CA bundle support.