### PR TITLE
feat(guide-sync): Adjusted scoring for an SQP to prefer multichannel over 2.0

### DIFF
--- a/docs/json/radarr/cf/20-stereo.json
+++ b/docs/json/radarr/cf/20-stereo.json
@@ -3,7 +3,7 @@
   "trash_scores": {
     "sqp-1-web-1080p": -175,
     "sqp-1-web-2160p": -175,
-    "sqp-4-ma-hybrid": 190
+    "sqp-4-ma-hybrid": 175
   },
   "name": "2.0 Stereo",
   "includeCustomFormatWhenRenaming": false,

--- a/docs/json/radarr/cf/aac.json
+++ b/docs/json/radarr/cf/aac.json
@@ -6,7 +6,7 @@
     "sqp-1-web-1080p": 0,
     "sqp-1-2160p": 0,
     "sqp-1-web-2160p": 0,
-    "sqp-4-ma-hybrid": 20
+    "sqp-4-ma-hybrid": 630
   },
   "name": "AAC",
   "includeCustomFormatWhenRenaming": false,

--- a/docs/json/radarr/cf/atmos-undefined.json
+++ b/docs/json/radarr/cf/atmos-undefined.json
@@ -6,7 +6,7 @@
     "sqp-1-web-1080p": 0,
     "sqp-1-2160p": 0,
     "sqp-1-web-2160p": 0,
-    "sqp-4-ma-hybrid": 720
+    "sqp-4-ma-hybrid": 730
   },
   "name": "ATMOS (undefined)",
   "includeCustomFormatWhenRenaming": false,

--- a/docs/json/radarr/cf/bhdstudio.json
+++ b/docs/json/radarr/cf/bhdstudio.json
@@ -4,7 +4,7 @@
     "default": 1000,
     "sqp-1-web-1080p": 550,
     "sqp-1-web-2160p": 550,
-    "sqp-4-ma-hybrid": 2945
+    "sqp-4-ma-hybrid": 3010
   },
   "name": "BHDStudio",
   "includeCustomFormatWhenRenaming": false,

--- a/docs/json/radarr/cf/dd.json
+++ b/docs/json/radarr/cf/dd.json
@@ -6,7 +6,7 @@
     "sqp-1-web-1080p": 115,
     "sqp-1-2160p": 115,
     "sqp-1-web-2160p": 115,
-    "sqp-4-ma-hybrid": 655
+    "sqp-4-ma-hybrid": 630
   },
   "name": "DD",
   "includeCustomFormatWhenRenaming": false,

--- a/docs/json/radarr/cf/ddplus-atmos.json
+++ b/docs/json/radarr/cf/ddplus-atmos.json
@@ -6,7 +6,7 @@
     "sqp-1-web-1080p": 135,
     "sqp-1-2160p": 135,
     "sqp-1-web-2160p": 135,
-    "sqp-4-ma-hybrid": 720
+    "sqp-4-ma-hybrid": 730
   },
   "name": "DD+ ATMOS",
   "includeCustomFormatWhenRenaming": false,

--- a/docs/json/radarr/cf/ddplus.json
+++ b/docs/json/radarr/cf/ddplus.json
@@ -6,7 +6,7 @@
     "sqp-1-web-1080p": 125,
     "sqp-1-2160p": 125,
     "sqp-1-web-2160p": 125,
-    "sqp-4-ma-hybrid": 715
+    "sqp-4-ma-hybrid": 680
   },
   "name": "DD+",
   "includeCustomFormatWhenRenaming": false,

--- a/docs/json/radarr/cf/dts-es.json
+++ b/docs/json/radarr/cf/dts-es.json
@@ -6,7 +6,7 @@
     "sqp-1-web-1080p": 0,
     "sqp-1-2160p": 0,
     "sqp-1-web-2160p": 0,
-    "sqp-4-ma-hybrid": 170
+    "sqp-4-ma-hybrid": 450
   },
   "name": "DTS-ES",
   "includeCustomFormatWhenRenaming": false,

--- a/docs/json/radarr/cf/dts-hd-hra.json
+++ b/docs/json/radarr/cf/dts-hd-hra.json
@@ -6,7 +6,7 @@
     "sqp-1-web-1080p": -10000,
     "sqp-1-2160p": -10000,
     "sqp-1-web-2160p": -10000,
-    "sqp-4-ma-hybrid": 320
+    "sqp-4-ma-hybrid": 500
   },
   "trash_regex": "https://regex101.com/r/jdUH4x/2",
   "name": "DTS-HD HRA",

--- a/docs/json/radarr/cf/dts.json
+++ b/docs/json/radarr/cf/dts.json
@@ -6,7 +6,7 @@
     "sqp-1-web-1080p": 0,
     "sqp-1-2160p": 0,
     "sqp-1-web-2160p": 0,
-    "sqp-4-ma-hybrid": 120
+    "sqp-4-ma-hybrid": 400
   },
   "trash_regex": "https://regex101.com/r/U1asQG/1",
   "name": "DTS",

--- a/docs/json/radarr/cf/flac.json
+++ b/docs/json/radarr/cf/flac.json
@@ -6,7 +6,7 @@
     "sqp-1-web-1080p": 0,
     "sqp-1-2160p": 0,
     "sqp-1-web-2160p": 0,
-    "sqp-4-ma-hybrid": 420
+    "sqp-4-ma-hybrid": 550
   },
   "name": "FLAC",
   "includeCustomFormatWhenRenaming": false,

--- a/docs/json/radarr/cf/hallowed.json
+++ b/docs/json/radarr/cf/hallowed.json
@@ -2,7 +2,7 @@
   "trash_id": "7a0d1ad358fee9f5b074af3ef3f9d9ef",
   "trash_scores": {
     "default": 600,
-    "sqp-4-ma-hybrid": 2955
+    "sqp-4-ma-hybrid": 3020
   },
   "name": "hallowed",
   "includeCustomFormatWhenRenaming": false,

--- a/docs/json/radarr/cf/imax-enhanced.json
+++ b/docs/json/radarr/cf/imax-enhanced.json
@@ -3,7 +3,7 @@
   "trash_regex": "https://regex101.com/r/y4MaGg/1",
   "trash_scores": {
     "default": 800,
-    "sqp-4-ma-hybrid": 345
+    "sqp-4-ma-hybrid": 385
   },
   "name": "IMAX Enhanced",
   "includeCustomFormatWhenRenaming": false,

--- a/docs/json/radarr/cf/ma.json
+++ b/docs/json/radarr/cf/ma.json
@@ -2,7 +2,7 @@
   "trash_id": "2a6039655313bf5dab1e43523b62c374",
   "trash_scores": {
     "default": 20,
-    "sqp-4-ma-hybrid": 350
+    "sqp-4-ma-hybrid": 390
   },
   "trash_regex": "https://regex101.com/r/k6okQj/1",
   "name": "MA",

--- a/docs/json/radarr/cf/mainframe.json
+++ b/docs/json/radarr/cf/mainframe.json
@@ -1,7 +1,7 @@
 {
   "trash_id": "8016f2f66e751dea613e6b5b94bf633c",
   "trash_scores": {
-    "sqp-4-ma-hybrid": 2830
+    "sqp-4-ma-hybrid": 2800
   },
   "name": "MainFrame",
   "includeCustomFormatWhenRenaming": false,

--- a/docs/json/radarr/cf/pcm.json
+++ b/docs/json/radarr/cf/pcm.json
@@ -6,7 +6,7 @@
     "sqp-1-web-1080p": 0,
     "sqp-1-2160p": 0,
     "sqp-1-web-2160p": 0,
-    "sqp-4-ma-hybrid": 420
+    "sqp-4-ma-hybrid": 550
   },
   "name": "PCM",
   "includeCustomFormatWhenRenaming": false,

--- a/docs/json/radarr/cf/play.json
+++ b/docs/json/radarr/cf/play.json
@@ -1,7 +1,7 @@
 {
   "trash_id": "350e9170619683a55cb9191d0b1ababa",
   "trash_scores": {
-    "sqp-4-ma-hybrid": 350
+    "sqp-4-ma-hybrid": 390
   },
   "name": "PLAY",
   "includeCustomFormatWhenRenaming": true,

--- a/docs/json/radarr/cf/webdl-boost.json
+++ b/docs/json/radarr/cf/webdl-boost.json
@@ -1,7 +1,7 @@
 {
   "trash_id": "8df7fe4569063d39319f07e69707285a",
   "trash_scores": {
-    "sqp-4-ma-hybrid": 3070
+    "sqp-4-ma-hybrid": 3030
   },
   "name": "WEBDL Boost",
   "includeCustomFormatWhenRenaming": false,

--- a/docs/json/radarr/quality-profiles/sqp-4-ma-hybrid.json
+++ b/docs/json/radarr/quality-profiles/sqp-4-ma-hybrid.json
@@ -6,7 +6,7 @@
   "group": 98,
   "upgradeAllowed": true,
   "cutoff": "Bluray|WEB-2160p",
-  "minFormatScore": 3070,
+  "minFormatScore": 3030,
   "cutoffFormatScore": 10000,
   "minUpgradeFormatScore": 1,
   "language": "Original",


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->

Adjusted scoring for an SQP to prefer multichannel over 2.0

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

Adjusted scoring for an SQP to prefer multichannel over 2.0

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Update Radarr audio-related custom formats and SQP quality profile scoring to prefer multichannel releases over 2.0 audio when selecting guides.

Enhancements:
- Adjust Radarr audio custom format scoring (e.g., stereo, AAC, DTS/DD variants, FLAC, PCM, Atmos, IMAX Enhanced) to de-prioritize 2.0 audio relative to multichannel tracks.
- Tune the `sqp-4-ma-hybrid` Radarr quality profile so that multichannel audio is selected over 2.0 when multiple options are available.