### PR TITLE
chore(misc): add issue type metadata to bug report form

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-error-found-in-the-guide.yml
+++ b/.github/ISSUE_TEMPLATE/bug-error-found-in-the-guide.yml
@@ -1,6 +1,7 @@
 name: Bug/Error Found in the Guide?
 description: Issues are only opened on GitHub by one of the team members after we have confirmed them on our Discord server. Issues raised directly on GitHub will be automatically closed.
 title: "[Bug]"
+type: "Bug"
 labels: ["Type: Bug", "Status: Triage Needed"]
 body:
   - type: checkboxes


### PR DESCRIPTION
Adds the new top-level `type:` key to the Bug/Error issue form so issues opened from it are auto-assigned the org-level **Bug** issue type (Task/Bug/Feature are already defined at the TRaSH-Guides org level).

- `type: "Bug"` added to `bug-error-found-in-the-guide.yml`.
- Existing `labels` retained unchanged (`Type: Bug`, `Status: Triage Needed`).

Ref: [GitHub issue-form `type` key](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms).

## Summary by Sourcery

CI:
- Set the bug/error issue form to use the GitHub issue-form `type: "Bug"` key while retaining existing labels.