### PR TITLE
fix(radarr-german): require Bluray source for German Anime Bluray Tier 03

### DIFF
--- a/docs/json/radarr/cf/german-anime-bluray-tier-01.json
+++ b/docs/json/radarr/cf/german-anime-bluray-tier-01.json
@@ -133,8 +133,8 @@
       }
     },
     {
-      "name": "Not REMUX",
-      "implementation": "SourceSpecification",
+      "name": "Not Remux",
+      "implementation": "QualityModifierSpecification",
       "negate": true,
       "required": true,
       "fields": {

--- a/docs/json/radarr/cf/german-anime-bluray-tier-02.json
+++ b/docs/json/radarr/cf/german-anime-bluray-tier-02.json
@@ -70,8 +70,8 @@
       }
     },
     {
-      "name": "Not REMUX",
-      "implementation": "SourceSpecification",
+      "name": "Not Remux",
+      "implementation": "QualityModifierSpecification",
       "negate": true,
       "required": true,
       "fields": {

--- a/docs/json/radarr/cf/german-anime-bluray-tier-03.json
+++ b/docs/json/radarr/cf/german-anime-bluray-tier-03.json
@@ -79,8 +79,8 @@
       }
     },
     {
-      "name": "Not REMUX",
-      "implementation": "SourceSpecification",
+      "name": "Not Remux",
+      "implementation": "QualityModifierSpecification",
       "negate": true,
       "required": true,
       "fields": {

--- a/docs/json/radarr/cf/german-anime-bluray-tier-03.json
+++ b/docs/json/radarr/cf/german-anime-bluray-tier-03.json
@@ -70,8 +70,17 @@
       }
     },
     {
-      "name": "Not Remux",
-      "implementation": "QualityModifierSpecification",
+      "name": "Bluray",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": true,
+      "fields": {
+        "value": 9
+      }
+    },
+    {
+      "name": "Not REMUX",
+      "implementation": "SourceSpecification",
       "negate": true,
       "required": true,
       "fields": {


### PR DESCRIPTION
# Pull Request

## Purpose

The Radarr custom format **German Anime Bluray Tier 03** (`docs/json/radarr/cf/german-anime-bluray-tier-03.json`) incorrectly matches WEB releases, causing them to be scored as Bluray.

The custom format's only mandatory condition is a `Not Remux` (`QualityModifierSpecification`, value `5`). That does **not** exclude WEB sources. All release-group conditions are `required: false` (OR-matched), and several of these groups — SUBARU, ATAX, HDC, Mindus, W33BSHiT, 4Baka — are also listed in `german-anime-web-tier-03.json`.

As a result, a WEB release such as `... German DL ANiME 1080p WEB x264-SUBARU` satisfies the release-group OR-condition, and `Not Remux` is true (WEB is not a remux), so it **wrongly matches Bluray Tier 03** in addition to the correct Web Tier 03.

By contrast, **Tier 01** and **Tier 02** correctly require the source to be Bluray via a `Bluray` (`SourceSpecification`, value `9`, required) + `Not REMUX` (`SourceSpecification`, value `5`, negate, required) pair. Sonarr's Bluray Tier 03/02 are also correct.

## Approach

Bring Tier 03 in line with Tier 01/02 by replacing the `Not Remux` `QualityModifierSpecification` with the two required `SourceSpecification` blocks (`Bluray` value `9`, and negated `Not REMUX` value `5`).

- The 7 release groups are unchanged.
- `trash_id`, `name`, `trash_scores` and `includeCustomFormatWhenRenaming` are unchanged → no new hashcode and no follow-up changes to `cf-groups`, `quality-profiles`, `quality-profile-groups` or `conflicts.json`.
- No release groups are added, removed, or moved.

**Result:** Tier 03 now requires a Bluray source, so the SUBARU WEB example no longer matches Bluray Tier 03 — only the correct Web Tier 03.

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Bug Fixes:
- Prevent German Anime Bluray Tier 03 from incorrectly matching WEB releases by requiring a Bluray source.