### PR TITLE
chore(gha): add issue auto-labeler for newly opened issues

### DIFF
--- a/.github/issue-labeler.yml
+++ b/.github/issue-labeler.yml
@@ -1,35 +1,35 @@
 "Status: Triage Needed":
-  - "/.*/"
+  - ".*"
 
 "Type: Guide Request":
-  - "^\\[Request\\]"
+  - "(?i)^\\[Request\\]"
 
 "Type: Bug":
-  - "^\\[Bug\\]"
+  - "(?i)^\\[Bug\\]"
 
 "Area: Radarr":
-  - "\\bradarr\\b"
+  - "(?i)\\bradarr\\b"
 
 "Area: Sonarr":
-  - "\\bsonarr\\b"
+  - "(?i)\\bsonarr\\b"
 
 "Area: Bazarr":
-  - "\\bbazarr\\b"
+  - "(?i)\\bbazarr\\b"
 
 "Area: Prowlarr":
-  - "\\bprowlarr\\b"
+  - "(?i)\\bprowlarr\\b"
 
 "Area: Recyclarr":
-  - "\\brecyclarr\\b"
+  - "(?i)\\brecyclarr\\b"
 
 "Area: Synology":
-  - "\\bsynology\\b"
+  - "(?i)\\bsynology\\b"
 
 "Area: Plex":
-  - "\\bplex\\b"
+  - "(?i)\\bplex\\b"
 
 "Area: Downloaders":
-  - "\\b(qbittorrent|sabnzbd|nzbget|deluge|transmission|downloaders?)\\b"
+  - "(?i)\\b(qbittorrent|sabnzbd|nzbget|deluge|transmission|downloaders?)\\b"
 
 "Area: Anime":
-  - "\\banime\\b"
+  - "(?i)\\banime\\b"

--- a/.github/issue-labeler.yml
+++ b/.github/issue-labeler.yml
@@ -1,0 +1,35 @@
+"Status: Triage Needed":
+  - "/.*/"
+
+"Type: Guide Request":
+  - "^\\[Request\\]"
+
+"Type: Bug":
+  - "^\\[Bug\\]"
+
+"Area: Radarr":
+  - "\\bradarr\\b"
+
+"Area: Sonarr":
+  - "\\bsonarr\\b"
+
+"Area: Bazarr":
+  - "\\bbazarr\\b"
+
+"Area: Prowlarr":
+  - "\\bprowlarr\\b"
+
+"Area: Recyclarr":
+  - "\\brecyclarr\\b"
+
+"Area: Synology":
+  - "\\bsynology\\b"
+
+"Area: Plex":
+  - "\\bplex\\b"
+
+"Area: Downloaders":
+  - "\\b(qbittorrent|sabnzbd|nzbget|deluge|transmission|downloaders?)\\b"
+
+"Area: Anime":
+  - "\\banime\\b"

--- a/.github/workflows/issue-labeler.yml
+++ b/.github/workflows/issue-labeler.yml
@@ -1,0 +1,23 @@
+name: Label Issues
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Issue Labeler
+        uses: github/issue-labeler@c1b0f9f52a63158c4adc09425e858e87b32e9685  # v3.4
+        with:
+          configuration-path: .github/issue-labeler.yml
+          enable-versioned-regex: "0"
+          include-title: "1"
+          include-body: "1"
+          sync-labels: "0"
+          repo-token: ${{ github.token }}


### PR DESCRIPTION
## Summary

- Adds an issue-side counterpart to the existing PR labeler (`.github/workflows/labeler.yml`), using [`github/issue-labeler`](https://github.com/github/issue-labeler) instead of `actions/labeler` since PR labeling is path-based (`changed-files`) while issue labeling has no file diff to key off — it needs title/body regex matching instead.
- Triggers on `issues: [opened]` only.
- Matches against issue title + body:
  - `Area: Radarr` / `Area: Sonarr` / `Area: Bazarr` / `Area: Prowlarr` / `Area: Recyclarr` / `Area: Synology` / `Area: Plex` / `Area: Anime` — keyword regex (`\bradarr\b`, etc.)
  - `Area: Downloaders` — qBittorrent/SABnzbd/NZBGet/Deluge/transmission keywords
  - `Type: Guide Request` / `Type: Bug` — title starting with `[Request]` / `[Bug]` (existing convention visible across historical issue titles)
  - `Status: Triage Needed` — applied unconditionally to every new issue
- No new labels invented; all 12 labels used already exist in the repo's label taxonomy (confirmed via `gh label list`). No `Area: Lidarr` label exists yet, so no Lidarr rule was added.
- Action pinned to the `v3.4` release SHA with a version comment, matching this repo's existing pinning convention.
- `sync-labels: "0"` — matches on `opened` only, so there's no re-evaluation to sync against; kept off to avoid ever stripping a label a maintainer manually adds seconds after creation.

Note: the repo's only remaining issue template (`bug-error-found-in-the-guide.yml`) already self-labels `Type: Bug` + `Status: Triage Needed` at creation. This labeler covers the common case of issues opened directly by maintainers off Discord-confirmed reports, which don't go through that template and currently get zero automatic labels.

## Test plan

- [x] `.github/issue-labeler.yml` and `.github/workflows/issue-labeler.yml` pass `pre-commit run` (yamllint, editorconfig-checker, zizmor all green)
- [x] Regex patterns cross-checked against real issue titles/labels in this repo's history (e.g. `Area: Sonarr`/`Area: Radarr` on #2809, `Area: Prowlarr` on #1378, `Area: Downloaders` on #2692 all match keyword occurrences)
- [ ] Merge and confirm on the next real issue open that labels land as expected

## Summary by Sourcery

Add an automated issue labeling workflow that applies existing area, type, and triage labels to newly opened issues based on their title and body.

New Features:
- Introduce issue label configuration mapping existing labels to regex-based title/body patterns for common areas and issue types.
- Add a GitHub Actions workflow that runs on newly opened issues to apply labels using the configured patterns.

CI:
- Create a GitHub Actions issue labeler workflow with scoped permissions and pinned action version for deterministic labeling behavior.