### PR TITLE
feat(radarr): Add RlsGrp `RBB` to `LQ` due to cam and microsized releases

### DIFF
--- a/docs/json/radarr/cf/lq.json
+++ b/docs/json/radarr/cf/lq.json
@@ -693,6 +693,15 @@
       }
     },
     {
+      "name": "RBB",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(RBB)$"
+      }
+    },
+    {
       "name": "RDN",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->

Add RlsGrp `RBB` to `LQ` due to cam and microsized releases

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

Added RlsGrp `RBB` to `LQ`

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

New Features:
- Recognize releases from the RBB release group as low-quality (LQ) in Radarr's custom format configuration.