### PR TITLE
feat(starr): Add release groups to German CFs

### DIFF
--- a/docs/json/radarr/cf/german-lq.json
+++ b/docs/json/radarr/cf/german-lq.json
@@ -410,6 +410,15 @@
       "fields": {
         "value": "^(SD7)$"
       }
+    },
+    {
+      "name": "PiKACHU",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(PiKACHU)$"
+      }
     }
   ]
 }

--- a/docs/json/radarr/cf/german-lq.json
+++ b/docs/json/radarr/cf/german-lq.json
@@ -7,33 +7,6 @@
   "includeCustomFormatWhenRenaming": false,
   "specifications": [
     {
-      "name": "PsO",
-      "implementation": "ReleaseGroupSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "^(PsO)$"
-      }
-    },
-    {
-      "name": "Cancer58",
-      "implementation": "ReleaseGroupSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "^(Cancer58)$"
-      }
-    },
-    {
-      "name": "Tylor.D",
-      "implementation": "ReleaseGroupSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "^(Tylor\\.D)$"
-      }
-    },
-    {
       "name": "1XBET",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,
@@ -52,75 +25,75 @@
       }
     },
     {
-      "name": "HELD",
+      "name": "AIDA",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,
       "required": false,
       "fields": {
-        "value": "^(HELD)$"
+        "value": "^(AIDA)$"
       }
     },
     {
-      "name": "kala",
+      "name": "AVTOMAT",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,
       "required": false,
       "fields": {
-        "value": "^(kala)$"
+        "value": "^(AVTOMAT)$"
       }
     },
     {
-      "name": "POE",
+      "name": "Cancer58",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,
       "required": false,
       "fields": {
-        "value": "^(POE)$"
+        "value": "^(Cancer58)$"
       }
     },
     {
-      "name": "SHOWE",
+      "name": "CTFOH",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,
       "required": false,
       "fields": {
-        "value": "^(SHOWE)$"
+        "value": "^(CTFOH)$"
       }
     },
     {
-      "name": "SHOWEHD",
+      "name": "EMVY",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,
       "required": false,
       "fields": {
-        "value": "^(SHOWEHD)$"
+        "value": "^(EMVY)$"
       }
     },
     {
-      "name": "ORCA88",
+      "name": "FORMBA",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,
       "required": false,
       "fields": {
-        "value": "^(ORCA88)$"
+        "value": "^(FORMBA)$"
       }
     },
     {
-      "name": "LuRCH",
+      "name": "FRAGGERS",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,
       "required": false,
       "fields": {
-        "value": "^(LuRCH)$"
+        "value": "^(FRAGGERS)$"
       }
     },
     {
-      "name": "N2D2",
+      "name": "FSX",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,
       "required": false,
       "fields": {
-        "value": "^(N2D2)$"
+        "value": "^(FSX)$"
       }
     },
     {
@@ -133,12 +106,30 @@
       }
     },
     {
-      "name": "TFARC",
+      "name": "HELD",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,
       "required": false,
       "fields": {
-        "value": "^(TFARC)$"
+        "value": "^(HELD)$"
+      }
+    },
+    {
+      "name": "iSSEYMiYAKE",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(iSSEYMiYAKE)$"
+      }
+    },
+    {
+      "name": "kala",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(kala)$"
       }
     },
     {
@@ -160,75 +151,21 @@
       }
     },
     {
-      "name": "CTFOH",
+      "name": "LizardSquad",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,
       "required": false,
       "fields": {
-        "value": "^(CTFOH)$"
+        "value": "^(LizardSquad)$"
       }
     },
     {
-      "name": "Pendeti",
+      "name": "LuRCH",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,
       "required": false,
       "fields": {
-        "value": "^(Pendeti)$"
-      }
-    },
-    {
-      "name": "OJ",
-      "implementation": "ReleaseGroupSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "^(OJ)$"
-      }
-    },
-    {
-      "name": "PS",
-      "implementation": "ReleaseGroupSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "^(PS)$"
-      }
-    },
-    {
-      "name": "FSX",
-      "implementation": "ReleaseGroupSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "^(FSX)$"
-      }
-    },
-    {
-      "name": "EMVY",
-      "implementation": "ReleaseGroupSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "^(EMVY)$"
-      }
-    },
-    {
-      "name": "ZaidaNulled",
-      "implementation": "ReleaseGroupSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "^(ZaidaNulled)$"
-      }
-    },
-    {
-      "name": "MEGA",
-      "implementation": "ReleaseGroupSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "^(MEGA)$"
+        "value": "^(LuRCH)$"
       }
     },
     {
@@ -241,30 +178,30 @@
       }
     },
     {
-      "name": "FORMBA",
+      "name": "MEGA",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,
       "required": false,
       "fields": {
-        "value": "^(FORMBA)$"
+        "value": "^(MEGA)$"
       }
     },
     {
-      "name": "PaZ",
+      "name": "N2D2",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,
       "required": false,
       "fields": {
-        "value": "^(PaZ)$"
+        "value": "^(N2D2)$"
       }
     },
     {
-      "name": "Whistler",
+      "name": "OJ",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,
       "required": false,
       "fields": {
-        "value": "^(Whistler)$"
+        "value": "^(OJ)$"
       }
     },
     {
@@ -277,39 +214,12 @@
       }
     },
     {
-      "name": "WOTT",
+      "name": "ORCA88",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,
       "required": false,
       "fields": {
-        "value": "^(WOTT)$"
-      }
-    },
-    {
-      "name": "SunDry",
-      "implementation": "ReleaseGroupSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "^(SunDry)$"
-      }
-    },
-    {
-      "name": "PL",
-      "implementation": "ReleaseGroupSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "^(PL)$"
-      }
-    },
-    {
-      "name": "TVARCHiV",
-      "implementation": "ReleaseGroupSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "^(TVARCHiV)$"
+        "value": "^(ORCA88)$"
       }
     },
     {
@@ -322,66 +232,66 @@
       }
     },
     {
-      "name": "LizardSquad",
+      "name": "PaZ",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,
       "required": false,
       "fields": {
-        "value": "^(LizardSquad)$"
+        "value": "^(PaZ)$"
       }
     },
     {
-      "name": "AVTOMAT",
+      "name": "Pendeti",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,
       "required": false,
       "fields": {
-        "value": "^(AVTOMAT)$"
+        "value": "^(Pendeti)$"
       }
     },
     {
-      "name": "iSSEYMiYAKE",
+      "name": "PiKACHU",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,
       "required": false,
       "fields": {
-        "value": "^(iSSEYMiYAKE)$"
+        "value": "^(PiKACHU)$"
       }
     },
     {
-      "name": "TVP",
+      "name": "PL",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,
       "required": false,
       "fields": {
-        "value": "^(TVP)$"
+        "value": "^(PL)$"
       }
     },
     {
-      "name": "AIDA",
+      "name": "POE",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,
       "required": false,
       "fields": {
-        "value": "^(AIDA)$"
+        "value": "^(POE)$"
       }
     },
     {
-      "name": "UTOPiA",
+      "name": "PS",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,
       "required": false,
       "fields": {
-        "value": "^(UTOPiA)$"
+        "value": "^(PS)$"
       }
     },
     {
-      "name": "FRAGGERS",
+      "name": "PsO",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,
       "required": false,
       "fields": {
-        "value": "^(FRAGGERS)$"
+        "value": "^(PsO)$"
       }
     },
     {
@@ -394,15 +304,6 @@
       }
     },
     {
-      "name": "VideoStar",
-      "implementation": "ReleaseGroupSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "^(VideoStar)$"
-      }
-    },
-    {
       "name": "SD7",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,
@@ -412,12 +313,111 @@
       }
     },
     {
-      "name": "PiKACHU",
+      "name": "SHOWE",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,
       "required": false,
       "fields": {
-        "value": "^(PiKACHU)$"
+        "value": "^(SHOWE)$"
+      }
+    },
+    {
+      "name": "SHOWEHD",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(SHOWEHD)$"
+      }
+    },
+    {
+      "name": "SunDry",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(SunDry)$"
+      }
+    },
+    {
+      "name": "TFARC",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(TFARC)$"
+      }
+    },
+    {
+      "name": "TVARCHiV",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(TVARCHiV)$"
+      }
+    },
+    {
+      "name": "TVP",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(TVP)$"
+      }
+    },
+    {
+      "name": "Tylor.D",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(Tylor\\.D)$"
+      }
+    },
+    {
+      "name": "UTOPiA",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(UTOPiA)$"
+      }
+    },
+    {
+      "name": "VideoStar",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(VideoStar)$"
+      }
+    },
+    {
+      "name": "Whistler",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(Whistler)$"
+      }
+    },
+    {
+      "name": "WOTT",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(WOTT)$"
+      }
+    },
+    {
+      "name": "ZaidaNulled",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(ZaidaNulled)$"
       }
     }
   ]

--- a/docs/json/radarr/cf/german-web-tier-01.json
+++ b/docs/json/radarr/cf/german-web-tier-01.json
@@ -7,39 +7,39 @@
   "includeCustomFormatWhenRenaming": false,
   "specifications": [
     {
-      "name": "ZeroTwo",
+      "name": "CNY",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,
       "required": false,
       "fields": {
-        "value": "^(ZeroTwo)$"
+        "value": "^(CNY)$"
       }
     },
     {
-      "name": "ZeroTwo Aliases",
+      "name": "D02KU",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,
       "required": false,
       "fields": {
-        "value": "\\b(BUTTERCUP|HARTZ02|XiSS|DOGPACK404|PRiNCESSDiANA|DiVA|WAREZCX|BiTCHNUGGET)\\b"
+        "value": "^(D02KU)$"
       }
     },
     {
-      "name": "TSCC",
+      "name": "KOMET",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,
       "required": false,
       "fields": {
-        "value": "^(TSCC)$"
+        "value": "^(KOMET)$"
       }
     },
     {
-      "name": "TvR",
+      "name": "MEDiATHEK",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,
       "required": false,
       "fields": {
-        "value": "^(TvR)$"
+        "value": "^(MEDiATHEK)$"
       }
     },
     {
@@ -52,21 +52,12 @@
       }
     },
     {
-      "name": "TVS",
+      "name": "pmHD",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,
       "required": false,
       "fields": {
-        "value": "^(TVS)$"
-      }
-    },
-    {
-      "name": "D02KU",
-      "implementation": "ReleaseGroupSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "^(D02KU)$"
+        "value": "^(pmHD)$"
       }
     },
     {
@@ -88,33 +79,6 @@
       }
     },
     {
-      "name": "CNY",
-      "implementation": "ReleaseGroupSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "^(CNY)$"
-      }
-    },
-    {
-      "name": "WeebPinn",
-      "implementation": "ReleaseGroupSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "^(WeebPinn)$"
-      }
-    },
-    {
-      "name": "MEDiATHEK",
-      "implementation": "ReleaseGroupSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "^(MEDiATHEK)$"
-      }
-    },
-    {
       "name": "RiiR",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,
@@ -133,6 +97,42 @@
       }
     },
     {
+      "name": "SLiDE",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(SLiDE)$"
+      }
+    },
+    {
+      "name": "TSCC",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(TSCC)$"
+      }
+    },
+    {
+      "name": "TvR",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(TvR)$"
+      }
+    },
+    {
+      "name": "TVS",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(TVS)$"
+      }
+    },
+    {
       "name": "WalterBishop",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,
@@ -142,30 +142,30 @@
       }
     },
     {
-      "name": "pmHD",
+      "name": "WeebPinn",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,
       "required": false,
       "fields": {
-        "value": "^(pmHD)$"
+        "value": "^(WeebPinn)$"
       }
     },
     {
-      "name": "SLiDE",
+      "name": "ZeroTwo",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,
       "required": false,
       "fields": {
-        "value": "^(SLiDE)$"
+        "value": "^(ZeroTwo)$"
       }
-    },    
+    },
     {
-      "name": "KOMET",
+      "name": "ZeroTwo Aliases",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,
       "required": false,
       "fields": {
-        "value": "^(KOMET)$"
+        "value": "\\b(BUTTERCUP|HARTZ02|XiSS|DOGPACK404|PRiNCESSDiANA|DiVA|WAREZCX|BiTCHNUGGET)\\b"
       }
     },
     {

--- a/docs/json/radarr/cf/german-web-tier-01.json
+++ b/docs/json/radarr/cf/german-web-tier-01.json
@@ -151,6 +151,24 @@
       }
     },
     {
+      "name": "SLiDE",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(SLiDE)$"
+      }
+    },    
+    {
+      "name": "KOMET",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(KOMET)$"
+      }
+    },
+    {
       "name": "WebDL",
       "implementation": "SourceSpecification",
       "negate": false,

--- a/docs/json/radarr/cf/german-web-tier-02.json
+++ b/docs/json/radarr/cf/german-web-tier-02.json
@@ -70,6 +70,15 @@
       }
     },
     {
+      "name": "FLORiX",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(FLORiX)$"
+      }
+    },
+    {
       "name": "WebDL",
       "implementation": "SourceSpecification",
       "negate": false,

--- a/docs/json/radarr/cf/german-web-tier-02.json
+++ b/docs/json/radarr/cf/german-web-tier-02.json
@@ -1,47 +1,11 @@
 {
   "trash_id": "08d120d5a003ec4954b5b255c0691d79",
   "trash_scores": {
-      "default": 1900
+    "default": 1900
   },
   "name": "German Web Tier 02",
   "includeCustomFormatWhenRenaming": false,
   "specifications": [
-    {
-      "name": "VECTOR",
-      "implementation": "ReleaseGroupSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "(VECTOR)$"
-      }
-    },
-    {
-      "name": "MULTiPLEX",
-      "implementation": "ReleaseGroupSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "(MULTiPLEX)$"
-      }
-    },
-    {
-      "name": "SiXTYNiNE",
-      "implementation": "ReleaseGroupSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "(SiXTYNiNE)$"
-      }
-    },
-    {
-      "name": "Oergel",
-      "implementation": "ReleaseGroupSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "(Oergel)$"
-      }
-    },
     {
       "name": "4SF",
       "implementation": "ReleaseGroupSpecification",
@@ -61,6 +25,33 @@
       }
     },
     {
+      "name": "FLORiX",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(FLORiX)$"
+      }
+    },
+    {
+      "name": "MULTiPLEX",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "(MULTiPLEX)$"
+      }
+    },
+    {
+      "name": "Oergel",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "(Oergel)$"
+      }
+    },
+    {
       "name": "paranoid06",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,
@@ -70,12 +61,21 @@
       }
     },
     {
-      "name": "FLORiX",
+      "name": "SiXTYNiNE",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,
       "required": false,
       "fields": {
-        "value": "^(FLORiX)$"
+        "value": "(SiXTYNiNE)$"
+      }
+    },
+    {
+      "name": "VECTOR",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "(VECTOR)$"
       }
     },
     {

--- a/docs/json/sonarr/cf/german-scene.json
+++ b/docs/json/sonarr/cf/german-scene.json
@@ -25,6 +25,15 @@
       }
     },
     {
+      "name": "W4K",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(W4K)$"
+      }
+    },
+    {
       "name": "WOMBAT",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,

--- a/docs/json/sonarr/cf/german-scene.json
+++ b/docs/json/sonarr/cf/german-scene.json
@@ -7,60 +7,6 @@
   "includeCustomFormatWhenRenaming": false,
   "specifications": [
     {
-      "name": "DETAiLS",
-      "implementation": "ReleaseGroupSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "^(DETAiLS)$"
-      }
-    },
-    {
-      "name": "WAYNE",
-      "implementation": "ReleaseGroupSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "^(WAYNE)$"
-      }
-    },
-    {
-      "name": "W4K",
-      "implementation": "ReleaseGroupSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "^(W4K)$"
-      }
-    },
-    {
-      "name": "WOMBAT",
-      "implementation": "ReleaseGroupSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "^(WOMBAT)$"
-      }
-    },
-    {
-      "name": "SAUERKRAUT",
-      "implementation": "ReleaseGroupSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "^(SAUERKRAUT)$"
-      }
-    },
-    {
-      "name": "WvF",
-      "implementation": "ReleaseGroupSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "^(WvF)$"
-      }
-    },
-    {
       "name": "4KCONNECTiON",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,
@@ -70,12 +16,12 @@
       }
     },
     {
-      "name": "STARS",
+      "name": "ACED",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,
       "required": false,
       "fields": {
-        "value": "^(STARS)$"
+        "value": "^(ACED)$"
       }
     },
     {
@@ -88,6 +34,51 @@
       }
     },
     {
+      "name": "bi0hazard",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(bi0hazard)$"
+      }
+    },
+    {
+      "name": "CDD",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(CDD)$"
+      }
+    },
+    {
+      "name": "CDP",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(CDP)$"
+      }
+    },
+    {
+      "name": "CONTRiBUTiON",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(CONTRiBUTiON)$"
+      }
+    },
+    {
+      "name": "DETAiLS",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(DETAiLS)$"
+      }
+    },
+    {
       "name": "DMPD",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,
@@ -97,12 +88,84 @@
       }
     },
     {
+      "name": "ENCOUNTERS",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(ENCOUNTERS)$"
+      }
+    },
+    {
+      "name": "ENDSTATiON",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(ENDSTATiON)$"
+      }
+    },
+    {
+      "name": "euHD",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(euHD)$"
+      }
+    },
+    {
       "name": "EXCiTED",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,
       "required": false,
       "fields": {
         "value": "^(EXCiTED)$"
+      }
+    },
+    {
+      "name": "FENDT",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(FENDT)$"
+      }
+    },
+    {
+      "name": "FKKTV",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(FKKTV)$"
+      }
+    },
+    {
+      "name": "GTVG",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(GTVG)$"
+      }
+    },
+    {
+      "name": "HAXE",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(HAXE)$"
+      }
+    },
+    {
+      "name": "HDARCHiV",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(HDARCHiV)$"
       }
     },
     {
@@ -142,6 +205,69 @@
       }
     },
     {
+      "name": "muhHD",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(muhHD)$"
+      }
+    },
+    {
+      "name": "OCA",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(OCA)$"
+      }
+    },
+    {
+      "name": "OHD",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(OHD)$"
+      }
+    },
+    {
+      "name": "PL3X",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(PL3X)$"
+      }
+    },
+    {
+      "name": "RiLE",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(RiLE)$"
+      }
+    },
+    {
+      "name": "RIPLEY",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(RIPLEY)$"
+      }
+    },
+    {
+      "name": "RSG",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(RSG)$"
+      }
+    },
+    {
       "name": "RUBBiSH",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,
@@ -157,6 +283,24 @@
       "required": false,
       "fields": {
         "value": "^(RWP)$"
+      }
+    },
+    {
+      "name": "SAUERKRAUT",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(SAUERKRAUT)$"
+      }
+    },
+    {
+      "name": "STARS",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(STARS)$"
       }
     },
     {
@@ -178,48 +322,21 @@
       }
     },
     {
-      "name": "HAXE",
+      "name": "TVNATiON",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,
       "required": false,
       "fields": {
-        "value": "^(HAXE)$"
+        "value": "^(TVNATiON)$"
       }
     },
     {
-      "name": "muhHD",
+      "name": "W4K",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,
       "required": false,
       "fields": {
-        "value": "^(muhHD)$"
-      }
-    },
-    {
-      "name": "ENDSTATiON",
-      "implementation": "ReleaseGroupSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "^(ENDSTATiON)$"
-      }
-    },
-    {
-      "name": "HDARCHiV",
-      "implementation": "ReleaseGroupSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "^(HDARCHiV)$"
-      }
-    },
-    {
-      "name": "PL3X",
-      "implementation": "ReleaseGroupSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "^(PL3X)$"
+        "value": "^(W4K)$"
       }
     },
     {
@@ -232,147 +349,30 @@
       }
     },
     {
-      "name": "OHD",
+      "name": "WAYNE",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,
       "required": false,
       "fields": {
-        "value": "^(OHD)$"
+        "value": "^(WAYNE)$"
       }
     },
     {
-      "name": "ENCOUNTERS",
+      "name": "WOMBAT",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,
       "required": false,
       "fields": {
-        "value": "^(ENCOUNTERS)$"
+        "value": "^(WOMBAT)$"
       }
     },
     {
-      "name": "RSG",
+      "name": "WvF",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,
       "required": false,
       "fields": {
-        "value": "^(RSG)$"
-      }
-    },
-    {
-      "name": "TVNATiON",
-      "implementation": "ReleaseGroupSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "^(TVNATiON)$"
-      }
-    },
-    {
-      "name": "FENDT",
-      "implementation": "ReleaseGroupSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "^(FENDT)$"
-      }
-    },
-    {
-      "name": "ACED",
-      "implementation": "ReleaseGroupSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "^(ACED)$"
-      }
-    },
-    {
-      "name": "FKKTV",
-      "implementation": "ReleaseGroupSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "^(FKKTV)$"
-      }
-    },
-    {
-      "name": "euHD",
-      "implementation": "ReleaseGroupSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "^(euHD)$"
-      }
-    },
-    {
-      "name": "OCA",
-      "implementation": "ReleaseGroupSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "^(OCA)$"
-      }
-    },
-    {
-      "name": "RIPLEY",
-      "implementation": "ReleaseGroupSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "^(RIPLEY)$"
-      }
-    },
-    {
-      "name": "GTVG",
-      "implementation": "ReleaseGroupSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "^(GTVG)$"
-      }
-    },
-    {
-      "name": "CDP",
-      "implementation": "ReleaseGroupSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "^(CDP)$"
-      }
-    },
-    {
-      "name": "CDD",
-      "implementation": "ReleaseGroupSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "^(CDD)$"
-      }
-    },
-    {
-      "name": "RiLE",
-      "implementation": "ReleaseGroupSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "^(RiLE)$"
-      }
-    },
-    {
-      "name": "CONTRiBUTiON",
-      "implementation": "ReleaseGroupSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "^(CONTRiBUTiON)$"
-      }
-    },
-    {
-      "name": "bi0hazard",
-      "implementation": "ReleaseGroupSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "^(bi0hazard)$"
+        "value": "^(WvF)$"
       }
     }
   ]

--- a/docs/json/sonarr/cf/german-web-tier-01.json
+++ b/docs/json/sonarr/cf/german-web-tier-01.json
@@ -7,39 +7,30 @@
   "includeCustomFormatWhenRenaming": false,
   "specifications": [
     {
-      "name": "ZeroTwo",
+      "name": "CNY",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,
       "required": false,
       "fields": {
-        "value": "^(ZeroTwo)$"
+        "value": "^(CNY)$"
       }
     },
     {
-      "name": "ZeroTwo Aliases",
+      "name": "KOMET",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,
       "required": false,
       "fields": {
-        "value": "\\b(BUTTERCUP|HARTZ02|XiSS|DOGPACK404|PRiNCESSDiANA|DiVA|D02KU|WAREZCX|BiTCHNUGGET)\\b"
+        "value": "^(KOMET)$"
       }
     },
     {
-      "name": "TSCC",
+      "name": "MEDiATHEK",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,
       "required": false,
       "fields": {
-        "value": "^(TSCC)$"
-      }
-    },
-    {
-      "name": "TvR",
-      "implementation": "ReleaseGroupSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "^(TvR)$"
+        "value": "^(MEDiATHEK)$"
       }
     },
     {
@@ -49,15 +40,6 @@
       "required": false,
       "fields": {
         "value": "^(NIMA4K)$"
-      }
-    },
-    {
-      "name": "TVS",
-      "implementation": "ReleaseGroupSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "^(TVS)$"
       }
     },
     {
@@ -79,33 +61,6 @@
       }
     },
     {
-      "name": "CNY",
-      "implementation": "ReleaseGroupSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "^(CNY)$"
-      }
-    },
-    {
-      "name": "WeebPinn",
-      "implementation": "ReleaseGroupSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "^(WeebPinn)$"
-      }
-    },
-    {
-      "name": "MEDiATHEK",
-      "implementation": "ReleaseGroupSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "^(MEDiATHEK)$"
-      }
-    },
-    {
       "name": "RiiR",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,
@@ -124,15 +79,6 @@
       }
     },
     {
-      "name": "WalterBishop",
-      "implementation": "ReleaseGroupSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "^(WalterBishop)$"
-      }
-    },    
-    {
       "name": "SLiDE",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,
@@ -140,14 +86,68 @@
       "fields": {
         "value": "^(SLiDE)$"
       }
-    },    
+    },
     {
-      "name": "KOMET",
+      "name": "TSCC",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,
       "required": false,
       "fields": {
-        "value": "^(KOMET)$"
+        "value": "^(TSCC)$"
+      }
+    },
+    {
+      "name": "TvR",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(TvR)$"
+      }
+    },
+    {
+      "name": "TVS",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(TVS)$"
+      }
+    },
+    {
+      "name": "WalterBishop",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(WalterBishop)$"
+      }
+    },
+    {
+      "name": "WeebPinn",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(WeebPinn)$"
+      }
+    },
+    {
+      "name": "ZeroTwo",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(ZeroTwo)$"
+      }
+    },
+    {
+      "name": "ZeroTwo Aliases",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(BUTTERCUP|HARTZ02|XiSS|DOGPACK404|PRiNCESSDiANA|DiVA|D02KU|WAREZCX|BiTCHNUGGET)\\b"
       }
     },
     {

--- a/docs/json/sonarr/cf/german-web-tier-01.json
+++ b/docs/json/sonarr/cf/german-web-tier-01.json
@@ -131,6 +131,24 @@
       "fields": {
         "value": "^(WalterBishop)$"
       }
+    },    
+    {
+      "name": "SLiDE",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(SLiDE)$"
+      }
+    },    
+    {
+      "name": "KOMET",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(KOMET)$"
+      }
     },
     {
       "name": "WebDL",

--- a/docs/json/sonarr/cf/german-web-tier-02.json
+++ b/docs/json/sonarr/cf/german-web-tier-02.json
@@ -70,6 +70,15 @@
       }
     },
     {
+      "name": "FLORiX",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(FLORiX)$"
+      }
+    },
+    {
       "name": "WebDL",
       "implementation": "SourceSpecification",
       "negate": false,

--- a/docs/json/sonarr/cf/german-web-tier-02.json
+++ b/docs/json/sonarr/cf/german-web-tier-02.json
@@ -1,47 +1,11 @@
 {
   "trash_id": "f51b96a50b0e6196cb69724b7833d837",
   "trash_scores": {
-      "default": 1900
+    "default": 1900
   },
   "name": "German Web Tier 02",
   "includeCustomFormatWhenRenaming": false,
   "specifications": [
-    {
-      "name": "VECTOR",
-      "implementation": "ReleaseGroupSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "^(VECTOR)$"
-      }
-    },
-    {
-      "name": "MULTiPLEX",
-      "implementation": "ReleaseGroupSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "^(MULTiPLEX)$"
-      }
-    },
-    {
-      "name": "SiXTYNiNE",
-      "implementation": "ReleaseGroupSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "^(SiXTYNiNE)$"
-      }
-    },
-    {
-      "name": "Oergel",
-      "implementation": "ReleaseGroupSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "^(Oergel)$"
-      }
-    },
     {
       "name": "4SF",
       "implementation": "ReleaseGroupSpecification",
@@ -76,6 +40,42 @@
       "required": false,
       "fields": {
         "value": "^(FLORiX)$"
+      }
+    },
+    {
+      "name": "MULTiPLEX",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(MULTiPLEX)$"
+      }
+    },
+    {
+      "name": "Oergel",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(Oergel)$"
+      }
+    },
+    {
+      "name": "SiXTYNiNE",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(SiXTYNiNE)$"
+      }
+    },
+    {
+      "name": "VECTOR",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(VECTOR)$"
       }
     },
     {


### PR DESCRIPTION
# Pull Request

## Purpose

- LQ: PiKACHU (radarr) - missing LD / MD in releasenames
- WEB Tier 01: SLiDE, KOMET (radarr + sonarr)
- WEB Tier 02: FLORiX (radarr + sonarr)
- Scene: W4K (sonarr)

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Add additional German release group handling to Radarr and Sonarr custom formats.

New Features:
- Extend German low-quality Radarr custom format to recognize additional release naming patterns.
- Extend German web tier 01 and 02 Radarr custom formats with new release group patterns.
- Extend German scene Sonarr custom format with additional release group patterns.
- Extend German web tier 01 and 02 Sonarr custom formats to cover new German release groups.