### PR TITLE
feat(starr-anime): Add nekotan to Anime BD Tier 03 and BlackRose to Anime Web Tier 02

### DIFF
--- a/docs/json/radarr/cf/anime-bd-tier-03.json
+++ b/docs/json/radarr/cf/anime-bd-tier-03.json
@@ -178,6 +178,15 @@
       }
     },
     {
+      "name": "nekotan",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(nekotan)\\b"
+      }
+    },
+    {
       "name": "Netaro",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,

--- a/docs/json/radarr/cf/anime-web-tier-02.json
+++ b/docs/json/radarr/cf/anime-web-tier-02.json
@@ -48,7 +48,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "\\b(BlackRose\\b"
+        "value": "\\b(BlackRose)\\b"
       }
     },
     {

--- a/docs/json/radarr/cf/anime-web-tier-02.json
+++ b/docs/json/radarr/cf/anime-web-tier-02.json
@@ -43,6 +43,15 @@
       }
     },
     {
+      "name": "BlackRose",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(BlackRose\\b"
+      }
+    },
+    {
       "name": "Cyan",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,

--- a/docs/json/sonarr/cf/anime-bd-tier-03.json
+++ b/docs/json/sonarr/cf/anime-bd-tier-03.json
@@ -187,6 +187,15 @@
       }
     },
     {
+      "name": "nekotan",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(nekotan)\\b"
+      }
+    },
+    {
       "name": "Netaro",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,

--- a/docs/json/sonarr/cf/anime-web-tier-02.json
+++ b/docs/json/sonarr/cf/anime-web-tier-02.json
@@ -52,6 +52,15 @@
       }
     },
     {
+      "name": "BlackRose",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(BlackRose)\\b"
+      }
+    },
+    {
       "name": "Cyan",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,


### PR DESCRIPTION
# Pull Request

## Purpose
Add nekotan to Anime BD Tier 03. This is a new group, but they have already trumped multiple releases from groups on lower tiers. Keeping in Tier 03 for now until they establish themselves more and because while they have trumped some groups in tier 3, other groups in that tier have the best release over them.

Add BlackRose to Anime Web Tier 02. They are already in Anime BD Tier 02 and do web releases as well now.

<!-- Please provide a detailed description of why you created this pull request. -->

## Approach
Standard anime regex

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Enhancements:
- Update Anime BD Tier 03 JSON configurations to include the nekotan group for Radarr and Sonarr filters.