### PR TITLE
fix(radarr): Update the Custom Formats `2.0` and `7.1` to prevent matching on movie titles that contain `2.0`

### DIFF
--- a/docs/json/radarr/cf/20-stereo.json
+++ b/docs/json/radarr/cf/20-stereo.json
@@ -14,7 +14,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "(?<!repac)[^0-9]2[ .]0\\b|\\bStereo\\b"
+        "value": "(?<=\\b[12]\\d{3}\\b.*?)(?<!repac)[^0-9]2[ .]0\\b|\\bStereo\\b"
       }
     },
     {

--- a/docs/json/radarr/cf/71-surround.json
+++ b/docs/json/radarr/cf/71-surround.json
@@ -21,7 +21,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "(?<!repac)[^0-9][1-4][ .][0-1]\\b|\\b(Stereo|Mono)\\b"
+        "value": "(?<=\\b[12]\\d{3}\\b.*?)(?<!repac)[^0-9][1-4][ .][0-1]\\b|\\b(Stereo|Mono)\\b"
       }
     }
   ]


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->

Updated the Audio Channels Custom Formats `2.0` and `7.1` to prevent matching on movie titles that include `2.0`.

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

Updated the Audio Channels Custom Formats `2.0` and `7.1` to prevent matching on movie titles that include `2.0`.

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Bug Fixes:
- Prevent the `2.0` and `7.1` audio channel custom formats from matching releases based on movie titles that contain `2.0` in their name.