### PR TITLE
feat(starr-german): add SLiDE to german web tier 1

### DIFF
--- a/docs/json/radarr/cf/german-web-tier-01.json
+++ b/docs/json/radarr/cf/german-web-tier-01.json
@@ -169,6 +169,15 @@
       }
     },
     {
+      "name": "SLiDE",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(SLiDE)$"
+      }
+    },
+    {
       "name": "WebDL",
       "implementation": "SourceSpecification",
       "negate": false,

--- a/docs/json/sonarr/cf/german-web-tier-01.json
+++ b/docs/json/sonarr/cf/german-web-tier-01.json
@@ -151,6 +151,15 @@
       }
     },
     {
+      "name": "SLiDE",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(SLiDE)$"
+      }
+    },
+    {
       "name": "WebDL",
       "implementation": "SourceSpecification",
       "negate": false,


### PR DESCRIPTION
# Pull Request

## Purpose

This adds the Release Group `SLiDE` to German Web Tier 1

## Reasoning

See the Discord Thread on UsenetDE `https://discord.com/channels/1204644340882870332/1328003974372130890/threads/1495457534386114730`

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Add the SLiDE release group to the German Web Tier 1 configuration for Radarr and Sonarr.

Enhancements:
- Extend German Web Tier 1 Radarr configuration to include the SLiDE release group.
- Extend German Web Tier 1 Sonarr configuration to include the SLiDE release group.