### PR TITLE
fix(ci): prevent fork-PR code execution in privileged deploy workflow

### DIFF
--- a/.github/workflows/deploy-pr.yml
+++ b/.github/workflows/deploy-pr.yml
@@ -1,4 +1,4 @@
-name: Build PR & Deploy
+name: Deploy PR Preview
 
 # workflow_run is intentional; this workflow deploys PR previews triggered by a
 # separate unprivileged workflow to safely access secrets.
@@ -15,102 +15,64 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  check:
+  deploy:
     runs-on: ubuntu-latest
-    if: github.event.repository.fork == false
+    if: github.event.workflow_run.conclusion == 'success' && github.event.repository.fork == false
     permissions:
       contents: read
       actions: read
     outputs:
-      should_deploy: ${{ steps.pr_info.outputs.should_deploy }}
-      pr_number: ${{ steps.pr_info.outputs.pr_number }}
+      url: ${{ steps.cloudflare.outputs.deployment-url }}
+      branch_url: ${{ steps.cloudflare.outputs.pages-deployment-alias-url }}
       pr_sha: ${{ steps.pr_info.outputs.pr_sha }}
+      pr_number: ${{ steps.pr_info.outputs.pr_number }}
+      should_deploy: ${{ steps.pr_info.outputs.should_deploy }}
     steps:
       - name: Download artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ github.token }}
-          name: pr_info
-          path: ${{ github.workspace }}/pr_info
+          name: pr_build
+          path: ${{ github.workspace }}/pr_build
 
-      - name: Read PR info
+      - name: Read PR metadata
         id: pr_info
         run: |
-          # SHOULD_DEPLOY is absent from artifacts produced by the
-          # pre-path-filter trigger workflow; default to false so a
-          # legacy artifact skips the deploy instead of failing cat.
-          should_deploy=$(cat "${{ github.workspace }}/pr_info/SHOULD_DEPLOY" 2>/dev/null || true)
+          should_deploy=$(cat "${{ github.workspace }}/pr_build/SHOULD_DEPLOY" 2>/dev/null || true)
           {
-            echo "pr_number=$(cat "${{ github.workspace }}/pr_info/PR_NUMBER")"
-            echo "pr_sha=$(cat "${{ github.workspace }}/pr_info/PR_SHA")"
+            echo "pr_number=$(cat "${{ github.workspace }}/pr_build/PR_NUMBER")"
+            echo "pr_sha=$(cat "${{ github.workspace }}/pr_build/PR_SHA")"
             echo "should_deploy=${should_deploy:-false}"
           } >> "$GITHUB_OUTPUT"
 
-  build:
-    needs: check
-    if: needs.check.outputs.should_deploy == 'true'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    outputs:
-      url: ${{ steps.cloudflare.outputs.deployment-url }}
-      branch_url: ${{ steps.cloudflare.outputs.pages-deployment-alias-url }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
-          ref: ${{ needs.check.outputs.pr_sha }}
-          fetch-depth: 0
-          sparse-checkout: |
-            docs
-            images
-            includes
-            overrides
-
-      # Only workflow_run from repo-owned workflows triggers this job; fork PRs cannot poison the cache.
-      - name: Setup python # zizmor: ignore[cache-poisoning]
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-        with:
-          python-version: 3.x
-          cache: pip
-          cache-dependency-path: docs/requirements.txt
-
-      - name: Install dependencies
-        run: pip install -r docs/requirements.txt
-
-      - name: Build mkdocs
-        run: |
-          mkdocs build --clean
-          mkdocs --version
-
-      - name: Publish to Cloudflare Pages
+      - name: Deploy to Cloudflare Pages
         id: cloudflare
+        if: steps.pr_info.outputs.should_deploy == 'true'
         uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4.0.0
         with:
           apiToken: ${{ secrets.CF_API_TOKEN }}
           accountId: ${{ secrets.CF_ACCOUNT_ID }}
           command: >
-            pages deploy site
+            pages deploy ${{ github.workspace }}/pr_build/site
             --project-name=trash-guides
-            --branch=pr-${{ needs.check.outputs.pr_number }}
-            --commit-hash=${{ needs.check.outputs.pr_sha }}
+            --branch=pr-${{ steps.pr_info.outputs.pr_number }}
+            --commit-hash=${{ steps.pr_info.outputs.pr_sha }}
 
   comment:
-    needs: [check, build]
+    needs: deploy
     runs-on: ubuntu-latest
-    if: always() && needs.check.outputs.should_deploy == 'true'
+    if: always() && needs.deploy.outputs.should_deploy == 'true'
     permissions:
       pull-requests: write
     steps:
       - name: Comment PR
         env:
-          PREVIEW_URL: ${{ needs.build.outputs.url }}
-          BRANCH_PREVIEW_URL: ${{ needs.build.outputs.branch_url }}
-          BUILD_STATUS: ${{ needs.build.result }}
-          PR_SHA: ${{ needs.check.outputs.pr_sha }}
-          PR_NUMBER: ${{ needs.check.outputs.pr_number }}
+          PREVIEW_URL: ${{ needs.deploy.outputs.url }}
+          BRANCH_PREVIEW_URL: ${{ needs.deploy.outputs.branch_url }}
+          BUILD_STATUS: ${{ needs.deploy.result }}
+          PR_SHA: ${{ needs.deploy.outputs.pr_sha }}
+          PR_NUMBER: ${{ needs.deploy.outputs.pr_number }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           if [ "$BUILD_STATUS" == "success" ]; then
@@ -118,7 +80,7 @@ jobs:
             STATUS_MESSAGE="Deploy successful!"
           else
             STATUS_EMOJI="❌"
-            STATUS_MESSAGE="Build failed!"
+            STATUS_MESSAGE="Deploy failed!"
           fi
 
           COMMENT_BODY="Deploying with ⚡ Cloudflare Pages<br><table><tr><td><strong>Latest commit:</strong></td><td><code>${PR_SHA}</code></td></tr><tr><td><strong>Status:</strong></td><td>&nbsp;$STATUS_EMOJI&nbsp; $STATUS_MESSAGE</td></tr><tr><td><strong>Preview URL:</strong></td><td><a href='$PREVIEW_URL'>$PREVIEW_URL</a></td></tr><tr><td><strong>Branch Preview URL:</strong></td><td><a href='$BRANCH_PREVIEW_URL'>$BRANCH_PREVIEW_URL</a></td></tr></table>"

--- a/.github/workflows/trigger-pr-deploy.yml
+++ b/.github/workflows/trigger-pr-deploy.yml
@@ -27,20 +27,58 @@ jobs:
               - 'includes/**'
               - 'overrides/**'
               - 'mkdocs.yml'
+              - 'docs/requirements.txt'
 
-      - name: Save PR info
+      - name: Checkout
+        if: steps.filter.outputs.rendered == 'true'
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+          sparse-checkout: |
+            docs
+            images
+            includes
+            overrides
+            mkdocs.yml
+            docs/requirements.txt
+
+      # PR caches are scoped to the merge ref and cannot be restored by the base branch
+      # or other PRs, so fork PRs cannot poison the cache used by trusted builds.
+      - name: Setup python # zizmor: ignore[cache-poisoning]
+        if: steps.filter.outputs.rendered == 'true'
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: 3.x
+          cache: pip
+          cache-dependency-path: docs/requirements.txt
+
+      - name: Install dependencies
+        if: steps.filter.outputs.rendered == 'true'
+        run: pip install -r docs/requirements.txt
+
+      - name: Build mkdocs
+        if: steps.filter.outputs.rendered == 'true'
+        run: |
+          mkdocs build --clean
+          mkdocs --version
+
+      - name: Save PR metadata
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_SHA: ${{ github.event.pull_request.head.sha }}
           SHOULD_DEPLOY: ${{ steps.filter.outputs.rendered }}
         run: |
-          mkdir -p ./pr_info
-          echo "$PR_NUMBER" > ./pr_info/PR_NUMBER
-          echo "$PR_SHA" > ./pr_info/PR_SHA
-          echo "$SHOULD_DEPLOY" > ./pr_info/SHOULD_DEPLOY
+          mkdir -p ./pr_build
+          echo "$PR_NUMBER" > ./pr_build/PR_NUMBER
+          echo "$PR_SHA" > ./pr_build/PR_SHA
+          echo "$SHOULD_DEPLOY" > ./pr_build/SHOULD_DEPLOY
+          if [ "$SHOULD_DEPLOY" = "true" ]; then
+            mv site pr_build/site
+          fi
 
-      - name: Upload PR info
+      - name: Upload PR build
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: pr_info
-          path: pr_info/
+          name: pr_build
+          path: pr_build/


### PR DESCRIPTION
## Pull Request

### Purpose

The PR deploy workflow chain (`trigger-pr-deploy.yml` + `deploy-pr.yml`) checks out fork-PR code and runs `pip install` in the privileged `workflow_run` job that has access to `CF_API_TOKEN` and `GITHUB_TOKEN`. A malicious fork could modify `requirements.txt` to execute arbitrary code during `pip install` and exfiltrate those secrets.

This is the same vulnerability class as [CVE-2026-55675](https://github.com/saltyorg/docs/security/advisories/GHSA-wr2h-fpxm-ff4x) (CVSS 10.0), which was found and fixed in `saltyorg/docs`. Credit to @saltydk for flagging it here.

### Approach

Moved the entire build (checkout, `pip install`, `mkdocs build`) into the unprivileged `trigger-pr-deploy.yml` workflow, which runs on `pull_request` with no secret access. The built `site/` directory gets bundled with PR metadata into a single artifact (`pr_build`).

`deploy-pr.yml` is reduced to downloading that pre-built artifact and deploying the static HTML to Cloudflare. No fork code executes in the secret-bearing job.

Specifically:

- `trigger-pr-deploy.yml` now performs: path filtering, checkout (sparse), setup-python, pip install, mkdocs build, then uploads the built site + PR metadata as a single artifact
- `deploy-pr.yml` loses its `check` and `build` jobs; the single `deploy` job downloads the artifact, reads metadata, and deploys to Cloudflare (gated on `workflow_run.conclusion == 'success'`)
- The `comment` job still runs on `always()` so it can post failure comments, and no longer checks out the repo (it only runs curl)
- All existing zizmor hardening is preserved (permissions blocks, env vars, suppression comments)

### Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Move PR preview build into an unprivileged workflow and limit the privileged deploy workflow to deploying pre-built artifacts to avoid executing fork code with secrets.

CI:
- Consolidate the deploy workflow into a single job that reads PR metadata from a pre-built artifact and deploys to Cloudflare only after successful builds.
- Shift checkout, dependency installation, and mkdocs build steps into the trigger workflow, bundling the built site and PR metadata into a single artifact consumed by the deploy workflow.
- Update PR comment logic to reflect deploy status and to rely on outputs from the new deploy job.