### PR TITLE
feat(guide-sync): Adjusted scoring for an SQP to prefer WEBDL over Blu-ray

### DIFF
--- a/docs/json/radarr/cf/71-surround.json
+++ b/docs/json/radarr/cf/71-surround.json
@@ -1,7 +1,7 @@
 {
   "trash_id": "e77382bcfeba57cb83744c9c5449b401",
     "trash_scores": {
-    "sqp-4-ma-hybrid": 380
+    "sqp-4-ma-hybrid": 375
   },
   "name": "7.1 Surround",
   "includeCustomFormatWhenRenaming": false,

--- a/docs/json/radarr/cf/bhdstudio.json
+++ b/docs/json/radarr/cf/bhdstudio.json
@@ -4,7 +4,7 @@
     "default": 1000,
     "sqp-1-web-1080p": 550,
     "sqp-1-web-2160p": 550,
-    "sqp-4-ma-hybrid": 3010
+    "sqp-4-ma-hybrid": 3020
   },
   "name": "BHDStudio",
   "includeCustomFormatWhenRenaming": false,

--- a/docs/json/radarr/cf/hallowed.json
+++ b/docs/json/radarr/cf/hallowed.json
@@ -2,7 +2,7 @@
   "trash_id": "7a0d1ad358fee9f5b074af3ef3f9d9ef",
   "trash_scores": {
     "default": 600,
-    "sqp-4-ma-hybrid": 3020
+    "sqp-4-ma-hybrid": 3025
   },
   "name": "hallowed",
   "includeCustomFormatWhenRenaming": false,

--- a/docs/json/radarr/cf/webdl-boost.json
+++ b/docs/json/radarr/cf/webdl-boost.json
@@ -1,7 +1,7 @@
 {
   "trash_id": "8df7fe4569063d39319f07e69707285a",
   "trash_scores": {
-    "sqp-4-ma-hybrid": 3030
+    "sqp-4-ma-hybrid": 3035
   },
   "name": "WEBDL Boost",
   "includeCustomFormatWhenRenaming": false,

--- a/docs/json/radarr/quality-profiles/sqp-4-ma-hybrid.json
+++ b/docs/json/radarr/quality-profiles/sqp-4-ma-hybrid.json
@@ -6,7 +6,7 @@
   "group": 98,
   "upgradeAllowed": true,
   "cutoff": "Bluray|WEB-2160p",
-  "minFormatScore": 3030,
+  "minFormatScore": 3035,
   "cutoffFormatScore": 10000,
   "minUpgradeFormatScore": 1,
   "language": "Original",


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->

Adjusted scoring for an SQP to prefer WEBDL over Blu-ray

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

Adjusted scoring for an SQP to prefer WEBDL over Blu-ray

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Adjust scoring in Radarr custom formats and the SQP-4 MA Hybrid quality profile to prefer WEBDL releases over Blu-ray for the affected guide configuration.

Enhancements:
- Tune scoring in surround, BHDStudio, Hallowed, and WebDL-boost custom formats to align with WEBDL-over-Blu-ray preference.
- Update the SQP-4 MA Hybrid Radarr quality profile configuration to reflect the new WEBDL-preferred scoring strategy.