### PR TITLE
feat(radarr): Add release groups FS, SyncUP and CLEANUP to LQ

### DIFF
--- a/docs/json/radarr/cf/lq.json
+++ b/docs/json/radarr/cf/lq.json
@@ -171,6 +171,15 @@
       }
     },
     {
+      "name": "CLEANUP",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(CLEANUP)$"
+      }
+    },
+    {
       "name": "COLLECTiVE",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,
@@ -312,6 +321,15 @@
       "required": false,
       "fields": {
         "value": "^(FRDS)$"
+      }
+    },
+    {
+      "name": "FS",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(FS)$"
       }
     },
     {
@@ -780,6 +798,15 @@
       "required": false,
       "fields": {
         "value": "^(SUNSCREEN)$"
+      }
+    },
+    {
+      "name": "SyncUP",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(SyncUP)$"
       }
     },
     {


### PR DESCRIPTION
Adds three low-quality release groups to the Radarr LQ custom format as `ReleaseGroupSpecification` entries (alphabetically placed):

- **SyncUP** — low-quality pre-releases (TELESYNC/CAM/mislabeled "WEB"/"WEB-DL"), frequently sourced from unknown/CAM sources with the wrong quality in the release title.
- **FS**, **CLEANUP** — likewise low-quality groups (CLEANUP is name-dropped in SyncUP release notes as an affiliated LQ group).

Closes #2798

## Summary by Sourcery

New Features:
- Add FS, SyncUP, and CLEANUP as low-quality release groups in the Radarr LQ custom format configuration.