### PR TITLE
chore(misc): Give the three identical 'triage' jobs distinct names

### DIFF
--- a/.github/workflows/conflicts.yml
+++ b/.github/workflows/conflicts.yml
@@ -8,7 +8,7 @@ on:
     types: [synchronize]
 
 jobs:
-  triage:
+  label-conflicts:
     runs-on: ubuntu-latest
     if: github.event.repository.fork == false
     permissions:

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -5,7 +5,7 @@ on:
   pull_request_target:
 
 jobs:
-  triage:
+  labeler:
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/mkdocs_bug_prevent.yml
+++ b/.github/workflows/mkdocs_bug_prevent.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
 
 jobs:
-  triage:
+  check-mkdocs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write


### PR DESCRIPTION
## Problem

`conflicts.yml`, `labeler.yml`, and `mkdocs_bug_prevent.yml` each name their job `triage`, so a PR's checks list shows **three indistinguishable `triage` entries**.

## Change

| Workflow | old job | new job |
|---|---|---|
| Label Conflicts | `triage` | `label-conflicts` |
| Label Pull Requests | `triage` | `labeler` |
| Check for Mkdocs Issues | `triage` | `check-mkdocs` |

Single job per workflow, no `needs:` refs — pure display-name change. Avoided `deploy-pr.yml`/`trigger-pr-deploy.yml` (#2738 rewrites those). `master` has no required-status-check rules, so safe.

## Summary by Sourcery

Rename CI workflow jobs so each triage-related check has a distinct name in GitHub checks list.

CI:
- Rename the conflicts workflow job from `triage` to `label-conflicts` for clearer check identification.
- Rename the labeler workflow job from `triage` to `labeler` for clearer check identification.
- Rename the MkDocs bug prevention workflow job from `triage` to `check-mkdocs` to distinguish it in status checks.