### PR TITLE
feat(guide-sync): Created Sonarr Remux Profiles

### DIFF
--- a/docs/json/sonarr/cf-groups/audio-formats.json
+++ b/docs/json/sonarr/cf-groups/audio-formats.json
@@ -86,6 +86,10 @@
     ],
     "quality_profiles": {
         "include": {
+            "Remux + WEB 1080p": "fe9470e577c300a5ad9a3274f6d1cdf2",
+            "Remux + WEB 2160p": "76a5053bdb2d1e4a8f16a69a37d46c12",
+            "Remux 2160p (Alternative)": "361717d531db5a6002e0f547ace46551",
+            "Remux 2160p (Combined)": "911df0e05a395c19d8b3efc76a7467c1",
             "WEB-1080p (Alternative)": "9d142234e45d6143785ac55f5a9e8dc9",
             "WEB-2160p (Alternative)": "dfa5eaae7894077ad6449169b6eb03e0",
             "Base Profile": "e58cf4e090184db3b3d7c79c1a9e9b4a"

--- a/docs/json/sonarr/cf-groups/hdr-formats-dv-boost.json
+++ b/docs/json/sonarr/cf-groups/hdr-formats-dv-boost.json
@@ -11,6 +11,9 @@
     ],
     "quality_profiles": {
         "include": {
+            "Remux + WEB 2160p": "76a5053bdb2d1e4a8f16a69a37d46c12",
+            "Remux 2160p (Alternative)": "361717d531db5a6002e0f547ace46551",
+            "Remux 2160p (Combined)": "911df0e05a395c19d8b3efc76a7467c1",
             "WEB-2160p": "d1498e7d189fbe6c7110ceaabb7473e6",
             "WEB-2160p (Alternative)": "dfa5eaae7894077ad6449169b6eb03e0",
             "WEB-2160p (Combined)": "c4cadd6b35b95f62c3d47a408e53e2f7",

--- a/docs/json/sonarr/cf-groups/hdr-formats-hdr.json
+++ b/docs/json/sonarr/cf-groups/hdr-formats-hdr.json
@@ -12,6 +12,9 @@
     ],
     "quality_profiles": {
         "include": {
+            "Remux + WEB 2160p": "76a5053bdb2d1e4a8f16a69a37d46c12",
+            "Remux 2160p (Alternative)": "361717d531db5a6002e0f547ace46551",
+            "Remux 2160p (Combined)": "911df0e05a395c19d8b3efc76a7467c1",
             "WEB-2160p": "d1498e7d189fbe6c7110ceaabb7473e6",
             "WEB-2160p (Alternative)": "dfa5eaae7894077ad6449169b6eb03e0",
             "WEB-2160p (Combined)": "c4cadd6b35b95f62c3d47a408e53e2f7",

--- a/docs/json/sonarr/cf-groups/hdr-formats-hdr10-boost.json
+++ b/docs/json/sonarr/cf-groups/hdr-formats-hdr10-boost.json
@@ -11,6 +11,9 @@
     ],
     "quality_profiles": {
         "include": {
+            "Remux + WEB 2160p": "76a5053bdb2d1e4a8f16a69a37d46c12",
+            "Remux 2160p (Alternative)": "361717d531db5a6002e0f547ace46551",
+            "Remux 2160p (Combined)": "911df0e05a395c19d8b3efc76a7467c1",
             "WEB-2160p": "d1498e7d189fbe6c7110ceaabb7473e6",
             "WEB-2160p (Alternative)": "dfa5eaae7894077ad6449169b6eb03e0",
             "WEB-2160p (Combined)": "c4cadd6b35b95f62c3d47a408e53e2f7",

--- a/docs/json/sonarr/cf-groups/hdr-formats-sdr.json
+++ b/docs/json/sonarr/cf-groups/hdr-formats-sdr.json
@@ -16,6 +16,9 @@
     ],
     "quality_profiles": {
         "include": {
+            "Remux + WEB 2160p": "76a5053bdb2d1e4a8f16a69a37d46c12",
+            "Remux 2160p (Alternative)": "361717d531db5a6002e0f547ace46551",
+            "Remux 2160p (Combined)": "911df0e05a395c19d8b3efc76a7467c1",
             "WEB-2160p": "d1498e7d189fbe6c7110ceaabb7473e6",
             "WEB-2160p (Alternative)": "dfa5eaae7894077ad6449169b6eb03e0",
             "WEB-2160p (Combined)": "c4cadd6b35b95f62c3d47a408e53e2f7",

--- a/docs/json/sonarr/cf-groups/optional-accessibility.json
+++ b/docs/json/sonarr/cf-groups/optional-accessibility.json
@@ -26,7 +26,11 @@
     ],
     "quality_profiles": {
         "include": {
+            "Remux + WEB 1080p": "fe9470e577c300a5ad9a3274f6d1cdf2",
+            "Remux + WEB 2160p": "76a5053bdb2d1e4a8f16a69a37d46c12",
             "WEB-1080p": "72dae194fc92bf828f32cde7744e51a1",
+            "Remux 2160p (Alternative)": "361717d531db5a6002e0f547ace46551",
+            "Remux 2160p (Combined)": "911df0e05a395c19d8b3efc76a7467c1",
             "WEB-1080p (Alternative)": "9d142234e45d6143785ac55f5a9e8dc9",
             "WEB-2160p": "d1498e7d189fbe6c7110ceaabb7473e6",
             "WEB-2160p (Alternative)": "dfa5eaae7894077ad6449169b6eb03e0",

--- a/docs/json/sonarr/cf-groups/optional-golden-rule-hd.json
+++ b/docs/json/sonarr/cf-groups/optional-golden-rule-hd.json
@@ -18,6 +18,7 @@
     ],
     "quality_profiles": {
         "include": {
+            "Remux + WEB 1080p": "fe9470e577c300a5ad9a3274f6d1cdf2",
             "WEB-1080p": "72dae194fc92bf828f32cde7744e51a1",
             "WEB-1080p (Alternative)": "9d142234e45d6143785ac55f5a9e8dc9",
             "[German] Anime HD Bluray + WEB": "6fe5937e1dcc2269e23b49eb46dfe6d6",

--- a/docs/json/sonarr/cf-groups/optional-golden-rule-uhd.json
+++ b/docs/json/sonarr/cf-groups/optional-golden-rule-uhd.json
@@ -18,6 +18,9 @@
     ],
     "quality_profiles": {
         "include": {
+            "Remux + WEB 2160p": "76a5053bdb2d1e4a8f16a69a37d46c12",
+            "Remux 2160p (Alternative)": "361717d531db5a6002e0f547ace46551",
+            "Remux 2160p (Combined)": "911df0e05a395c19d8b3efc76a7467c1",
             "WEB-2160p": "d1498e7d189fbe6c7110ceaabb7473e6",
             "WEB-2160p (Alternative)": "dfa5eaae7894077ad6449169b6eb03e0",
             "WEB-2160p (Combined)": "c4cadd6b35b95f62c3d47a408e53e2f7",

--- a/docs/json/sonarr/cf-groups/optional-language-profiles.json
+++ b/docs/json/sonarr/cf-groups/optional-language-profiles.json
@@ -63,7 +63,11 @@
     ],
     "quality_profiles": {
         "include": {
+            "Remux + WEB 1080p": "fe9470e577c300a5ad9a3274f6d1cdf2",
+            "Remux + WEB 2160p": "76a5053bdb2d1e4a8f16a69a37d46c12",
             "WEB-1080p": "72dae194fc92bf828f32cde7744e51a1",
+            "Remux 2160p (Alternative)": "361717d531db5a6002e0f547ace46551",
+            "Remux 2160p (Combined)": "911df0e05a395c19d8b3efc76a7467c1",
             "WEB-1080p (Alternative)": "9d142234e45d6143785ac55f5a9e8dc9",
             "WEB-2160p": "d1498e7d189fbe6c7110ceaabb7473e6",
             "WEB-2160p (Alternative)": "dfa5eaae7894077ad6449169b6eb03e0",

--- a/docs/json/sonarr/cf-groups/optional-miscellaneous.json
+++ b/docs/json/sonarr/cf-groups/optional-miscellaneous.json
@@ -76,7 +76,11 @@
     ],
     "quality_profiles": {
         "include": {
+            "Remux + WEB 1080p": "fe9470e577c300a5ad9a3274f6d1cdf2",
+            "Remux + WEB 2160p": "76a5053bdb2d1e4a8f16a69a37d46c12",
             "WEB-1080p": "72dae194fc92bf828f32cde7744e51a1",
+            "Remux 2160p (Alternative)": "361717d531db5a6002e0f547ace46551",
+            "Remux 2160p (Combined)": "911df0e05a395c19d8b3efc76a7467c1",
             "WEB-1080p (Alternative)": "9d142234e45d6143785ac55f5a9e8dc9",
             "WEB-2160p": "d1498e7d189fbe6c7110ceaabb7473e6",
             "WEB-2160p (Alternative)": "dfa5eaae7894077ad6449169b6eb03e0",

--- a/docs/json/sonarr/cf-groups/optional-season-packs.json
+++ b/docs/json/sonarr/cf-groups/optional-season-packs.json
@@ -11,7 +11,11 @@
     ],
     "quality_profiles": {
         "include": {
+            "Remux + WEB 1080p": "fe9470e577c300a5ad9a3274f6d1cdf2",
+            "Remux + WEB 2160p": "76a5053bdb2d1e4a8f16a69a37d46c12",
             "WEB-1080p": "72dae194fc92bf828f32cde7744e51a1",
+            "Remux 2160p (Alternative)": "361717d531db5a6002e0f547ace46551",
+            "Remux 2160p (Combined)": "911df0e05a395c19d8b3efc76a7467c1",
             "WEB-1080p (Alternative)": "9d142234e45d6143785ac55f5a9e8dc9",
             "WEB-2160p": "d1498e7d189fbe6c7110ceaabb7473e6",
             "WEB-2160p (Alternative)": "dfa5eaae7894077ad6449169b6eb03e0",

--- a/docs/json/sonarr/cf-groups/streaming-services-anime.json
+++ b/docs/json/sonarr/cf-groups/streaming-services-anime.json
@@ -51,7 +51,11 @@
     ],
     "quality_profiles": {
         "include": {
+            "Remux + WEB 1080p": "fe9470e577c300a5ad9a3274f6d1cdf2",
+            "Remux + WEB 2160p": "76a5053bdb2d1e4a8f16a69a37d46c12",
             "WEB-1080p": "72dae194fc92bf828f32cde7744e51a1",
+            "Remux 2160p (Alternative)": "361717d531db5a6002e0f547ace46551",
+            "Remux 2160p (Combined)": "911df0e05a395c19d8b3efc76a7467c1",
             "WEB-1080p (Alternative)": "9d142234e45d6143785ac55f5a9e8dc9",
             "WEB-2160p": "d1498e7d189fbe6c7110ceaabb7473e6",
             "WEB-2160p (Alternative)": "dfa5eaae7894077ad6449169b6eb03e0",

--- a/docs/json/sonarr/cf-groups/streaming-services-asian.json
+++ b/docs/json/sonarr/cf-groups/streaming-services-asian.json
@@ -101,7 +101,11 @@
     ],
     "quality_profiles": {
         "include": {
+            "Remux + WEB 1080p": "fe9470e577c300a5ad9a3274f6d1cdf2",
+            "Remux + WEB 2160p": "76a5053bdb2d1e4a8f16a69a37d46c12",
             "WEB-1080p": "72dae194fc92bf828f32cde7744e51a1",
+            "Remux 2160p (Alternative)": "361717d531db5a6002e0f547ace46551",
+            "Remux 2160p (Combined)": "911df0e05a395c19d8b3efc76a7467c1",
             "WEB-1080p (Alternative)": "9d142234e45d6143785ac55f5a9e8dc9",
             "WEB-2160p": "d1498e7d189fbe6c7110ceaabb7473e6",
             "WEB-2160p (Alternative)": "dfa5eaae7894077ad6449169b6eb03e0",

--- a/docs/json/sonarr/cf-groups/streaming-services-dutch.json
+++ b/docs/json/sonarr/cf-groups/streaming-services-dutch.json
@@ -16,7 +16,11 @@
     ],
     "quality_profiles": {
         "include": {
+            "Remux + WEB 1080p": "fe9470e577c300a5ad9a3274f6d1cdf2",
+            "Remux + WEB 2160p": "76a5053bdb2d1e4a8f16a69a37d46c12",
             "WEB-1080p": "72dae194fc92bf828f32cde7744e51a1",
+            "Remux 2160p (Alternative)": "361717d531db5a6002e0f547ace46551",
+            "Remux 2160p (Combined)": "911df0e05a395c19d8b3efc76a7467c1",
             "WEB-1080p (Alternative)": "9d142234e45d6143785ac55f5a9e8dc9",
             "WEB-2160p": "d1498e7d189fbe6c7110ceaabb7473e6",
             "WEB-2160p (Alternative)": "dfa5eaae7894077ad6449169b6eb03e0",

--- a/docs/json/sonarr/cf-groups/streaming-services-french.json
+++ b/docs/json/sonarr/cf-groups/streaming-services-french.json
@@ -21,7 +21,11 @@
     ],
     "quality_profiles": {
         "include": {
+            "Remux + WEB 1080p": "fe9470e577c300a5ad9a3274f6d1cdf2",
+            "Remux + WEB 2160p": "76a5053bdb2d1e4a8f16a69a37d46c12",
             "WEB-1080p": "72dae194fc92bf828f32cde7744e51a1",
+            "Remux 2160p (Alternative)": "361717d531db5a6002e0f547ace46551",
+            "Remux 2160p (Combined)": "911df0e05a395c19d8b3efc76a7467c1",
             "WEB-1080p (Alternative)": "9d142234e45d6143785ac55f5a9e8dc9",
             "WEB-2160p": "d1498e7d189fbe6c7110ceaabb7473e6",
             "WEB-2160p (Alternative)": "dfa5eaae7894077ad6449169b6eb03e0",

--- a/docs/json/sonarr/cf-groups/streaming-services-general.json
+++ b/docs/json/sonarr/cf-groups/streaming-services-general.json
@@ -102,7 +102,11 @@
     ],
     "quality_profiles": {
         "include": {
+            "Remux + WEB 1080p": "fe9470e577c300a5ad9a3274f6d1cdf2",
+            "Remux + WEB 2160p": "76a5053bdb2d1e4a8f16a69a37d46c12",
             "WEB-1080p": "72dae194fc92bf828f32cde7744e51a1",
+            "Remux 2160p (Alternative)": "361717d531db5a6002e0f547ace46551",
+            "Remux 2160p (Combined)": "911df0e05a395c19d8b3efc76a7467c1",
             "WEB-1080p (Alternative)": "9d142234e45d6143785ac55f5a9e8dc9",
             "WEB-2160p": "d1498e7d189fbe6c7110ceaabb7473e6",
             "WEB-2160p (Alternative)": "dfa5eaae7894077ad6449169b6eb03e0",

--- a/docs/json/sonarr/cf-groups/streaming-services-hd-uhd-boost.json
+++ b/docs/json/sonarr/cf-groups/streaming-services-hd-uhd-boost.json
@@ -19,7 +19,11 @@
     ],
     "quality_profiles": {
         "include": {
+            "Remux + WEB 1080p": "fe9470e577c300a5ad9a3274f6d1cdf2",
+            "Remux + WEB 2160p": "76a5053bdb2d1e4a8f16a69a37d46c12",
             "WEB-1080p": "72dae194fc92bf828f32cde7744e51a1",
+            "Remux 2160p (Alternative)": "361717d531db5a6002e0f547ace46551",
+            "Remux 2160p (Combined)": "911df0e05a395c19d8b3efc76a7467c1",
             "WEB-1080p (Alternative)": "9d142234e45d6143785ac55f5a9e8dc9",
             "WEB-2160p": "d1498e7d189fbe6c7110ceaabb7473e6",
             "WEB-2160p (Alternative)": "dfa5eaae7894077ad6449169b6eb03e0",

--- a/docs/json/sonarr/cf-groups/streaming-services-miscellaneous.json
+++ b/docs/json/sonarr/cf-groups/streaming-services-miscellaneous.json
@@ -51,7 +51,11 @@
     ],
     "quality_profiles": {
         "include": {
+            "Remux + WEB 1080p": "fe9470e577c300a5ad9a3274f6d1cdf2",
+            "Remux + WEB 2160p": "76a5053bdb2d1e4a8f16a69a37d46c12",
             "WEB-1080p": "72dae194fc92bf828f32cde7744e51a1",
+            "Remux 2160p (Alternative)": "361717d531db5a6002e0f547ace46551",
+            "Remux 2160p (Combined)": "911df0e05a395c19d8b3efc76a7467c1",
             "WEB-1080p (Alternative)": "9d142234e45d6143785ac55f5a9e8dc9",
             "WEB-2160p": "d1498e7d189fbe6c7110ceaabb7473e6",
             "WEB-2160p (Alternative)": "dfa5eaae7894077ad6449169b6eb03e0",

--- a/docs/json/sonarr/cf-groups/unwanted-formats.json
+++ b/docs/json/sonarr/cf-groups/unwanted-formats.json
@@ -79,7 +79,11 @@
     ],
     "quality_profiles": {
         "include": {
+            "Remux + WEB 1080p": "fe9470e577c300a5ad9a3274f6d1cdf2",
+            "Remux + WEB 2160p": "76a5053bdb2d1e4a8f16a69a37d46c12",
             "WEB-1080p": "72dae194fc92bf828f32cde7744e51a1",
+            "Remux 2160p (Alternative)": "361717d531db5a6002e0f547ace46551",
+            "Remux 2160p (Combined)": "911df0e05a395c19d8b3efc76a7467c1",
             "WEB-1080p (Alternative)": "9d142234e45d6143785ac55f5a9e8dc9",
             "WEB-2160p": "d1498e7d189fbe6c7110ceaabb7473e6",
             "WEB-2160p (Alternative)": "dfa5eaae7894077ad6449169b6eb03e0",

--- a/docs/json/sonarr/quality-profile-groups/groups.json
+++ b/docs/json/sonarr/quality-profile-groups/groups.json
@@ -6,7 +6,11 @@
       "web-1080p-alternative": "9d142234e45d6143785ac55f5a9e8dc9",
       "web-2160p-combined": "c4cadd6b35b95f62c3d47a408e53e2f7",
       "web-2160p": "d1498e7d189fbe6c7110ceaabb7473e6",
-      "web-2160p-alternative": "dfa5eaae7894077ad6449169b6eb03e0"
+      "web-2160p-alternative": "dfa5eaae7894077ad6449169b6eb03e0",
+      "remux-web-1080p": "fe9470e577c300a5ad9a3274f6d1cdf2",
+      "remux-2160p-combined": "911df0e05a395c19d8b3efc76a7467c1",
+      "remux-2160p-alternative": "361717d531db5a6002e0f547ace46551",
+      "remux-web-2160p": "76a5053bdb2d1e4a8f16a69a37d46c12"
     }
   },
   {

--- a/docs/json/sonarr/quality-profile-groups/groups.json
+++ b/docs/json/sonarr/quality-profile-groups/groups.json
@@ -4,13 +4,13 @@
     "profiles": {
       "web-1080p": "72dae194fc92bf828f32cde7744e51a1",
       "web-1080p-alternative": "9d142234e45d6143785ac55f5a9e8dc9",
-      "web-2160p-combined": "c4cadd6b35b95f62c3d47a408e53e2f7",
       "web-2160p": "d1498e7d189fbe6c7110ceaabb7473e6",
+      "web-2160p-combined": "c4cadd6b35b95f62c3d47a408e53e2f7",
       "web-2160p-alternative": "dfa5eaae7894077ad6449169b6eb03e0",
       "remux-web-1080p": "fe9470e577c300a5ad9a3274f6d1cdf2",
+      "remux-web-2160p": "76a5053bdb2d1e4a8f16a69a37d46c12",
       "remux-2160p-combined": "911df0e05a395c19d8b3efc76a7467c1",
-      "remux-2160p-alternative": "361717d531db5a6002e0f547ace46551",
-      "remux-web-2160p": "76a5053bdb2d1e4a8f16a69a37d46c12"
+      "remux-2160p-alternative": "361717d531db5a6002e0f547ace46551"
     }
   },
   {

--- a/docs/json/sonarr/quality-profiles/remux-2160p-alternative.json
+++ b/docs/json/sonarr/quality-profiles/remux-2160p-alternative.json
@@ -1,7 +1,7 @@
 {
   "trash_id": "361717d531db5a6002e0f547ace46551",
   "name": "Remux 2160p (Alternative)",
-  "trash_description": "Quality Profile that covers:<br>- HDTV 720p, 1080p<br>- WEBDL: 720, 1080p, 2160p<br>- Bluray 720p, 1080p, 2160p<br>- Remux: 1080p, 2160p",
+  "trash_description": "Quality Profile that covers:<br>- HDTV: 720p, 1080p<br>- WEBDL: 720, 1080p, 2160p<br>- Bluray: 720p, 1080p, 2160p<br>- Remux: 1080p, 2160p",
   "group": 2,
   "upgradeAllowed": true,
   "cutoff": "Bluray-2160p Remux",

--- a/docs/json/sonarr/quality-profiles/remux-2160p-alternative.json
+++ b/docs/json/sonarr/quality-profiles/remux-2160p-alternative.json
@@ -1,0 +1,58 @@
+{
+  "trash_id": "361717d531db5a6002e0f547ace46551",
+  "name": "Remux 2160p (Alternative)",
+  "trash_description": "Quality Profile that covers:<br>- HDTV 720p, 1080p<br>- WEBDL: 720, 1080p, 2160p<br>- Bluray 720p, 1080p, 2160p<br>- Remux: 1080p, 2160p",
+  "group": 2,
+  "upgradeAllowed": true,
+  "cutoff": "Bluray-2160p Remux",
+  "minFormatScore": 0,
+  "cutoffFormatScore": 10000,
+  "minUpgradeFormatScore": 1,
+  "items": [
+    { "name": "Bluray-2160p Remux", "allowed": true },
+    {
+      "name": "WEB 2160p",
+      "allowed": true,
+      "items": ["WEBRip-2160p", "WEBDL-2160p"]
+    },
+    { "name": "Bluray-2160p", "allowed": true },
+    { "name": "Bluray-1080p Remux", "allowed": true },
+    {
+      "name": "WEB 1080p",
+      "allowed": true,
+      "items": ["WEBRip-1080p", "WEBDL-1080p"]
+    },
+    { "name": "Bluray-1080p", "allowed": true },
+    { "name": "HDTV-1080p", "allowed": true },
+    {
+      "name": "WEB 720p",
+      "allowed": true,
+      "items": ["WEBRip-720p", "WEBDL-720p"]
+    },
+    { "name": "Bluray-720p", "allowed": true },
+    { "name": "HDTV-720p", "allowed": true },
+    { "name": "Bluray-576p", "allowed": false },
+    {
+      "name": "WEB 480p",
+      "allowed": false,
+      "items": ["WEBRip-480p", "WEBDL-480p"]
+    },
+    { "name": "Bluray-480p", "allowed": false },
+    { "name": "DVD", "allowed": false },
+    { "name": "SDTV", "allowed": false },
+    { "name": "HDTV-2160p", "allowed": false },
+    { "name": "Raw-HD", "allowed": false },
+    { "name": "Unknown", "allowed": false }
+  ],
+  "formatItems": {
+    "Remux Tier 01": "9965a052eb87b0d10313b1cea89eb451",
+    "Remux Tier 02": "8a1d0c3d7497e741736761a1da866a2e",
+    "WEB Tier 01": "e6258996055b9fbab7e9cb2f75819294",
+    "WEB Tier 02": "58790d4e2fdcd9733aa7ae68ba2bb503",
+    "WEB Scene": "d0c516558625b04b363fa6c5c2c7cfd4",
+    "WEB Tier 03": "d84935abd3f8556dcd51d4f27e22d0a6",
+    "Repack3": "44e7c4de10ae50265753082e5dc76047",
+    "Repack2": "eb3d5cc0a2be0db205fb823640db6a3c",
+    "Repack/Proper": "ec8fa7296b64e8cd390a1600981f3923"
+  }
+}

--- a/docs/json/sonarr/quality-profiles/remux-2160p-alternative.json
+++ b/docs/json/sonarr/quality-profiles/remux-2160p-alternative.json
@@ -2,7 +2,7 @@
   "trash_id": "361717d531db5a6002e0f547ace46551",
   "name": "Remux 2160p (Alternative)",
   "trash_description": "Quality Profile that covers:<br>- HDTV: 720p, 1080p<br>- WEBDL: 720, 1080p, 2160p<br>- Bluray: 720p, 1080p, 2160p<br>- Remux: 1080p, 2160p",
-  "group": 2,
+  "group": 8,
   "upgradeAllowed": true,
   "cutoff": "Bluray-2160p Remux",
   "minFormatScore": 0,

--- a/docs/json/sonarr/quality-profiles/remux-2160p-combined.json
+++ b/docs/json/sonarr/quality-profiles/remux-2160p-combined.json
@@ -1,0 +1,58 @@
+{
+  "trash_id": "911df0e05a395c19d8b3efc76a7467c1",
+  "name": "Remux 2160p (Combined)",
+  "trash_description": "Quality Profile that covers:<br>- WEBDL: 1080p, 2160p<br>- Remux: 1080p, 2160p",
+  "group": 2,
+  "upgradeAllowed": true,
+  "cutoff": "Bluray-2160p Remux",
+  "minFormatScore": 0,
+  "cutoffFormatScore": 10000,
+  "minUpgradeFormatScore": 1,
+  "items": [
+    { "name": "Bluray-2160p Remux", "allowed": true },
+    {
+      "name": "WEB 2160p",
+      "allowed": true,
+      "items": ["WEBRip-2160p", "WEBDL-2160p"]
+    },
+    { "name": "Bluray-1080p Remux", "allowed": true },
+    {
+      "name": "WEB 1080p",
+      "allowed": true,
+      "items": ["WEBRip-1080p", "WEBDL-1080p"]
+    },
+    { "name": "Bluray-2160p", "allowed": false },
+    { "name": "HDTV-2160p", "allowed": false },
+    { "name": "Bluray-1080p", "allowed": false },
+    { "name": "Bluray-720p", "allowed": false },
+    {
+      "name": "WEB 720p",
+      "allowed": false,
+      "items": ["WEBRip-720p", "WEBDL-720p"]
+    },
+    { "name": "Raw-HD", "allowed": false },
+    { "name": "HDTV-1080p", "allowed": false },
+    { "name": "HDTV-720p", "allowed": false },
+    { "name": "Bluray-576p", "allowed": false },
+    { "name": "Bluray-480p", "allowed": false },
+    { "name": "DVD", "allowed": false },
+    {
+      "name": "WEB 480p",
+      "allowed": false,
+      "items": ["WEBRip-480p", "WEBDL-480p"]
+    },
+    { "name": "SDTV", "allowed": false },
+    { "name": "Unknown", "allowed": false }
+  ],
+  "formatItems": {
+    "Remux Tier 01": "9965a052eb87b0d10313b1cea89eb451",
+    "Remux Tier 02": "8a1d0c3d7497e741736761a1da866a2e",
+    "WEB Tier 01": "e6258996055b9fbab7e9cb2f75819294",
+    "WEB Tier 02": "58790d4e2fdcd9733aa7ae68ba2bb503",
+    "WEB Scene": "d0c516558625b04b363fa6c5c2c7cfd4",
+    "WEB Tier 03": "d84935abd3f8556dcd51d4f27e22d0a6",
+    "Repack3": "44e7c4de10ae50265753082e5dc76047",
+    "Repack2": "eb3d5cc0a2be0db205fb823640db6a3c",
+    "Repack/Proper": "ec8fa7296b64e8cd390a1600981f3923"
+  }
+}

--- a/docs/json/sonarr/quality-profiles/remux-2160p-combined.json
+++ b/docs/json/sonarr/quality-profiles/remux-2160p-combined.json
@@ -2,7 +2,7 @@
   "trash_id": "911df0e05a395c19d8b3efc76a7467c1",
   "name": "Remux 2160p (Combined)",
   "trash_description": "Quality Profile that covers:<br>- WEBDL: 1080p, 2160p<br>- Remux: 1080p, 2160p",
-  "group": 2,
+  "group": 7,
   "upgradeAllowed": true,
   "cutoff": "Bluray-2160p Remux",
   "minFormatScore": 0,

--- a/docs/json/sonarr/quality-profiles/remux-web-1080p.json
+++ b/docs/json/sonarr/quality-profiles/remux-web-1080p.json
@@ -2,7 +2,7 @@
   "trash_id": "fe9470e577c300a5ad9a3274f6d1cdf2",
   "name": "Remux + WEB 1080p",
   "trash_description": "Quality Profile that covers:<br>- WEBDL: 1080p<br>- Remux: 1080p",
-  "group": 1,
+  "group": 6,
   "upgradeAllowed": true,
   "cutoff": "Bluray-1080p Remux",
   "minFormatScore": 0,

--- a/docs/json/sonarr/quality-profiles/remux-web-1080p.json
+++ b/docs/json/sonarr/quality-profiles/remux-web-1080p.json
@@ -1,0 +1,58 @@
+{
+  "trash_id": "fe9470e577c300a5ad9a3274f6d1cdf2",
+  "name": "Remux + WEB 1080p",
+  "trash_description": "Quality Profile that covers:<br>- WEBDL: 1080p<br>- Remux: 1080p",
+  "group": 1,
+  "upgradeAllowed": true,
+  "cutoff": "Bluray-1080p Remux",
+  "minFormatScore": 0,
+  "cutoffFormatScore": 10000,
+  "minUpgradeFormatScore": 1,
+  "items": [
+    { "name": "Bluray-1080p Remux", "allowed": true },
+    {
+      "name": "WEB 1080p",
+      "allowed": true,
+      "items": ["WEBRip-1080p", "WEBDL-1080p"]
+    },
+    { "name": "Bluray-2160p Remux", "allowed": false },
+    { "name": "Bluray-2160p", "allowed": false },
+    {
+      "name": "WEB 2160p",
+      "allowed": false,
+      "items": ["WEBRip-2160p", "WEBDL-2160p"]
+    },
+    { "name": "HDTV-2160p", "allowed": false },
+    { "name": "Bluray-1080p", "allowed": false },
+    { "name": "Bluray-720p", "allowed": false },
+    {
+      "name": "WEB 720p",
+      "allowed": false,
+      "items": ["WEBRip-720p", "WEBDL-720p"]
+    },
+    { "name": "Raw-HD", "allowed": false },
+    { "name": "HDTV-1080p", "allowed": false },
+    { "name": "HDTV-720p", "allowed": false },
+    { "name": "Bluray-576p", "allowed": false },
+    { "name": "Bluray-480p", "allowed": false },
+    { "name": "DVD", "allowed": false },
+    {
+      "name": "WEB 480p",
+      "allowed": false,
+      "items": ["WEBRip-480p", "WEBDL-480p"]
+    },
+    { "name": "SDTV", "allowed": false },
+    { "name": "Unknown", "allowed": false }
+  ],
+  "formatItems": {
+    "Remux Tier 01": "9965a052eb87b0d10313b1cea89eb451",
+    "Remux Tier 02": "8a1d0c3d7497e741736761a1da866a2e",
+    "WEB Tier 01": "e6258996055b9fbab7e9cb2f75819294",
+    "WEB Tier 02": "58790d4e2fdcd9733aa7ae68ba2bb503",
+    "WEB Scene": "d0c516558625b04b363fa6c5c2c7cfd4",
+    "WEB Tier 03": "d84935abd3f8556dcd51d4f27e22d0a6",
+    "Repack3": "44e7c4de10ae50265753082e5dc76047",
+    "Repack2": "eb3d5cc0a2be0db205fb823640db6a3c",
+    "Repack/Proper": "ec8fa7296b64e8cd390a1600981f3923"
+  }
+}

--- a/docs/json/sonarr/quality-profiles/remux-web-2160p.json
+++ b/docs/json/sonarr/quality-profiles/remux-web-2160p.json
@@ -1,0 +1,58 @@
+{
+  "trash_id": "76a5053bdb2d1e4a8f16a69a37d46c12",
+  "name": "Remux + WEB 2160p",
+  "trash_description": "Quality Profile that covers:<br>- WEBDL: 2160p<br>- Remux: 2160p",
+  "group": 1,
+  "upgradeAllowed": true,
+  "cutoff": "Bluray-2160p Remux",
+  "minFormatScore": 0,
+  "cutoffFormatScore": 10000,
+  "minUpgradeFormatScore": 1,
+  "items": [
+    { "name": "Bluray-2160p Remux", "allowed": true },
+    {
+      "name": "WEB 2160p",
+      "allowed": true,
+      "items": ["WEBRip-2160p", "WEBDL-2160p"]
+    },
+    { "name": "Bluray-2160p", "allowed": false },
+    { "name": "HDTV-2160p", "allowed": false },
+    { "name": "Bluray-1080p Remux", "allowed": false },
+    { "name": "Bluray-1080p", "allowed": false },
+    {
+      "name": "WEB 1080p",
+      "allowed": false,
+      "items": ["WEBRip-1080p", "WEBDL-1080p"]
+    },
+    { "name": "Bluray-720p", "allowed": false },
+    {
+      "name": "WEB 720p",
+      "allowed": false,
+      "items": ["WEBRip-720p", "WEBDL-720p"]
+    },
+    { "name": "Raw-HD", "allowed": false },
+    { "name": "HDTV-1080p", "allowed": false },
+    { "name": "HDTV-720p", "allowed": false },
+    { "name": "Bluray-576p", "allowed": false },
+    { "name": "Bluray-480p", "allowed": false },
+    { "name": "DVD", "allowed": false },
+    {
+      "name": "WEB 480p",
+      "allowed": false,
+      "items": ["WEBRip-480p", "WEBDL-480p"]
+    },
+    { "name": "SDTV", "allowed": false },
+    { "name": "Unknown", "allowed": false }
+  ],
+  "formatItems": {
+    "Remux Tier 01": "9965a052eb87b0d10313b1cea89eb451",
+    "Remux Tier 02": "8a1d0c3d7497e741736761a1da866a2e",
+    "WEB Tier 01": "e6258996055b9fbab7e9cb2f75819294",
+    "WEB Tier 02": "58790d4e2fdcd9733aa7ae68ba2bb503",
+    "WEB Scene": "d0c516558625b04b363fa6c5c2c7cfd4",
+    "WEB Tier 03": "d84935abd3f8556dcd51d4f27e22d0a6",
+    "Repack3": "44e7c4de10ae50265753082e5dc76047",
+    "Repack2": "eb3d5cc0a2be0db205fb823640db6a3c",
+    "Repack/Proper": "ec8fa7296b64e8cd390a1600981f3923"
+  }
+}

--- a/docs/json/sonarr/quality-profiles/remux-web-2160p.json
+++ b/docs/json/sonarr/quality-profiles/remux-web-2160p.json
@@ -2,7 +2,7 @@
   "trash_id": "76a5053bdb2d1e4a8f16a69a37d46c12",
   "name": "Remux + WEB 2160p",
   "trash_description": "Quality Profile that covers:<br>- WEBDL: 2160p<br>- Remux: 2160p",
-  "group": 1,
+  "group": 6,
   "upgradeAllowed": true,
   "cutoff": "Bluray-2160p Remux",
   "minFormatScore": 0,

--- a/docs/json/sonarr/quality-profiles/web-1080p-alternative.json
+++ b/docs/json/sonarr/quality-profiles/web-1080p-alternative.json
@@ -1,7 +1,7 @@
 {
   "trash_id": "9d142234e45d6143785ac55f5a9e8dc9",
   "name": "WEB-1080p (Alternative)",
-  "trash_description": "Quality Profile that covers:<br>- SDTV, DVD<br>- HDTV 720p, 1080p<br>- WEBDL: 480p, 720, 1080p<br>- Bluray 480p, 576p, 720p, 1080p",
+  "trash_description": "Quality Profile that covers:<br>- HDTV: 720p, 1080p<br>- WEBDL: 720, 1080p<br>- Bluray: 720p, 1080p",
   "trash_url": "https://trash-guides.info/Sonarr/sonarr-setup-quality-profiles/#web-1080p",
   "group": 2,
   "upgradeAllowed": true,

--- a/docs/json/sonarr/quality-profiles/web-2160p-alternative.json
+++ b/docs/json/sonarr/quality-profiles/web-2160p-alternative.json
@@ -1,7 +1,7 @@
 {
   "trash_id": "dfa5eaae7894077ad6449169b6eb03e0",
   "name": "WEB-2160p (Alternative)",
-  "trash_description": "Quality Profile that covers:<br>- SDTV, DVD<br>- HDTV 720p, 1080p<br>- WEBDL: 480p, 720, 1080p, 2160p<br>- Bluray 480p, 576p, 720p, 1080p, 2160p",
+  "trash_description": "Quality Profile that covers:<br>- HDTV: 720p, 1080p<br>- WEBDL: 720, 1080p, 2160p<br>- Bluray: 720p, 1080p, 2160p",
   "trash_url": "https://trash-guides.info/Sonarr/sonarr-setup-quality-profiles/#web-2160p",
   "group": 4,
   "upgradeAllowed": true,

--- a/docs/json/sonarr/quality-profiles/web-2160p-combined.json
+++ b/docs/json/sonarr/quality-profiles/web-2160p-combined.json
@@ -3,7 +3,7 @@
   "name": "WEB-2160p (Combined)",
   "trash_description": "Quality Profile that covers:<br>- WEBDL: 1080p, 2160p",
   "trash_url": "https://trash-guides.info/Sonarr/sonarr-setup-quality-profiles/#web-2160p",
-  "group": 4,
+  "group": 3,
   "upgradeAllowed": true,
   "cutoff": "WEB 2160p",
   "minFormatScore": 0,

--- a/docs/json/sonarr/quality-profiles/web-2160p.json
+++ b/docs/json/sonarr/quality-profiles/web-2160p.json
@@ -3,7 +3,7 @@
   "name": "WEB-2160p",
   "trash_description": "Quality Profile that covers:<br>- WEBDL: 2160p",
   "trash_url": "https://trash-guides.info/Sonarr/sonarr-setup-quality-profiles/#web-2160p",
-  "group": 3,
+  "group": 2,
   "upgradeAllowed": true,
   "cutoff": "WEB 2160p",
   "minFormatScore": 0,


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->
To create remux profiles for sonarr and 3rd party sync applications.

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [X] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [X] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Add Sonarr remux-focused quality profiles and update related custom format groups to support guide synchronization for remux and web profiles.

New Features:
- Introduce new Sonarr remux quality profiles for 1080p and 2160p, including alternative and combined variants.

Enhancements:
- Update existing Sonarr custom format groups and web quality profiles to align with the new remux profiles and third-party sync requirements.