### PR TITLE
fix(sonarr-anime): Update anime-lq-groups - Regex for RL Ari

### DIFF
--- a/docs/json/sonarr/cf/anime-lq-groups.json
+++ b/docs/json/sonarr/cf/anime-lq-groups.json
@@ -175,7 +175,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "^\[Ari\]|-Ari$"
+        "value": "\^\\[Ari\\]|-Ari\$"
       }
     },
     {

--- a/docs/json/sonarr/cf/anime-lq-groups.json
+++ b/docs/json/sonarr/cf/anime-lq-groups.json
@@ -175,7 +175,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "\^\\[Ari\]|-Ari\$"
+        "value": "\\^\\[Ari\\]|-Ari\\$"
       }
     },
     {

--- a/docs/json/sonarr/cf/anime-lq-groups.json
+++ b/docs/json/sonarr/cf/anime-lq-groups.json
@@ -175,7 +175,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "\\^\\[Ari\\]|-Ari\\$"
+        "value": "^\\[Ari\\]|-Ari$"
       }
     },
     {

--- a/docs/json/sonarr/cf/anime-lq-groups.json
+++ b/docs/json/sonarr/cf/anime-lq-groups.json
@@ -175,7 +175,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "\^\\[Ari\\]|-Ari\$"
+        "value": "\^\\[Ari\]|-Ari\$"
       }
     },
     {

--- a/docs/json/sonarr/cf/anime-lq-groups.json
+++ b/docs/json/sonarr/cf/anime-lq-groups.json
@@ -175,7 +175,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "\\[Ari\\]|-Ari\\b"
+        "value": "^\[Ari\]|-Ari$"
       }
     },
     {


### PR DESCRIPTION
Current regex will match `Ari` in `[SubsPlease] Tai-Ari deshita. Ojousama wa Kakutou Game nante Shinai - 01 (1080p) [4845A1F4]` and tag it as Anime LQ group, changing regex to match RL when it's at the beginning or the end of the string. [Regex101 test case](https://regex101.com/?regex=%5E%5C%5BAri%5C%5D%7C-Ari%24&testString=%5BSubsPlease%5D+Tai-Ari+deshita.+Ojousama+wa+Kakutou+Game+nante+Shinai+-+01+%281080p%29+%5B4845A1F4%5D%0A%5BAri%5D+Tai-Ari+deshita.+Ojousama+wa+Kakutou+Game+nante+Shinai+-+01+%281080p%29+%5B4845A1F4%5D%0ATai-Ari+deshita.+Ojousama+wa+Kakutou+Game+nante+Shinai+-+01+%281080p%29+%5B4845A1F4%5D-Ari&flags=gm&flavor=pcre2&delimiter=%2F)

# Pull Request

## Purpose

Update regex for RL Ari so that it doesn't match the word mid-string and cause inaccurate match

## Approach

Only match when `[Ari]` is at the beginning or `-Ari` at the end of the string

## Open Questions and Pre-Merge TODOs

None

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
