### PR TITLE
feat(guide-sync): Adjusted scoring for an SQP to prefer multichannel over 2.0 when it shares the same audio format

### DIFF
--- a/docs/json/radarr/cf-groups/unwanted-formats-sqp.json
+++ b/docs/json/radarr/cf-groups/unwanted-formats-sqp.json
@@ -8,7 +8,7 @@
             "name": "10bit",
             "trash_id": "a5d148168c4506b55cf53984107c396e",
             "required": false,
-            "default": true
+            "default": false
         },
         {
             "name": "Bad Dual Groups",

--- a/docs/json/radarr/cf/10-mono.json
+++ b/docs/json/radarr/cf/10-mono.json
@@ -1,7 +1,7 @@
 {
   "trash_id": "b124be9b146540f8e62f98fe32e49a2a",
   "trash_scores": {
-    "sqp-4-ma-hybrid": 156
+    "sqp-4-ma-hybrid": 0
   },
   "name": "1.0 Mono",
   "includeCustomFormatWhenRenaming": false,

--- a/docs/json/radarr/cf/20-stereo.json
+++ b/docs/json/radarr/cf/20-stereo.json
@@ -3,7 +3,7 @@
   "trash_scores": {
     "sqp-1-web-1080p": -175,
     "sqp-1-web-2160p": -175,
-    "sqp-4-ma-hybrid": 157
+    "sqp-4-ma-hybrid": 190
   },
   "name": "2.0 Stereo",
   "includeCustomFormatWhenRenaming": false,

--- a/docs/json/radarr/cf/51-surround.json
+++ b/docs/json/radarr/cf/51-surround.json
@@ -1,7 +1,7 @@
 {
   "trash_id": "77ff61788dfe1097194fd8743d7b4524",
     "trash_scores": {
-    "sqp-4-ma-hybrid": 375
+    "sqp-4-ma-hybrid": 370
   },
   "name": "5.1 Surround",
   "includeCustomFormatWhenRenaming": false,

--- a/docs/json/radarr/cf/51-surround.json
+++ b/docs/json/radarr/cf/51-surround.json
@@ -1,7 +1,7 @@
 {
   "trash_id": "77ff61788dfe1097194fd8743d7b4524",
     "trash_scores": {
-    "sqp-4-ma-hybrid": 190
+    "sqp-4-ma-hybrid": 375
   },
   "name": "5.1 Surround",
   "includeCustomFormatWhenRenaming": false,

--- a/docs/json/radarr/cf/71-surround.json
+++ b/docs/json/radarr/cf/71-surround.json
@@ -1,7 +1,7 @@
 {
   "trash_id": "e77382bcfeba57cb83744c9c5449b401",
     "trash_scores": {
-    "sqp-4-ma-hybrid": 195
+    "sqp-4-ma-hybrid": 380
   },
   "name": "7.1 Surround",
   "includeCustomFormatWhenRenaming": false,

--- a/docs/json/radarr/cf/aac.json
+++ b/docs/json/radarr/cf/aac.json
@@ -6,7 +6,7 @@
     "sqp-1-web-1080p": 0,
     "sqp-1-2160p": 0,
     "sqp-1-web-2160p": 0,
-    "sqp-4-ma-hybrid": 720
+    "sqp-4-ma-hybrid": 20
   },
   "name": "AAC",
   "includeCustomFormatWhenRenaming": false,

--- a/docs/json/radarr/cf/aac.json
+++ b/docs/json/radarr/cf/aac.json
@@ -6,7 +6,7 @@
     "sqp-1-web-1080p": 0,
     "sqp-1-2160p": 0,
     "sqp-1-web-2160p": 0,
-    "sqp-4-ma-hybrid": 0
+    "sqp-4-ma-hybrid": 720
   },
   "name": "AAC",
   "includeCustomFormatWhenRenaming": false,

--- a/docs/json/radarr/cf/atmos-undefined.json
+++ b/docs/json/radarr/cf/atmos-undefined.json
@@ -6,7 +6,7 @@
     "sqp-1-web-1080p": 0,
     "sqp-1-2160p": 0,
     "sqp-1-web-2160p": 0,
-    "sqp-4-ma-hybrid": 605
+    "sqp-4-ma-hybrid": 1420
   },
   "name": "ATMOS (undefined)",
   "includeCustomFormatWhenRenaming": false,

--- a/docs/json/radarr/cf/atmos-undefined.json
+++ b/docs/json/radarr/cf/atmos-undefined.json
@@ -6,7 +6,7 @@
     "sqp-1-web-1080p": 0,
     "sqp-1-2160p": 0,
     "sqp-1-web-2160p": 0,
-    "sqp-4-ma-hybrid": 1420
+    "sqp-4-ma-hybrid": 720
   },
   "name": "ATMOS (undefined)",
   "includeCustomFormatWhenRenaming": false,

--- a/docs/json/radarr/cf/bhdstudio.json
+++ b/docs/json/radarr/cf/bhdstudio.json
@@ -4,7 +4,7 @@
     "default": 1000,
     "sqp-1-web-1080p": 550,
     "sqp-1-web-2160p": 550,
-    "sqp-4-ma-hybrid": 2240
+    "sqp-4-ma-hybrid": 2945
   },
   "name": "BHDStudio",
   "includeCustomFormatWhenRenaming": false,

--- a/docs/json/radarr/cf/dd.json
+++ b/docs/json/radarr/cf/dd.json
@@ -6,7 +6,7 @@
     "sqp-1-web-1080p": 115,
     "sqp-1-2160p": 115,
     "sqp-1-web-2160p": 115,
-    "sqp-4-ma-hybrid": 575
+    "sqp-4-ma-hybrid": 1390
   },
   "name": "DD",
   "includeCustomFormatWhenRenaming": false,

--- a/docs/json/radarr/cf/dd.json
+++ b/docs/json/radarr/cf/dd.json
@@ -6,7 +6,7 @@
     "sqp-1-web-1080p": 115,
     "sqp-1-2160p": 115,
     "sqp-1-web-2160p": 115,
-    "sqp-4-ma-hybrid": 1390
+    "sqp-4-ma-hybrid": 655
   },
   "name": "DD",
   "includeCustomFormatWhenRenaming": false,

--- a/docs/json/radarr/cf/ddplus-atmos.json
+++ b/docs/json/radarr/cf/ddplus-atmos.json
@@ -6,7 +6,7 @@
     "sqp-1-web-1080p": 135,
     "sqp-1-2160p": 135,
     "sqp-1-web-2160p": 135,
-    "sqp-4-ma-hybrid": 1420
+    "sqp-4-ma-hybrid": 720
   },
   "name": "DD+ ATMOS",
   "includeCustomFormatWhenRenaming": false,

--- a/docs/json/radarr/cf/ddplus-atmos.json
+++ b/docs/json/radarr/cf/ddplus-atmos.json
@@ -6,7 +6,7 @@
     "sqp-1-web-1080p": 135,
     "sqp-1-2160p": 135,
     "sqp-1-web-2160p": 135,
-    "sqp-4-ma-hybrid": 605
+    "sqp-4-ma-hybrid": 1420
   },
   "name": "DD+ ATMOS",
   "includeCustomFormatWhenRenaming": false,

--- a/docs/json/radarr/cf/ddplus.json
+++ b/docs/json/radarr/cf/ddplus.json
@@ -6,7 +6,7 @@
     "sqp-1-web-1080p": 125,
     "sqp-1-2160p": 125,
     "sqp-1-web-2160p": 125,
-    "sqp-4-ma-hybrid": 1415
+    "sqp-4-ma-hybrid": 715
   },
   "name": "DD+",
   "includeCustomFormatWhenRenaming": false,

--- a/docs/json/radarr/cf/ddplus.json
+++ b/docs/json/radarr/cf/ddplus.json
@@ -6,7 +6,7 @@
     "sqp-1-web-1080p": 125,
     "sqp-1-2160p": 125,
     "sqp-1-web-2160p": 125,
-    "sqp-4-ma-hybrid": 600
+    "sqp-4-ma-hybrid": 1415
   },
   "name": "DD+",
   "includeCustomFormatWhenRenaming": false,

--- a/docs/json/radarr/cf/dts-es.json
+++ b/docs/json/radarr/cf/dts-es.json
@@ -6,7 +6,7 @@
     "sqp-1-web-1080p": 0,
     "sqp-1-2160p": 0,
     "sqp-1-web-2160p": 0,
-    "sqp-4-ma-hybrid": 870
+    "sqp-4-ma-hybrid": 170
   },
   "name": "DTS-ES",
   "includeCustomFormatWhenRenaming": false,

--- a/docs/json/radarr/cf/dts-es.json
+++ b/docs/json/radarr/cf/dts-es.json
@@ -6,7 +6,7 @@
     "sqp-1-web-1080p": 0,
     "sqp-1-2160p": 0,
     "sqp-1-web-2160p": 0,
-    "sqp-4-ma-hybrid": 55
+    "sqp-4-ma-hybrid": 870
   },
   "name": "DTS-ES",
   "includeCustomFormatWhenRenaming": false,

--- a/docs/json/radarr/cf/dts-hd-hra.json
+++ b/docs/json/radarr/cf/dts-hd-hra.json
@@ -6,7 +6,7 @@
     "sqp-1-web-1080p": -10000,
     "sqp-1-2160p": -10000,
     "sqp-1-web-2160p": -10000,
-    "sqp-4-ma-hybrid": 1020
+    "sqp-4-ma-hybrid": 320
   },
   "trash_regex": "https://regex101.com/r/jdUH4x/2",
   "name": "DTS-HD HRA",

--- a/docs/json/radarr/cf/dts-hd-hra.json
+++ b/docs/json/radarr/cf/dts-hd-hra.json
@@ -6,7 +6,7 @@
     "sqp-1-web-1080p": -10000,
     "sqp-1-2160p": -10000,
     "sqp-1-web-2160p": -10000,
-    "sqp-4-ma-hybrid": 205
+    "sqp-4-ma-hybrid": 1020
   },
   "trash_regex": "https://regex101.com/r/jdUH4x/2",
   "name": "DTS-HD HRA",

--- a/docs/json/radarr/cf/dts-hd-ma.json
+++ b/docs/json/radarr/cf/dts-hd-ma.json
@@ -6,7 +6,7 @@
     "sqp-1-web-1080p": -10000,
     "sqp-1-2160p": -10000,
     "sqp-1-web-2160p": -10000,
-    "sqp-4-ma-hybrid": 2550
+    "sqp-4-ma-hybrid": 1850
   },
   "trash_regex": "https://regex101.com/r/U1asQG/1",
   "name": "DTS-HD MA",

--- a/docs/json/radarr/cf/dts-hd-ma.json
+++ b/docs/json/radarr/cf/dts-hd-ma.json
@@ -6,7 +6,7 @@
     "sqp-1-web-1080p": -10000,
     "sqp-1-2160p": -10000,
     "sqp-1-web-2160p": -10000,
-    "sqp-4-ma-hybrid": 1735
+    "sqp-4-ma-hybrid": 2550
   },
   "trash_regex": "https://regex101.com/r/U1asQG/1",
   "name": "DTS-HD MA",

--- a/docs/json/radarr/cf/dts-x.json
+++ b/docs/json/radarr/cf/dts-x.json
@@ -6,7 +6,7 @@
     "sqp-1-web-1080p": -10000,
     "sqp-1-2160p": -10000,
     "sqp-1-web-2160p": -10000,
-    "sqp-4-ma-hybrid": 2560
+    "sqp-4-ma-hybrid": 1860
   },
   "trash_regex": "https://regex101.com/r/VWCW8c/1",
   "name": "DTS X",

--- a/docs/json/radarr/cf/dts-x.json
+++ b/docs/json/radarr/cf/dts-x.json
@@ -6,7 +6,7 @@
     "sqp-1-web-1080p": -10000,
     "sqp-1-2160p": -10000,
     "sqp-1-web-2160p": -10000,
-    "sqp-4-ma-hybrid": 1745
+    "sqp-4-ma-hybrid": 2560
   },
   "trash_regex": "https://regex101.com/r/VWCW8c/1",
   "name": "DTS X",

--- a/docs/json/radarr/cf/dts.json
+++ b/docs/json/radarr/cf/dts.json
@@ -6,7 +6,7 @@
     "sqp-1-web-1080p": 0,
     "sqp-1-2160p": 0,
     "sqp-1-web-2160p": 0,
-    "sqp-4-ma-hybrid": 5
+    "sqp-4-ma-hybrid": 820
   },
   "trash_regex": "https://regex101.com/r/U1asQG/1",
   "name": "DTS",

--- a/docs/json/radarr/cf/dts.json
+++ b/docs/json/radarr/cf/dts.json
@@ -6,7 +6,7 @@
     "sqp-1-web-1080p": 0,
     "sqp-1-2160p": 0,
     "sqp-1-web-2160p": 0,
-    "sqp-4-ma-hybrid": 820
+    "sqp-4-ma-hybrid": 120
   },
   "trash_regex": "https://regex101.com/r/U1asQG/1",
   "name": "DTS",

--- a/docs/json/radarr/cf/flac.json
+++ b/docs/json/radarr/cf/flac.json
@@ -6,7 +6,7 @@
     "sqp-1-web-1080p": 0,
     "sqp-1-2160p": 0,
     "sqp-1-web-2160p": 0,
-    "sqp-4-ma-hybrid": 305
+    "sqp-4-ma-hybrid": 1120
   },
   "name": "FLAC",
   "includeCustomFormatWhenRenaming": false,

--- a/docs/json/radarr/cf/flac.json
+++ b/docs/json/radarr/cf/flac.json
@@ -6,7 +6,7 @@
     "sqp-1-web-1080p": 0,
     "sqp-1-2160p": 0,
     "sqp-1-web-2160p": 0,
-    "sqp-4-ma-hybrid": 1120
+    "sqp-4-ma-hybrid": 420
   },
   "name": "FLAC",
   "includeCustomFormatWhenRenaming": false,

--- a/docs/json/radarr/cf/hallowed.json
+++ b/docs/json/radarr/cf/hallowed.json
@@ -2,7 +2,7 @@
   "trash_id": "7a0d1ad358fee9f5b074af3ef3f9d9ef",
   "trash_scores": {
     "default": 600,
-    "sqp-4-ma-hybrid": 2250
+    "sqp-4-ma-hybrid": 2955
   },
   "name": "hallowed",
   "includeCustomFormatWhenRenaming": false,

--- a/docs/json/radarr/cf/mainframe.json
+++ b/docs/json/radarr/cf/mainframe.json
@@ -1,7 +1,7 @@
 {
   "trash_id": "8016f2f66e751dea613e6b5b94bf633c",
   "trash_scores": {
-    "sqp-4-ma-hybrid": 2130
+    "sqp-4-ma-hybrid": 2830
   },
   "name": "MainFrame",
   "includeCustomFormatWhenRenaming": false,

--- a/docs/json/radarr/cf/pcm.json
+++ b/docs/json/radarr/cf/pcm.json
@@ -6,7 +6,7 @@
     "sqp-1-web-1080p": 0,
     "sqp-1-2160p": 0,
     "sqp-1-web-2160p": 0,
-    "sqp-4-ma-hybrid": 305
+    "sqp-4-ma-hybrid": 1120
   },
   "name": "PCM",
   "includeCustomFormatWhenRenaming": false,

--- a/docs/json/radarr/cf/pcm.json
+++ b/docs/json/radarr/cf/pcm.json
@@ -6,7 +6,7 @@
     "sqp-1-web-1080p": 0,
     "sqp-1-2160p": 0,
     "sqp-1-web-2160p": 0,
-    "sqp-4-ma-hybrid": 1120
+    "sqp-4-ma-hybrid": 420
   },
   "name": "PCM",
   "includeCustomFormatWhenRenaming": false,

--- a/docs/json/radarr/cf/truehd-atmos.json
+++ b/docs/json/radarr/cf/truehd-atmos.json
@@ -6,7 +6,7 @@
     "sqp-1-web-1080p": -10000,
     "sqp-1-2160p": -10000,
     "sqp-1-web-2160p": -10000,
-    "sqp-4-ma-hybrid": 1745
+    "sqp-4-ma-hybrid": 2560
   },
   "name": "TrueHD ATMOS",
   "includeCustomFormatWhenRenaming": false,

--- a/docs/json/radarr/cf/truehd-atmos.json
+++ b/docs/json/radarr/cf/truehd-atmos.json
@@ -6,7 +6,7 @@
     "sqp-1-web-1080p": -10000,
     "sqp-1-2160p": -10000,
     "sqp-1-web-2160p": -10000,
-    "sqp-4-ma-hybrid": 2560
+    "sqp-4-ma-hybrid": 1860
   },
   "name": "TrueHD ATMOS",
   "includeCustomFormatWhenRenaming": false,

--- a/docs/json/radarr/cf/truehd.json
+++ b/docs/json/radarr/cf/truehd.json
@@ -6,7 +6,7 @@
     "sqp-1-web-1080p": -10000,
     "sqp-1-2160p": -10000,
     "sqp-1-web-2160p": -10000,
-    "sqp-4-ma-hybrid": 2550
+    "sqp-4-ma-hybrid": 1850
   },
   "name": "TrueHD",
   "includeCustomFormatWhenRenaming": false,

--- a/docs/json/radarr/cf/truehd.json
+++ b/docs/json/radarr/cf/truehd.json
@@ -6,7 +6,7 @@
     "sqp-1-web-1080p": -10000,
     "sqp-1-2160p": -10000,
     "sqp-1-web-2160p": -10000,
-    "sqp-4-ma-hybrid": 1735
+    "sqp-4-ma-hybrid": 2550
   },
   "name": "TrueHD",
   "includeCustomFormatWhenRenaming": false,

--- a/docs/json/radarr/cf/webdl-boost.json
+++ b/docs/json/radarr/cf/webdl-boost.json
@@ -1,7 +1,7 @@
 {
   "trash_id": "8df7fe4569063d39319f07e69707285a",
   "trash_scores": {
-    "sqp-4-ma-hybrid": 2370
+    "sqp-4-ma-hybrid": 3070
   },
   "name": "WEBDL Boost",
   "includeCustomFormatWhenRenaming": false,

--- a/docs/json/radarr/quality-profiles/sqp-4-ma-hybrid.json
+++ b/docs/json/radarr/quality-profiles/sqp-4-ma-hybrid.json
@@ -6,7 +6,7 @@
   "group": 98,
   "upgradeAllowed": true,
   "cutoff": "Bluray|WEB-2160p",
-  "minFormatScore": 2370,
+  "minFormatScore": 3070,
   "cutoffFormatScore": 10000,
   "minUpgradeFormatScore": 1,
   "language": "Original",

--- a/docs/json/radarr/quality-profiles/sqp-4-ma-hybrid.json
+++ b/docs/json/radarr/quality-profiles/sqp-4-ma-hybrid.json
@@ -67,7 +67,6 @@
     "DTS": "1c1a4c5e823891c75bc50380a6866f73",
     "AAC": "240770601cc226190c367ef59aba7463",
     "DD": "c2998bd0d90ed5621d8df281e839436e",
-    "1.0 Mono": "b124be9b146540f8e62f98fe32e49a2a",
     "2.0 Stereo": "89dac1be53d5268a7e10a19d3c896826",
     "5.1 Surround": "77ff61788dfe1097194fd8743d7b4524",
     "7.1 Surround": "e77382bcfeba57cb83744c9c5449b401",


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->

Adjusted scoring for an SQP to prefer multichannel over 2.0 when it shares the same audio format

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

Adjusted scoring for an SQP to prefer multichannel over 2.0 when it shares the same audio format

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Adjust Radarr SQP audio scoring to prefer multichannel releases over 2.0 stereo when they share the same audio format.

Enhancements:
- Retune audio channel custom format scores (mono, stereo, 5.1, 7.1, Atmos and related codecs) to favor higher-channel mixes over 2.0 for the same codec.
- Update the SQP unwanted-format group and MA hybrid quality profile to align with the new multichannel-preferred scoring behaviour.