### PR TITLE
feat(starr): Add RlsGrp `C76` to `Bad Dual Groups`

### DIFF
--- a/docs/json/radarr/cf/bad-dual-groups.json
+++ b/docs/json/radarr/cf/bad-dual-groups.json
@@ -57,6 +57,15 @@
       }
     },
     {
+      "name": "C76",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(C76)$"
+      }
+    },
+    {
       "name": "Cory",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,

--- a/docs/json/sonarr/cf/bad-dual-groups.json
+++ b/docs/json/sonarr/cf/bad-dual-groups.json
@@ -29,33 +29,6 @@
       }
     },
     {
-      "name": "CYPHER",
-      "implementation": "ReleaseGroupSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "^(CYPHER)$"
-      }
-    },
-    {
-      "name": "MLH",
-      "implementation": "ReleaseGroupSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "^(MLH)$"
-      }
-    },
-    {
-      "name": "XiQUEXiQUE",
-      "implementation": "ReleaseGroupSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "^(XiQUEXiQUE)$"
-      }
-    },
-    {
       "name": "BiOMA",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,
@@ -92,12 +65,30 @@
       }
     },
     {
+      "name": "C76",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(C76)$"
+      }
+    },
+    {
       "name": "Cory",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,
       "required": false,
       "fields": {
         "value": "^(Cory)$"
+      }
+    },
+    {
+      "name": "CYPHER",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(CYPHER)$"
       }
     },
     {
@@ -161,6 +152,15 @@
       "required": false,
       "fields": {
         "value": "^(LCD)$"
+      }
+    },
+    {
+      "name": "MLH",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(MLH)$"
       }
     },
     {
@@ -260,6 +260,15 @@
       "required": false,
       "fields": {
         "value": "^(WTV)$"
+      }
+    },
+    {
+      "name": "XiQUEXiQUE",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(XiQUEXiQUE)$"
       }
     },
     {


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->

Add RlsGrp `C76` to `Bad Dual Groups`

C76 appears to be a Portuguese group, and while they use DUAL, Portuguese is the default language. It comes with both English and Portuguese subtitles (default and forced).

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

Added RlsGrp `C76` to `Bad Dual Groups`

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Add the C76 release group to the bad dual audio groups configuration for both Radarr and Sonarr.

Enhancements:
- Extend Radarr bad dual groups custom format to include the C76 release group.
- Extend Sonarr bad dual groups custom format to include the C76 release group.