### PR TITLE
feat(radarr): Add RlsGRp `RandomBytes` to `UHD Bluray Tier 02`

### DIFF
--- a/docs/json/radarr/cf/uhd-bluray-tier-02.json
+++ b/docs/json/radarr/cf/uhd-bluray-tier-02.json
@@ -64,6 +64,15 @@
       "fields": {
         "value": "^(HQMUX)$"
       }
+    },
+    {
+      "name": "RandomBytes",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(RandomBytes)$"
+      }
     }
   ]
 }


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->

Add RlsGRp `RandomBytes` to `UHD Bluray Tier 02`

- **Activity:** Consistent stream of releases, with over 160 UHD Encode PRs in recent months, increasing in frequency.
- **Quality:** Consistently releases transparent encodes with high-quality settings. Uses high-quality sources, lossless audio, and bakes FEL when applicable. Provides sources, logs, comparisons, and dv/hdr10p plots. Repackages accordingly.
- **Discoverability:** Several Private trackers.

The reason we placed them directly in `UHD Bluray Tier 02` instead of `UHD Bluray Tier 03` is that in `UHD Bluray Tier 03` we mainly have release groups that use lossy audio, whereas `RandomBytes` uses lossless audio.

## Suggestion
Add RG `RandomBytes` to **UHD Bluray Tier**

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

Added RlsGRp `RandomBytes` to `UHD Bluray Tier 02`

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

New Features:
- Include RandomBytes as a supported UHD Bluray Tier 02 release group in the Radarr custom format JSON.