### PR TITLE
fix(misc): Replace abandoned merge-conflict label action

### DIFF
--- a/.github/workflows/conflicts.yml
+++ b/.github/workflows/conflicts.yml
@@ -11,10 +11,11 @@ jobs:
       pull-requests: write
     steps:
       - name: Label merge conflicts
-        uses: mschilde/auto-label-merge-conflicts@5981f8933e92b78098af86b9e33fe0871cc7a3be # v2.0
+        uses: eps1lon/actions-label-merge-conflict@e0e7fd9fd8ddda6d9727236e35daf319381a0a4f # v3.1.0
         if: github.event.repository.fork == false
         with:
-          CONFLICT_LABEL_NAME: "Status: Conflicted"
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          MAX_RETRIES: 5
-          WAIT_MS: 5000
+          dirtyLabel: "Status: Conflicted"
+          repoToken: ${{ secrets.GITHUB_TOKEN }}
+          retryMax: 5
+          retryAfter: 5
+          continueOnMissingPermissions: true


### PR DESCRIPTION
## Problem

The `triage` job (`.github/workflows/conflicts.yml`) fails on **every** push and PR. `mschilde/auto-label-merge-conflicts` builds a Docker image whose `Dockerfile` runs `yarn install --frozen-lockfile` on `node:alpine`, which no longer ships yarn:

```
/bin/sh: yarn: not found
ERROR: process "/bin/sh -c yarn install --frozen-lockfile" did not complete successfully: exit code: 127
```

The action is unmaintained, so this won't be fixed upstream.

## Fix

Replace it with the maintained **eps1lon/actions-label-merge-conflict@v3.1.0** (a node24 JS action — no Docker, no yarn). Inputs mapped 1:1:

| old | new |
|---|---|
| `CONFLICT_LABEL_NAME` | `dirtyLabel` |
| `GITHUB_TOKEN` | `repoToken` |
| `MAX_RETRIES` | `retryMax` |
| `WAIT_MS: 5000` (ms) | `retryAfter: 5` (sec) |

Also added `continueOnMissingPermissions: true` so PRs **from forks** (which only get a read-only token) don't fail the check.

Pinned to SHA `e0e7fd9` with a version comment, matching the repo's pinning convention.

## Summary by Sourcery

CI:
- Update the merge-conflict triage workflow to use eps1lon/actions-label-merge-conflict with equivalent settings and support for missing permissions on forked PRs.