### PR TITLE
feat(starr-anime): Some Anime Tier adjustments

### DIFF
--- a/docs/json/radarr/cf/anime-bd-tier-01.json
+++ b/docs/json/radarr/cf/anime-bd-tier-01.json
@@ -70,15 +70,6 @@
       }
     },
     {
-      "name": "NAN0",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "(?<=remux).*\\b(NAN0)\\b"
-      }
-    },
-    {
       "name": "sam",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,
@@ -103,15 +94,6 @@
       "required": false,
       "fields": {
         "value": "\\[SoM\\]|-SoM\\b"
-      }
-    },
-    {
-      "name": "ZR",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "\\b(ZR)\\b|-ZR-"
       }
     }
   ]

--- a/docs/json/radarr/cf/anime-bd-tier-02.json
+++ b/docs/json/radarr/cf/anime-bd-tier-02.json
@@ -52,6 +52,15 @@
       }
     },
     {
+      "name": "BlackRose",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(BlackRose)\\b"
+      }
+    },
+    {
       "name": "FateSucks",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,
@@ -148,15 +157,6 @@
       "required": false,
       "fields": {
         "value": "\\[Orphan\\]|-Orphan\\b"
-      }
-    },
-    {
-      "name": "PMR",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "^(?=.*\\b(PMR)\\b)(?=.*\\b(Remux)\\b)"
       }
     },
     {

--- a/docs/json/radarr/cf/anime-bd-tier-03.json
+++ b/docs/json/radarr/cf/anime-bd-tier-03.json
@@ -169,6 +169,15 @@
       }
     },
     {
+      "name": "NAN0",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "(?<=remux).*\\b(NAN0)\\b"
+      }
+    },
+    {
       "name": "Netaro",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,
@@ -220,6 +229,15 @@
       "required": false,
       "fields": {
         "value": "\\b(P9)\\b"
+      }
+    },
+    {
+      "name": "PMR",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(?=.*\\b(PMR)\\b)(?=.*\\b(Remux)\\b)"
       }
     },
     {
@@ -286,12 +304,30 @@
       }
     },
     {
+      "name": "Sylvar",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Sylvar)\\b"
+      }
+    },
+    {
       "name": "uba",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,
       "required": false,
       "fields": {
         "value": "\\[uba\\]|-uba\\b"
+      }
+    },
+    {
+      "name": "ZR",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(ZR)\\b|-ZR-"
       }
     }
   ]

--- a/docs/json/sonarr/cf/anime-bd-tier-01.json
+++ b/docs/json/sonarr/cf/anime-bd-tier-01.json
@@ -79,15 +79,6 @@
       }
     },
     {
-      "name": "NAN0",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "(?<=remux).*\\b(NAN0)\\b"
-      }
-    },
-    {
       "name": "sam",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,
@@ -112,15 +103,6 @@
       "required": false,
       "fields": {
         "value": "\\[SoM\\]|-SoM\\b"
-      }
-    },
-    {
-      "name": "ZR",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "\\b(ZR)\\b|-ZR-"
       }
     }
   ]

--- a/docs/json/sonarr/cf/anime-bd-tier-02.json
+++ b/docs/json/sonarr/cf/anime-bd-tier-02.json
@@ -61,6 +61,15 @@
       }
     },
     {
+      "name": "BlackRose",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(BlackRose)\\b"
+      }
+    },
+    {
       "name": "FateSucks",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,

--- a/docs/json/sonarr/cf/anime-bd-tier-02.json
+++ b/docs/json/sonarr/cf/anime-bd-tier-02.json
@@ -169,15 +169,6 @@
       }
     },
     {
-      "name": "PMR",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "^(?=.*\\b(PMR)\\b)(?=.*\\b(Remux)\\b)"
-      }
-    },
-    {
       "name": "Vodes",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,

--- a/docs/json/sonarr/cf/anime-bd-tier-03.json
+++ b/docs/json/sonarr/cf/anime-bd-tier-03.json
@@ -178,6 +178,15 @@
       }
     },
     {
+      "name": "NAN0",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "(?<=remux).*\\b(NAN0)\\b"
+      }
+    },
+    {
       "name": "Netaro",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,
@@ -229,6 +238,15 @@
       "required": false,
       "fields": {
         "value": "\\b(P9)\\b"
+      }
+    },
+    {
+      "name": "PMR",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(?=.*\\b(PMR)\\b)(?=.*\\b(Remux)\\b)"
       }
     },
     {
@@ -301,7 +319,16 @@
       "required": false,
       "fields": {
         "value": "\\[uba\\]|-uba\\b"
+      },
+      {
+      "name": "ZR",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(ZR)\\b|-ZR-"
       }
+    }
     }
   ]
 }

--- a/docs/json/sonarr/cf/anime-bd-tier-03.json
+++ b/docs/json/sonarr/cf/anime-bd-tier-03.json
@@ -313,6 +313,15 @@
       }
     },
     {
+      "name": "Sylvar",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Sylvar)\\b"
+      }
+    },
+    {
       "name": "uba",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,

--- a/docs/json/sonarr/cf/anime-bd-tier-03.json
+++ b/docs/json/sonarr/cf/anime-bd-tier-03.json
@@ -328,8 +328,9 @@
       "required": false,
       "fields": {
         "value": "\\[uba\\]|-uba\\b"
-      },
-      {
+      }
+    },
+    {
       "name": "ZR",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,
@@ -337,7 +338,6 @@
       "fields": {
         "value": "\\b(ZR)\\b|-ZR-"
       }
-    }
     }
   ]
 }


### PR DESCRIPTION
# Pull Request

## Purpose
Adding new groups BlackRose and Sylvar and moving remux groups into Anime Tier 03 since even though they have a huge number of "best" releases, it seems those are simply the default releases which are trumped when a "better" release is created.
<!-- Please provide a detailed description of why you created this pull request. -->

## Approach
Just moving and adding groups into the anime tier CFs
<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Adjust anime Blu-ray tier configurations for Radarr and Sonarr to reclassify certain release groups and add new groups to the appropriate tiers.

New Features:
- Add new anime release groups BlackRose and Sylvar to the tiered Blu-ray configurations for Radarr and Sonarr.

Enhancements:
- Reassign remux-focused anime release groups into Anime Tier 03 across Radarr and Sonarr config files to better reflect their relative priority.