### PR TITLE
fix(guide-sync): wrong audio channel count for SQP

### DIFF
--- a/docs/json/radarr/quality-profiles/sqp-4-ma-hybrid.json
+++ b/docs/json/radarr/quality-profiles/sqp-4-ma-hybrid.json
@@ -70,7 +70,7 @@
     "1.0 Mono": "b124be9b146540f8e62f98fe32e49a2a",
     "2.0 Stereo": "89dac1be53d5268a7e10a19d3c896826",
     "5.1 Surround": "77ff61788dfe1097194fd8743d7b4524",
-    "6.1 Surround": "6fd7b090c3f7317502ab3b63cc7f51e3",
+    "7.1 Surround": "e77382bcfeba57cb83744c9c5449b401",
     "WEBDL Boost": "8df7fe4569063d39319f07e69707285a",
     "WEB Tier 01": "c20f169ef63c5f40c2def54abaf4438e",
     "WEB Tier 02": "403816d65392c79236dcb6dd591aeda4",


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->

Fix mistake with last PR

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

Fixed the wrong chosen audio channel count CF 

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Bug Fixes:
- Fix incorrect audio channel count settings in the SQP 4 MA Hybrid Radarr quality profile configuration.