### PR TITLE
feat/guide-sync-created-sonarr-remux-profiles

### DIFF
--- a/docs/json/sonarr/quality-profiles/remux-2160p-combined.json
+++ b/docs/json/sonarr/quality-profiles/remux-2160p-combined.json
@@ -1,8 +1,8 @@
 {
   "trash_id": "c4cadd6b35b95f62c3d47a408e53e2f7",
   "name": "Remux + Web 2160p (Combined)",
-  "trash_description": "Quality Profile that covers:<br>- WEBDL: 1080p, 2160p",
-  "group": 99,
+  "trash_description": "Quality Profile that covers:<br>- WEBDL: 1080p, 2160p<br>- Bluray: 1080p, 2160p<br>- Remux: 1080p, 2160p",
+  "group": 2,
   "upgradeAllowed": true,
   "cutoff": "Bluray-2160p Remux",
   "minFormatScore": 0,

--- a/docs/json/sonarr/quality-profiles/remux-2160p-combined.json
+++ b/docs/json/sonarr/quality-profiles/remux-2160p-combined.json
@@ -1,0 +1,58 @@
+{
+  "trash_id": "c4cadd6b35b95f62c3d47a408e53e2f7",
+  "name": "Remux + Web 2160p (Combined)",
+  "trash_description": "Quality Profile that covers:<br>- WEBDL: 1080p, 2160p",
+  "group": 99,
+  "upgradeAllowed": true,
+  "cutoff": "Bluray-2160p Remux",
+  "minFormatScore": 0,
+  "cutoffFormatScore": 10000,
+  "minUpgradeFormatScore": 1,
+  "items": [
+    { "name": "Bluray-2160p Remux", "allowed": true },
+    {
+      "name": "WEB 2160p",
+      "allowed": true,
+      "items": ["WEBRip-2160p", "WEBDL-2160p"]
+    },
+    { "name": "Bluray-1080p Remux", "allowed": true },
+    {
+      "name": "WEB 1080p",
+      "allowed": true,
+      "items": ["WEBRip-1080p", "WEBDL-1080p"]
+    },
+    { "name": "Bluray-2160p", "allowed": false },
+    { "name": "HDTV-2160p", "allowed": false },
+    { "name": "Bluray-1080p", "allowed": false },
+    { "name": "Bluray-720p", "allowed": false },
+    {
+      "name": "WEB 720p",
+      "allowed": false,
+      "items": ["WEBRip-720p", "WEBDL-720p"]
+    },
+    { "name": "Raw-HD", "allowed": false },
+    { "name": "HDTV-1080p", "allowed": false },
+    { "name": "HDTV-720p", "allowed": false },
+    { "name": "Bluray-576p", "allowed": false },
+    { "name": "Bluray-480p", "allowed": false },
+    { "name": "DVD", "allowed": false },
+    {
+      "name": "WEB 480p",
+      "allowed": false,
+      "items": ["WEBRip-480p", "WEBDL-480p"]
+    },
+    { "name": "SDTV", "allowed": false },
+    { "name": "Unknown", "allowed": false }
+  ],
+  "formatItems": {
+    "Remux Tier 01": "9965a052eb87b0d10313b1cea89eb451",
+    "Remux Tier 02": "8a1d0c3d7497e741736761a1da866a2e",
+    "WEB Tier 01": "e6258996055b9fbab7e9cb2f75819294",
+    "WEB Tier 02": "58790d4e2fdcd9733aa7ae68ba2bb503",
+    "WEB Scene": "d0c516558625b04b363fa6c5c2c7cfd4",
+    "WEB Tier 03": "d84935abd3f8556dcd51d4f27e22d0a6",
+    "Repack3": "44e7c4de10ae50265753082e5dc76047",
+    "Repack2": "eb3d5cc0a2be0db205fb823640db6a3c",
+    "Repack/Proper": "ec8fa7296b64e8cd390a1600981f3923"
+  }
+}

--- a/docs/json/sonarr/quality-profiles/remux-web-1080p.json
+++ b/docs/json/sonarr/quality-profiles/remux-web-1080p.json
@@ -1,0 +1,58 @@
+{
+  "trash_id": "72dae194fc92bf828f32cde7744e51a1",
+  "name": "Remux + WEB 1080p",
+  "trash_description": "Quality Profile that covers:<br>- WEBDL: 1080p<br>- Remux: 1080p",
+  "group": 1,
+  "upgradeAllowed": true,
+  "cutoff": "Bluray-2160p Remux",
+  "minFormatScore": 0,
+  "cutoffFormatScore": 10000,
+  "minUpgradeFormatScore": 1,
+  "items": [
+    { "name": "Bluray-2160p Remux", "allowed": true },
+    { "name": "Bluray-2160p", "allowed": true },
+    {
+      "name": "WEBDL-2160p | WEBRip-2160p",
+      "allowed": true,
+      "items": ["WEBDL-2160p", "WEBRip-2160p"]
+    },
+    { "name": "HDTV-2160p", "allowed": true },
+    { "name": "Bluray-1080p Remux", "allowed": true },
+    { "name": "Bluray-1080p", "allowed": true },
+    {
+      "name": "WEBDL-1080p | WEBRip-1080p",
+      "allowed": true,
+      "items": ["WEBDL-1080p", "WEBRip-1080p"]
+    },
+    { "name": "Bluray-720p", "allowed": true },
+    {
+      "name": "WEBDL-720p | WEBRip-720p",
+      "allowed": true,
+      "items": ["WEBDL-720p", "WEBRip-720p"]
+    },
+    { "name": "Raw-HD", "allowed": false },
+    { "name": "HDTV-1080p", "allowed": true },
+    { "name": "HDTV-720p", "allowed": true },
+    { "name": "Bluray-576p", "allowed": true },
+    { "name": "Bluray-480p", "allowed": true },
+    { "name": "DVD", "allowed": false },
+    {
+      "name": "WEBDL-480p | WEBRip-480p",
+      "allowed": true,
+      "items": ["WEBDL-480p", "WEBRip-480p"]
+    },
+    { "name": "SDTV", "allowed": true },
+    { "name": "Unknown", "allowed": false }
+  ],
+  "formatItems": {
+    "Remux Tier 01": "9965a052eb87b0d10313b1cea89eb451",
+    "Remux Tier 02": "8a1d0c3d7497e741736761a1da866a2e",
+    "WEB Tier 01": "e6258996055b9fbab7e9cb2f75819294",
+    "WEB Tier 02": "58790d4e2fdcd9733aa7ae68ba2bb503",
+    "WEB Scene": "d0c516558625b04b363fa6c5c2c7cfd4",
+    "WEB Tier 03": "d84935abd3f8556dcd51d4f27e22d0a6",
+    "Repack3": "44e7c4de10ae50265753082e5dc76047",
+    "Repack2": "eb3d5cc0a2be0db205fb823640db6a3c",
+    "Repack/Proper": "ec8fa7296b64e8cd390a1600981f3923"
+  }
+}

--- a/docs/json/sonarr/quality-profiles/remux-web-2160p.json
+++ b/docs/json/sonarr/quality-profiles/remux-web-2160p.json
@@ -1,0 +1,58 @@
+{
+  "trash_id": "d1498e7d189fbe6c7110ceaabb7473e6",
+  "name": "Remux + WEB 2160p",
+  "trash_description": "Quality Profile that covers:<br>- WEBDL: 2160p<br>- Remux: 2160p",
+  "group": 1,
+  "upgradeAllowed": true,
+  "cutoff": "Bluray-2160p Remux",
+  "minFormatScore": 0,
+  "cutoffFormatScore": 10000,
+  "minUpgradeFormatScore": 1,
+  "items": [
+    { "name": "Bluray-2160p Remux", "allowed": true },
+    {
+      "name": "WEB 2160p",
+      "allowed": true,
+      "items": ["WEBRip-2160p", "WEBDL-2160p"]
+    },
+    { "name": "Bluray-2160p", "allowed": false },
+    { "name": "HDTV-2160p", "allowed": false },
+    { "name": "Bluray-1080p Remux", "allowed": false },
+    { "name": "Bluray-1080p", "allowed": false },
+    {
+      "name": "WEB 1080p",
+      "allowed": false,
+      "items": ["WEBRip-1080p", "WEBDL-1080p"]
+    },
+    { "name": "Bluray-720p", "allowed": false },
+    {
+      "name": "WEB 720p",
+      "allowed": false,
+      "items": ["WEBRip-720p", "WEBDL-720p"]
+    },
+    { "name": "Raw-HD", "allowed": false },
+    { "name": "HDTV-1080p", "allowed": false },
+    { "name": "HDTV-720p", "allowed": false },
+    { "name": "Bluray-576p", "allowed": false },
+    { "name": "Bluray-480p", "allowed": false },
+    { "name": "DVD", "allowed": false },
+    {
+      "name": "WEB 480p",
+      "allowed": false,
+      "items": ["WEBRip-480p", "WEBDL-480p"]
+    },
+    { "name": "SDTV", "allowed": false },
+    { "name": "Unknown", "allowed": false }
+  ],
+  "formatItems": {
+    "Remux Tier 01": "9965a052eb87b0d10313b1cea89eb451",
+    "Remux Tier 02": "8a1d0c3d7497e741736761a1da866a2e",
+    "WEB Tier 01": "e6258996055b9fbab7e9cb2f75819294",
+    "WEB Tier 02": "58790d4e2fdcd9733aa7ae68ba2bb503",
+    "WEB Scene": "d0c516558625b04b363fa6c5c2c7cfd4",
+    "WEB Tier 03": "d84935abd3f8556dcd51d4f27e22d0a6",
+    "Repack3": "44e7c4de10ae50265753082e5dc76047",
+    "Repack2": "eb3d5cc0a2be0db205fb823640db6a3c",
+    "Repack/Proper": "ec8fa7296b64e8cd390a1600981f3923"
+  }
+}


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- To create remux profiles in sonarr for guide sync applications. -->
To create remux profiles in sonarr for guide sync applications.

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

## Open Questions and Pre-Merge TODOs

<!-- - [ X] Use GitHub checklists. When solved, check the box and explain the answer. -->

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [X ] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [ X] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Add new Sonarr remux quality profiles for guide sync usage.

New Features:
- Introduce a remux 2160p combined Sonarr quality profile JSON definition.
- Add a remux WEB 1080p Sonarr quality profile JSON definition.
- Add a remux WEB 2160p Sonarr quality profile JSON definition.