### PR TITLE
feat(radarr): Add release group HiDt to UHD Bluray Tier 02

### DIFF
--- a/docs/json/radarr/cf/uhd-bluray-tier-02.json
+++ b/docs/json/radarr/cf/uhd-bluray-tier-02.json
@@ -48,6 +48,15 @@
       }
     },
     {
+      "name": "HiDt",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(HiDt)$"
+      }
+    },
+    {
       "name": "HQMUX",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,


### PR DESCRIPTION
HiDt produces high-quality 2160p UHD Bluray x265 encodes (transparent, lossless audio, baking in FEL when needed) and is already on HD Bluray Tier 02. Added as a `ReleaseGroupSpecification` (`^(HiDt)$`) alongside HQMUX in the UHD Bluray Tier 02 CF.

Closes #2797

## Summary by Sourcery

New Features:
- Add HiDt release group to the Radarr UHD Bluray Tier 02 custom format configuration.