### PR TITLE
chore(misc): Request Dependencies team reviews for Renovate PRs

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -12,6 +12,8 @@
     ":enableVulnerabilityAlerts",
     ":renovatePrefix"
   ],
+  "additionalReviewers": ["team:dependencies"],
+  "assignAutomerge": true,
   "minimumReleaseAge": "3 days",
   "pre-commit": {
     "enabled": true


### PR DESCRIPTION
## Purpose

Ensure every Renovate pull request requests review from the Dependencies team, including updates eligible for automerge.

## Approach

- Add `team:dependencies` through Renovate’s mergeable `additionalReviewers` setting so inherited reviewers are preserved.
- Enable `assignAutomerge` because Renovate otherwise skips reviewer requests for automerge-enabled pull requests.

## Open Questions and Pre-Merge TODOs

None.

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).

## AI disclosure

This pull request was created with AI assistance.

## Summary by Sourcery

Configure Renovate to always request review from the Dependencies team, including for automerge-eligible updates.

Enhancements:
- Update Renovate configuration to add the Dependencies team as additional reviewers while preserving inherited reviewers.

CI:
- Adjust Renovate settings so automerge-eligible dependency update PRs still request reviewers via assignAutomerge.