### PR TITLE
fix(gha): reliable mkdocs macro guard + stop duplicate CI runs

### DIFF
--- a/.github/workflows/custom-format-validation.yml
+++ b/.github/workflows/custom-format-validation.yml
@@ -2,6 +2,7 @@ name: Validate Custom Format JSONs
 
 on:
   push:
+    branches: [master]
     paths:
       - .github/workflows/custom-format-validation.yml
       - docs/json/guide-only/*.json
@@ -19,6 +20,10 @@ on:
       - docs/json/radarr/conflicts.json
       - docs/json/sonarr/conflicts.json
       - schemas/**/*.json
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,6 +2,7 @@ name: Build and Deploy Docs
 
 on:
   push:
+    branches: [master]
 
 permissions:
   contents: read

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,7 +1,6 @@
 name: Label Pull Requests
 
 on:
-  push:
   pull_request_target:
 
 jobs:

--- a/.github/workflows/metadata-validation.yml
+++ b/.github/workflows/metadata-validation.yml
@@ -2,6 +2,7 @@ name: Validate Metadata JSON
 
 on:
   push:
+    branches: [master]
     paths:
       - metadata.json
       - metadata.schema.json
@@ -11,6 +12,10 @@ on:
       - metadata.json
       - metadata.schema.json
       - .github/workflows/metadata-validation.yml
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read

--- a/.github/workflows/mkdocs_bug_prevent.yml
+++ b/.github/workflows/mkdocs_bug_prevent.yml
@@ -2,41 +2,66 @@ name: Check for Mkdocs Issues
 
 on:
   push:
+    branches: [master]
   pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   check-mkdocs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: write
 
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
+          fetch-depth: 0
 
-      - name: Find JSON Files Changed in Commit
+      - name: Find JSON Files Changed
         id: find_json_files
         env:
+          EVENT_NAME: ${{ github.event_name }}
           BEFORE_SHA: ${{ github.event.before }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           CURRENT_SHA: ${{ github.sha }}
         run: |
-          # Get the list of JSON files changed in the commit
-          JSON_FILES=$(git diff --name-only "$BEFORE_SHA" "$CURRENT_SHA" | grep '\.json$' || true)
-          echo "json_files=$JSON_FILES" >> "$GITHUB_ENV"
+          if [[ "$EVENT_NAME" == "pull_request" ]]; then
+            BASE="$PR_BASE_SHA"
+          elif [[ "$BEFORE_SHA" == "0000000000000000000000000000000000000000" ]]; then
+            # First push to branch — no history to diff against; scan all tracked JSON files
+            # shellcheck disable=SC2046
+            JSON_FILES=$(git ls-files '*.json' | tr '\n' ' ')
+            echo "JSON_FILES=${JSON_FILES}" >> "$GITHUB_ENV"
+            exit 0
+          else
+            BASE="$BEFORE_SHA"
+          fi
+          RAW=$(git diff --name-only "$BASE" "$CURRENT_SHA" | grep '\.json$' || true)
+          # Keep only files that still exist (deleted files cannot be scanned)
+          JSON_FILES=""
+          for f in $RAW; do
+            [[ -f "$f" ]] && JSON_FILES="$JSON_FILES $f"
+          done
+          JSON_FILES="${JSON_FILES# }"
+          echo "JSON_FILES=${JSON_FILES}" >> "$GITHUB_ENV"
 
       - name: Check JSON Files for MkDocs Macro Issues
         run: |
           # Check if any JSON files contain the [[ pattern
           if [[ -n "$JSON_FILES" ]]; then
+            # shellcheck disable=SC2086
             if grep -r '\[\[' $JSON_FILES; then
               echo "::error::Found '[[', which breaks MkDocs macros in JSON files:"
+              # shellcheck disable=SC2086
               grep -r -n '\[\[' $JSON_FILES
               exit 1
             else
-              echo "No '[[', patterns found in JSON files."
+              echo "No '[[' patterns found in JSON files."
             fi
           else
             echo "No JSON files changed in this commit."

--- a/.github/workflows/pr-naming-check.yml
+++ b/.github/workflows/pr-naming-check.yml
@@ -4,8 +4,11 @@ on:
   pull_request:
     types: [opened, reopened, edited, synchronize]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
-  issues: write
   pull-requests: write
 
 jobs:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -5,6 +5,10 @@ on:
   push:
     branches: [master]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/quality-profile-validation.yml
+++ b/.github/workflows/quality-profile-validation.yml
@@ -2,6 +2,7 @@ name: Validate Quality Profiles
 
 on:
   push:
+    branches: [master]
     paths:
       - .github/workflows/quality-profile-validation.yml
       - docs/json/radarr/cf/*.json
@@ -25,6 +26,10 @@ on:
       - docs/json/sonarr/quality-profile-groups/**
       - docs/json/sonarr/cf-groups/**
       - scripts/validate-quality-profiles.py
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read


### PR DESCRIPTION
## Purpose

Three hardening fixes to GitHub Actions workflows:

1. **`mkdocs_bug_prevent.yml` silently passed on every run** — two independent bugs: (a) depth-1 checkout meant `BEFORE_SHA` was unreachable so `git diff` always failed silently, and (b) GITHUB_ENV wrote `json_files` (lowercase) while the check step read `$JSON_FILES` (uppercase) — on Linux these are different variables, so the file list was always empty. The check never inspected a single file.
2. **Duplicate CI runs** — `custom-format-validation`, `metadata-validation`, `quality-profile-validation`, and `deploy` ran on every push to every branch, triggering twice on open PRs (once as `push`, once as `pull_request`). `labeler` also ran on bare pushes where it has no function.
3. **Missing concurrency guards** — six PR-triggered workflows had no `cancel-in-progress` group, so a rapid sequence of force-pushes stacked redundant runs.

## Approach

- `mkdocs_bug_prevent`: `fetch-depth: 0` + per-event base-ref selection (`github.event.pull_request.base.sha` for PRs; `github.event.before` for pushes; scan all tracked JSON files on first-push zero-SHA). Env var name made consistent (`JSON_FILES` uppercase throughout). `pull-requests: write` permission dropped (was unused).
- Push triggers scoped to `branches: [master]` on the four validators and `deploy`; `push` removed from `labeler` entirely.
- `concurrency: cancel-in-progress: true` added to `mkdocs_bug_prevent`, `custom-format-validation`, `metadata-validation`, `quality-profile-validation`, `pre-commit`, and `pr-naming-check`. `issues: write` removed from `pr-naming-check` (redundant alongside `pull-requests: write`).
- No new third-party actions introduced. All existing pinned SHAs unchanged.
- `actionlint` passes with zero errors across all workflows.

## Open Questions and Pre-Merge TODOs

<!-- None -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Harden GitHub Actions workflows by making the MkDocs macro guard actually inspect changed JSON files, reducing redundant workflow triggers, and ensuring in-progress runs are cancelled on new pushes.

Bug Fixes:
- Fix the MkDocs JSON macro guard so it correctly computes the diff base, discovers changed JSON files, and skips deleted files across push and pull_request events.

Enhancements:
- Restrict validation and deploy workflows to run only on pushes to master while keeping targeted pull_request triggers for PR validation.
- Add concurrency groups with cancel-in-progress semantics to key PR and push workflows to avoid stacking redundant runs.
- Simplify workflow permissions by removing unused pull-requests and issues write scopes.
- Stop the labeler workflow from running on bare pushes where it has no effect.

Build:
- Adjust workflow checkout depth and event-based logic in mkdocs_bug_prevent to support reliable detection of changed JSON files in CI.