### PR TITLE
chore(misc): Hold dependency updates 3 days before automerge

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -12,6 +12,7 @@
     ":enableVulnerabilityAlerts",
     ":renovatePrefix"
   ],
+  "minimumReleaseAge": "3 days",
   "pre-commit": {
     "enabled": true
   },


### PR DESCRIPTION
## What

Adds `"minimumReleaseAge": "3 days"` to `.github/renovate.json`.

## Why

The config automerges digest/minor/patch updates across GitHub Actions, pip, Docker, and pre-commit. Without a release-age gate, a brand-new release is eligible to **auto-merge the moment it publishes** — including a release that's broken or compromised (the supply-chain risk pattern seen in recent npm / GitHub Action incidents).

`minimumReleaseAge: 3 days` makes Renovate **hold the PR and its automerge** until the release has been public for 3 days, giving time for bad releases to be yanked. It does **not** change which updates are eligible, only delays them slightly. Verified against the [Renovate docs](https://docs.renovatebot.com/configuration-options/#minimumreleaseage) ("Await X time duration before Automerging").

## Summary by Sourcery

Build:
- Add a three-day minimum release age to the Renovate configuration to gate automerge of dependency updates.