### PR TITLE
feat(sonarr): Update Why only WEB-DL FAQ with remux setup guidance

### DIFF
--- a/.cursor/rules/agents.mdc
+++ b/.cursor/rules/agents.mdc
@@ -1,0 +1,6 @@
+---
+description: Repository AI agent instructions
+alwaysApply: true
+---
+
+Follow all instructions in `AGENTS.md` when working in this repository. Claude should also read `CLAUDE.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,45 @@
+# AI Agent Instructions
+
+Instructions for AI assistants working in this repository. This is the canonical source for all AI tools. Entry points: [CLAUDE.md](CLAUDE.md) (Claude), [.cursor/rules/agents.mdc](.cursor/rules/agents.mdc) (Cursor).
+
+## Writing style
+
+If an em-dash would normally appear, use a comma, hyphen, or period instead, even if it is not the perfect use of punctuation.
+
+## Pull requests
+
+When opening a pull request:
+
+1. Follow [CONTRIBUTING.md](CONTRIBUTING.md) for branch naming, PR naming, and change requirements.
+2. Use the PR title format: `type(guide-category): short detailed description` (example: `feat(sonarr): Update Why only WEB-DL FAQ with remux setup guidance`).
+3. Fill out the full PR body using [.github/PULL_REQUEST_TEMPLATE.md](.github/PULL_REQUEST_TEMPLATE.md):
+    - **Purpose**
+    - **Approach**
+    - **Open Questions and Pre-Merge TODOs**
+    - **Requirements** (check both boxes when applicable)
+4. Open as a **draft** if the work is incomplete or not ready for review.
+5. Add an **AI disclosure** section at the end of the PR body:
+
+```markdown
+## AI disclosure
+
+This pull request was created with AI assistance.
+```
+
+## GitHub issues
+
+When opening a GitHub issue:
+
+1. Follow repository policy in [.github/ISSUE_TEMPLATE/config.yml](.github/ISSUE_TEMPLATE/config.yml). Bug reports are normally confirmed on [Discord](https://trash-guides.info/discord) first and opened on GitHub by the team. Do not open bug issues directly unless a maintainer has asked you to.
+2. If an issue is appropriate, use [.github/ISSUE_TEMPLATE/bug-error-found-in-the-guide.yml](.github/ISSUE_TEMPLATE/bug-error-found-in-the-guide.yml) and complete every required field.
+3. Add an **AI disclosure** section at the end of the issue body:
+
+```markdown
+## AI disclosure
+
+This issue was created with AI assistance.
+```
+
+## AI disclosure
+
+Always disclose AI involvement in pull requests and GitHub issues opened on behalf of a user. Do not omit or obscure AI assistance.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+# Claude Instructions
+
+Instructions for Claude when working in this repository.
+
+Read and follow every instruction in [AGENTS.md](AGENTS.md). That file is the canonical source for all AI assistants, including Claude.

--- a/docs/Sonarr/sonarr-setup-quality-profiles.md
+++ b/docs/Sonarr/sonarr-setup-quality-profiles.md
@@ -195,7 +195,24 @@ The following custom format groups should be combined with the Quality Profiles 
 
 ??? question "Why do you only have Profiles for WEB-DL - [Click to show/hide]"
 
-    We only do WEB-DL, myself, for TV shows. In our opinion, WEB-DL is the sweet spot between quality and size (you often don't see big differences anyway for TV shows) except for shows like GOT, Vikings, etc.
+    **Why we focus on WEB-DL**
+
+    Most TV shows today debut on streaming services, and many never receive a physical release at all. WEB-DL is usually the best source available, and often the only one.
+
+    TV remuxes also come with a steep storage cost. A season can easily consume hundreds of gigabytes, and larger shows can approach a terabyte. With drive prices where they are, that adds up fast for content where the quality difference over WEB-DL is often hard to notice.
+
+    There isn't much community interest in TV remux profiles either, so we haven't invested time in creating one.
+
+    **How to enable remux on a WEB profile**
+
+    If you prefer remuxes, you can adapt [`WEB-2160p (Alternative)`](/Sonarr/sonarr-setup-quality-profiles/#web-2160p-alternative-quality-profile){:target="_blank" rel="noopener noreferrer"}, the variant above that includes 720p/1080p/2160p WEB and Bluray sources as fallbacks. That profile is built around WEB-DL as the cutoff, so enabling remux takes a few extra steps:
+
+    1. Enable `Bluray-1080p Remux` and `Bluray-2160p Remux`.
+    1. Move both remux qualities above `WEB 2160p`, with `Bluray-2160p Remux` at the top, since quality rank beats custom format score.
+    1. Change **Upgrade Until** from `WEB 2160p` to `Bluray-2160p Remux`; otherwise Sonarr stops at WEB and will not upgrade to remux.
+    1. [Merge](/Sonarr/Tips/Merge-quality/){:target="_blank" rel="noopener noreferrer"} remux with the matching WEB qualities (e.g. `Bluray-2160p Remux` + `WEBDL-2160p` / `WEBRip-2160p`) so upgrades between them work cleanly.
+
+    Keep the existing custom formats; lower qualities in the Alternative profile remain useful as fallbacks when no remux exists. This is still a WEB-focused profile with no dedicated remux release-group scoring, and `Audio Formats` custom formats are not used here. For most TV shows, no remux will exist anyway.
 
 ### Why prefer P2P groups
 


### PR DESCRIPTION
# Pull Request

## Purpose

Update the "Why only WEB-DL" FAQ on the Sonarr quality profiles guide with current reasoning around streaming availability, storage costs, and practical remux setup guidance.

## Approach

Rewrote the FAQ answer in `docs/Sonarr/sonarr-setup-quality-profiles.md` to explain:

- Why WEB-DL is the practical default for modern TV (streaming-first releases)
- Why TV remuxes are a poor fit for most users (storage footprint vs. quality gains)
- How to enable remux on a WEB profile (quality order, cutoff, merging) when remux is preferred

## Open Questions and Pre-Merge TODOs

N/A

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Documentation:
- Revise the "Why only WEB-DL" FAQ answer to explain modern streaming-first releases, storage trade-offs for TV remuxes, and how to configure profiles when preferring remux.