### PR TITLE
feat(guide-sync): Created Sonarr Remux Profiles

### DIFF
--- a/docs/json/radarr/quality-profiles/remux-web-1080p.json
+++ b/docs/json/radarr/quality-profiles/remux-web-1080p.json
@@ -1,5 +1,5 @@
 {
-  "trash_id": "9ca12ea80aa55ef916e3751f4b874151",
+  "trash_id": "fe9470e577c300a5ad9a3274f6d1cdf2",
   "name": "Remux + WEB 1080p",
   "trash_description": "Quality Profile that covers:<br>- WEBDL: 1080p<br>- Remux: 1080p",
   "trash_url": "https://trash-guides.info/Radarr/radarr-setup-quality-profiles/#remux-web-1080p",

--- a/docs/json/radarr/quality-profiles/remux-web-2160p.json
+++ b/docs/json/radarr/quality-profiles/remux-web-2160p.json
@@ -1,5 +1,5 @@
 {
-  "trash_id": "fd161a61e3ab826d3a22d53f935696dd",
+  "trash_id": "76a5053bdb2d1e4a8f16a69a37d46c12",
   "name": "Remux + WEB 2160p",
   "trash_description": "Quality Profile that covers:<br>- WEBDL: 2160p<br>- Remux: 2160p",
   "trash_url": "https://trash-guides.info/Radarr/radarr-setup-quality-profiles/#remux-web-2160p",

--- a/docs/json/sonarr/quality-profile-groups/groups.json
+++ b/docs/json/sonarr/quality-profile-groups/groups.json
@@ -6,7 +6,10 @@
       "web-1080p-alternative": "9d142234e45d6143785ac55f5a9e8dc9",
       "web-2160p-combined": "c4cadd6b35b95f62c3d47a408e53e2f7",
       "web-2160p": "d1498e7d189fbe6c7110ceaabb7473e6",
-      "web-2160p-alternative": "dfa5eaae7894077ad6449169b6eb03e0"
+      "web-2160p-alternative": "dfa5eaae7894077ad6449169b6eb03e0",
+      "remux-web-1080p": "fe9470e577c300a5ad9a3274f6d1cdf2",
+      "remux-web-2160p": "76a5053bdb2d1e4a8f16a69a37d46c12",
+      "remux-2160p-combined": "911df0e05a395c19d8b3efc76a7467c1"
     }
   },
   {

--- a/docs/json/sonarr/quality-profiles/remux-2160p-alternative.json
+++ b/docs/json/sonarr/quality-profiles/remux-2160p-alternative.json
@@ -1,0 +1,58 @@
+{
+  "trash_id": "361717d531db5a6002e0f547ace46551",
+  "name": "Remux 2160p (Alternative)",
+  "trash_description": "Quality Profile that covers:<br>- HDTV 720p, 1080p<br>- WEBDL: 480p, 720, 1080p, 2160p<br>- Bluray 480p, 576p, 720p, 1080p, 2160p<br>- Remux: 1080p, 2160p",
+  "group": 2,
+  "upgradeAllowed": true,
+  "cutoff": "Bluray-2160p Remux",
+  "minFormatScore": 0,
+  "cutoffFormatScore": 10000,
+  "minUpgradeFormatScore": 1,
+  "items": [
+    { "name": "Bluray-2160p Remux", "allowed": true },
+    {
+      "name": "WEB 2160p",
+      "allowed": true,
+      "items": ["WEBRip-2160p", "WEBDL-2160p"]
+    },
+    { "name": "Bluray-2160p", "allowed": true },
+    { "name": "Bluray-1080p Remux", "allowed": true },
+    {
+      "name": "WEB 1080p",
+      "allowed": true,
+      "items": ["WEBRip-1080p", "WEBDL-1080p"]
+    },
+    { "name": "Bluray-1080p", "allowed": true },
+    { "name": "HDTV-1080p", "allowed": true },
+    {
+      "name": "WEB 720p",
+      "allowed": true,
+      "items": ["WEBRip-720p", "WEBDL-720p"]
+    },
+    { "name": "Bluray-720p", "allowed": true },
+    { "name": "HDTV-720p", "allowed": true },
+    { "name": "Bluray-576p", "allowed": false },
+    {
+      "name": "WEB 480p",
+      "allowed": false,
+      "items": ["WEBRip-480p", "WEBDL-480p"]
+    },
+    { "name": "Bluray-480p", "allowed": false },
+    { "name": "DVD", "allowed": false },
+    { "name": "SDTV", "allowed": false },
+    { "name": "HDTV-2160p", "allowed": false },
+    { "name": "Raw-HD", "allowed": false },
+    { "name": "Unknown", "allowed": false }
+  ],
+  "formatItems": {
+    "Remux Tier 01": "9965a052eb87b0d10313b1cea89eb451",
+    "Remux Tier 02": "8a1d0c3d7497e741736761a1da866a2e",
+    "WEB Tier 01": "e6258996055b9fbab7e9cb2f75819294",
+    "WEB Tier 02": "58790d4e2fdcd9733aa7ae68ba2bb503",
+    "WEB Scene": "d0c516558625b04b363fa6c5c2c7cfd4",
+    "WEB Tier 03": "d84935abd3f8556dcd51d4f27e22d0a6",
+    "Repack3": "44e7c4de10ae50265753082e5dc76047",
+    "Repack2": "eb3d5cc0a2be0db205fb823640db6a3c",
+    "Repack/Proper": "ec8fa7296b64e8cd390a1600981f3923"
+  }
+}

--- a/docs/json/sonarr/quality-profiles/remux-2160p-combined.json
+++ b/docs/json/sonarr/quality-profiles/remux-2160p-combined.json
@@ -1,0 +1,58 @@
+{
+  "trash_id": "911df0e05a395c19d8b3efc76a7467c1",
+  "name": "Remux 2160p (Combined)",
+  "trash_description": "Quality Profile that covers:<br>- WEBDL: 1080p, 2160p<br>- Remux: 1080p, 2160p",
+  "group": 99,
+  "upgradeAllowed": true,
+  "cutoff": "Bluray-2160p Remux",
+  "minFormatScore": 0,
+  "cutoffFormatScore": 10000,
+  "minUpgradeFormatScore": 1,
+  "items": [
+    { "name": "Bluray-2160p Remux", "allowed": true },
+    {
+      "name": "WEB 2160p",
+      "allowed": true,
+      "items": ["WEBRip-2160p", "WEBDL-2160p"]
+    },
+    { "name": "Bluray-1080p Remux", "allowed": true },
+    {
+      "name": "WEB 1080p",
+      "allowed": true,
+      "items": ["WEBRip-1080p", "WEBDL-1080p"]
+    },
+    { "name": "Bluray-2160p", "allowed": false },
+    { "name": "HDTV-2160p", "allowed": false },
+    { "name": "Bluray-1080p", "allowed": false },
+    { "name": "Bluray-720p", "allowed": false },
+    {
+      "name": "WEB 720p",
+      "allowed": false,
+      "items": ["WEBRip-720p", "WEBDL-720p"]
+    },
+    { "name": "Raw-HD", "allowed": false },
+    { "name": "HDTV-1080p", "allowed": false },
+    { "name": "HDTV-720p", "allowed": false },
+    { "name": "Bluray-576p", "allowed": false },
+    { "name": "Bluray-480p", "allowed": false },
+    { "name": "DVD", "allowed": false },
+    {
+      "name": "WEB 480p",
+      "allowed": false,
+      "items": ["WEBRip-480p", "WEBDL-480p"]
+    },
+    { "name": "SDTV", "allowed": false },
+    { "name": "Unknown", "allowed": false }
+  ],
+  "formatItems": {
+    "Remux Tier 01": "9965a052eb87b0d10313b1cea89eb451",
+    "Remux Tier 02": "8a1d0c3d7497e741736761a1da866a2e",
+    "WEB Tier 01": "e6258996055b9fbab7e9cb2f75819294",
+    "WEB Tier 02": "58790d4e2fdcd9733aa7ae68ba2bb503",
+    "WEB Scene": "d0c516558625b04b363fa6c5c2c7cfd4",
+    "WEB Tier 03": "d84935abd3f8556dcd51d4f27e22d0a6",
+    "Repack3": "44e7c4de10ae50265753082e5dc76047",
+    "Repack2": "eb3d5cc0a2be0db205fb823640db6a3c",
+    "Repack/Proper": "ec8fa7296b64e8cd390a1600981f3923"
+  }
+}

--- a/docs/json/sonarr/quality-profiles/remux-2160p-combined.json
+++ b/docs/json/sonarr/quality-profiles/remux-2160p-combined.json
@@ -2,7 +2,7 @@
   "trash_id": "911df0e05a395c19d8b3efc76a7467c1",
   "name": "Remux 2160p (Combined)",
   "trash_description": "Quality Profile that covers:<br>- WEBDL: 1080p, 2160p<br>- Remux: 1080p, 2160p",
-  "group": 99,
+  "group": 2,
   "upgradeAllowed": true,
   "cutoff": "Bluray-2160p Remux",
   "minFormatScore": 0,

--- a/docs/json/sonarr/quality-profiles/remux-web-1080p.json
+++ b/docs/json/sonarr/quality-profiles/remux-web-1080p.json
@@ -2,7 +2,7 @@
   "trash_id": "fe9470e577c300a5ad9a3274f6d1cdf2",
   "name": "Remux + WEB 1080p",
   "trash_description": "Quality Profile that covers:<br>- WEBDL: 1080p<br>- Remux: 1080p",
-  "group": 99,
+  "group": 1,
   "upgradeAllowed": true,
   "cutoff": "Bluray-1080p Remux",
   "minFormatScore": 0,

--- a/docs/json/sonarr/quality-profiles/remux-web-1080p.json
+++ b/docs/json/sonarr/quality-profiles/remux-web-1080p.json
@@ -1,0 +1,58 @@
+{
+  "trash_id": "fe9470e577c300a5ad9a3274f6d1cdf2",
+  "name": "Remux + WEB 1080p",
+  "trash_description": "Quality Profile that covers:<br>- WEBDL: 1080p<br>- Remux: 1080p",
+  "group": 99,
+  "upgradeAllowed": true,
+  "cutoff": "Bluray-1080p Remux",
+  "minFormatScore": 0,
+  "cutoffFormatScore": 10000,
+  "minUpgradeFormatScore": 1,
+  "items": [
+    { "name": "Bluray-1080p Remux", "allowed": true },
+    {
+      "name": "WEB 1080p",
+      "allowed": true,
+      "items": ["WEBRip-1080p", "WEBDL-1080p"]
+    },
+    { "name": "Bluray-2160p Remux", "allowed": false },
+    { "name": "Bluray-2160p", "allowed": false },
+    {
+      "name": "WEB 2160p",
+      "allowed": false,
+      "items": ["WEBRip-2160p", "WEBDL-2160p"]
+    },
+    { "name": "HDTV-2160p", "allowed": false },
+    { "name": "Bluray-1080p", "allowed": false },
+    { "name": "Bluray-720p", "allowed": false },
+    {
+      "name": "WEB 720p",
+      "allowed": false,
+      "items": ["WEBRip-720p", "WEBDL-720p"]
+    },
+    { "name": "Raw-HD", "allowed": false },
+    { "name": "HDTV-1080p", "allowed": false },
+    { "name": "HDTV-720p", "allowed": false },
+    { "name": "Bluray-576p", "allowed": false },
+    { "name": "Bluray-480p", "allowed": false },
+    { "name": "DVD", "allowed": false },
+    {
+      "name": "WEB 480p",
+      "allowed": false,
+      "items": ["WEBRip-480p", "WEBDL-480p"]
+    },
+    { "name": "SDTV", "allowed": false },
+    { "name": "Unknown", "allowed": false }
+  ],
+  "formatItems": {
+    "Remux Tier 01": "9965a052eb87b0d10313b1cea89eb451",
+    "Remux Tier 02": "8a1d0c3d7497e741736761a1da866a2e",
+    "WEB Tier 01": "e6258996055b9fbab7e9cb2f75819294",
+    "WEB Tier 02": "58790d4e2fdcd9733aa7ae68ba2bb503",
+    "WEB Scene": "d0c516558625b04b363fa6c5c2c7cfd4",
+    "WEB Tier 03": "d84935abd3f8556dcd51d4f27e22d0a6",
+    "Repack3": "44e7c4de10ae50265753082e5dc76047",
+    "Repack2": "eb3d5cc0a2be0db205fb823640db6a3c",
+    "Repack/Proper": "ec8fa7296b64e8cd390a1600981f3923"
+  }
+}

--- a/docs/json/sonarr/quality-profiles/remux-web-2160p.json
+++ b/docs/json/sonarr/quality-profiles/remux-web-2160p.json
@@ -1,0 +1,58 @@
+{
+  "trash_id": "76a5053bdb2d1e4a8f16a69a37d46c12",
+  "name": "Remux + WEB 2160p",
+  "trash_description": "Quality Profile that covers:<br>- WEBDL: 2160p",
+  "group": 99,
+  "upgradeAllowed": true,
+  "cutoff": "Bluray-2160p Remux",
+  "minFormatScore": 0,
+  "cutoffFormatScore": 10000,
+  "minUpgradeFormatScore": 1,
+  "items": [
+    { "name": "Bluray-2160p Remux", "allowed": true },
+    {
+      "name": "WEB 2160p",
+      "allowed": true,
+      "items": ["WEBRip-2160p", "WEBDL-2160p"]
+    },
+    { "name": "Bluray-2160p", "allowed": false },
+    { "name": "HDTV-2160p", "allowed": false },
+    { "name": "Bluray-1080p Remux", "allowed": false },
+    { "name": "Bluray-1080p", "allowed": false },
+    {
+      "name": "WEB 1080p",
+      "allowed": false,
+      "items": ["WEBRip-1080p", "WEBDL-1080p"]
+    },
+    { "name": "Bluray-720p", "allowed": false },
+    {
+      "name": "WEB 720p",
+      "allowed": false,
+      "items": ["WEBRip-720p", "WEBDL-720p"]
+    },
+    { "name": "Raw-HD", "allowed": false },
+    { "name": "HDTV-1080p", "allowed": false },
+    { "name": "HDTV-720p", "allowed": false },
+    { "name": "Bluray-576p", "allowed": false },
+    { "name": "Bluray-480p", "allowed": false },
+    { "name": "DVD", "allowed": false },
+    {
+      "name": "WEB 480p",
+      "allowed": false,
+      "items": ["WEBRip-480p", "WEBDL-480p"]
+    },
+    { "name": "SDTV", "allowed": false },
+    { "name": "Unknown", "allowed": false }
+  ],
+  "formatItems": {
+    "Remux Tier 01": "9965a052eb87b0d10313b1cea89eb451",
+    "Remux Tier 02": "8a1d0c3d7497e741736761a1da866a2e",
+    "WEB Tier 01": "e6258996055b9fbab7e9cb2f75819294",
+    "WEB Tier 02": "58790d4e2fdcd9733aa7ae68ba2bb503",
+    "WEB Scene": "d0c516558625b04b363fa6c5c2c7cfd4",
+    "WEB Tier 03": "d84935abd3f8556dcd51d4f27e22d0a6",
+    "Repack3": "44e7c4de10ae50265753082e5dc76047",
+    "Repack2": "eb3d5cc0a2be0db205fb823640db6a3c",
+    "Repack/Proper": "ec8fa7296b64e8cd390a1600981f3923"
+  }
+}

--- a/docs/json/sonarr/quality-profiles/remux-web-2160p.json
+++ b/docs/json/sonarr/quality-profiles/remux-web-2160p.json
@@ -1,7 +1,7 @@
 {
   "trash_id": "76a5053bdb2d1e4a8f16a69a37d46c12",
   "name": "Remux + WEB 2160p",
-  "trash_description": "Quality Profile that covers:<br>- WEBDL: 2160p",
+  "trash_description": "Quality Profile that covers:<br>- WEBDL: 2160p<br>- Remux: 2160p",
   "group": 99,
   "upgradeAllowed": true,
   "cutoff": "Bluray-2160p Remux",

--- a/docs/json/sonarr/quality-profiles/remux-web-2160p.json
+++ b/docs/json/sonarr/quality-profiles/remux-web-2160p.json
@@ -2,7 +2,7 @@
   "trash_id": "76a5053bdb2d1e4a8f16a69a37d46c12",
   "name": "Remux + WEB 2160p",
   "trash_description": "Quality Profile that covers:<br>- WEBDL: 2160p<br>- Remux: 2160p",
-  "group": 99,
+  "group": 1,
   "upgradeAllowed": true,
   "cutoff": "Bluray-2160p Remux",
   "minFormatScore": 0,


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->
To create Sonarr Remux profiles for guide sync applications.

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [ X] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [ X] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Add new Sonarr remux quality profiles and integrate them into the existing quality profile group configuration.

New Features:
- Introduce a combined 2160p remux Sonarr quality profile JSON definition.
- Add a 1080p remux web Sonarr quality profile JSON definition.
- Add a 2160p remux web Sonarr quality profile JSON definition.

Enhancements:
- Update Sonarr quality profile groups configuration to reference the new remux profiles.