### PR TITLE
fix(radarr): Validate Remux source and modifier semantics in CI

### DIFF
--- a/.github/workflows/custom-format-validation.yml
+++ b/.github/workflows/custom-format-validation.yml
@@ -80,6 +80,10 @@ jobs:
           BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
           HEAD_SHA: ${{ github.sha }}
         run: |
+          if [[ "$BASE_SHA" == "0000000000000000000000000000000000000000" ]]; then
+            echo "Initial branch push; skipping diff-based Remux check."
+            exit 0
+          fi
           mapfile -t changed_files < <(
             git diff --name-only --diff-filter=ACM "$BASE_SHA" "$HEAD_SHA" -- 'docs/json/radarr/cf/*.json'
           )

--- a/.github/workflows/custom-format-validation.yml
+++ b/.github/workflows/custom-format-validation.yml
@@ -11,6 +11,8 @@ on:
       - docs/json/radarr/conflicts.json
       - docs/json/sonarr/conflicts.json
       - schemas/**/*.json
+      - scripts/validate-source-specifications.py
+      - tests/test_validate_source_specifications.py
   pull_request:
     paths:
       - .github/workflows/custom-format-validation.yml
@@ -20,6 +22,8 @@ on:
       - docs/json/radarr/conflicts.json
       - docs/json/sonarr/conflicts.json
       - schemas/**/*.json
+      - scripts/validate-source-specifications.py
+      - tests/test_validate_source_specifications.py
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -36,6 +40,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          fetch-depth: 0
           persist-credentials: false
 
       - name: Setup python
@@ -66,3 +71,16 @@ jobs:
 
       - name: Validate SourceSpecification per-app values
         run: python scripts/validate-source-specifications.py
+
+      - name: Test source and modifier validation
+        run: python -m unittest tests/test_validate_source_specifications.py
+
+      - name: Validate changed Radarr Remux specifications
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+          HEAD_SHA: ${{ github.sha }}
+        run: |
+          mapfile -t changed_files < <(
+            git diff --name-only --diff-filter=ACM "$BASE_SHA" "$HEAD_SHA" -- 'docs/json/radarr/cf/*.json'
+          )
+          python scripts/validate-source-specifications.py --remux-files "${changed_files[@]}"

--- a/scripts/validate-source-specifications.py
+++ b/scripts/validate-source-specifications.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Validate SourceSpecification value semantics per app.
+"""Validate source and quality-modifier value semantics per app.
 
 Radarr's QualitySource enum spans 1-9; Sonarr's spans 1-7. The shared
 schemas/specs/source-spec.json enforces the union (1-9) at the JSON
@@ -14,6 +14,9 @@ Schema layer. This script enforces the per-app rules:
         under sonarr/cf/. When the wrong value happens to match the
         other app's encoding, the error includes a hint pointing at
         the likely copy-paste source.
+    3. Changed-file Radarr Remux semantics. Radarr represents Remux as
+        Bluray source value 9 plus QualityModifierSpecification value 5.
+        New or modified files cannot encode Remux as a source.
 
 The mapping tables below were verified against:
     Radarr/Radarr  src/NzbDrone.Core/Qualities/QualitySource.cs
@@ -39,6 +42,7 @@ Known limitations (intentional):
 Exit code 0 on success, 1 on any failure.
 """
 
+import argparse
 import json
 import re
 import sys
@@ -77,6 +81,9 @@ SONARR_SOURCE = {
 
 EXPECTED = {"radarr": RADARR_SOURCE, "sonarr": SONARR_SOURCE}
 
+RADARR_REMUX_SOURCE_LABELS = {"REMUX", "NOTREMUX", "BLURAYREMUX"}
+RADARR_REMUX_MODIFIERS = {"REMUX", "NOTREMUX"}
+
 # Per-app valid integer ranges for SourceSpecification.fields.value.
 # The shared JSON schema only enforces the union (1..9); per-app bounds
 # live here so the schema stays simple.
@@ -90,7 +97,29 @@ def normalize(name: str) -> str:
     return re.sub(r"[^A-Z0-9]", "", name.upper())
 
 
-def check_file(app: str, path: Path) -> list[str]:
+def check_radarr_remux(spec: dict, path: Path) -> tuple[bool, str | None]:
+    implementation = spec.get("implementation")
+    spec_name = spec.get("name", "")
+    value = spec.get("fields", {}).get("value")
+    key = normalize(spec_name)
+
+    if implementation == "SourceSpecification" and key in RADARR_REMUX_SOURCE_LABELS:
+        return True, (
+            f"[radarr] cf/{path.name}: SourceSpecification '{spec_name}'"
+            " is invalid for Radarr Remux; use Bluray source value 9 with"
+            " QualityModifierSpecification value 5"
+        )
+    if implementation == "QualityModifierSpecification" and key in RADARR_REMUX_MODIFIERS:
+        if value != 5:
+            return True, (
+                f"[radarr] cf/{path.name}: QualityModifierSpecification"
+                f" '{spec_name}' has value {value}, expected 5 for Radarr Remux"
+            )
+        return True, None
+    return False, None
+
+
+def check_file(app: str, path: Path, check_remux: bool = False) -> list[str]:
     errors: list[str] = []
     try:
         with open(path) as f:
@@ -105,10 +134,18 @@ def check_file(app: str, path: Path) -> list[str]:
     valid = VALID_VALUES[app]
 
     for spec in data.get("specifications", []):
-        if spec.get("implementation") != "SourceSpecification":
-            continue
+        implementation = spec.get("implementation")
         spec_name = spec.get("name", "")
         value = spec.get("fields", {}).get("value")
+        if check_remux and app == "radarr":
+            handled, error = check_radarr_remux(spec, path)
+            if error:
+                errors.append(error)
+            if handled:
+                continue
+
+        if implementation != "SourceSpecification":
+            continue
 
         # Per-app range check. The shared JSON schema accepts the union
         # 1..9; this catches values valid in the other app but not here
@@ -121,8 +158,7 @@ def check_file(app: str, path: Path) -> list[str]:
             )
             continue
 
-        key = normalize(spec_name)
-        expected = table.get(key)
+        expected = table.get(normalize(spec_name))
         if expected is None:
             # Unknown label — range check above is the only constraint.
             continue
@@ -145,22 +181,41 @@ def check_file(app: str, path: Path) -> list[str]:
     return errors
 
 
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--remux-files",
+        nargs="*",
+        type=Path,
+        help="Radarr CF files changed by the current push or pull request",
+    )
+    return parser.parse_args()
+
+
 def main() -> int:
+    args = parse_args()
     all_errors: list[str] = []
-    for app in ("radarr", "sonarr"):
-        cf_dir = BASE / app / "cf"
-        if not cf_dir.is_dir():
-            continue
-        for f in sorted(cf_dir.glob("*.json")):
-            all_errors.extend(check_file(app, f))
+    if args.remux_files is not None:
+        for path in args.remux_files:
+            all_errors.extend(check_file("radarr", path, check_remux=True))
+    else:
+        for app in ("radarr", "sonarr"):
+            cf_dir = BASE / app / "cf"
+            if not cf_dir.is_dir():
+                continue
+            for f in sorted(cf_dir.glob("*.json")):
+                all_errors.extend(check_file(app, f))
 
     if all_errors:
-        print(f"\nFound {len(all_errors)} SourceSpecification error(s):\n")
+        print(f"\nFound {len(all_errors)} source/modifier validation error(s):\n")
         for err in all_errors:
             print(f"  ERROR: {err}")
         return 1
 
-    print("All SourceSpecification values match the expected per-app mapping.")
+    if args.remux_files is not None:
+        print("Changed Radarr CFs use the expected Remux source and modifier semantics.")
+    else:
+        print("All SourceSpecification values match the expected per-app mapping.")
     return 0
 
 

--- a/scripts/validate-source-specifications.py
+++ b/scripts/validate-source-specifications.py
@@ -158,7 +158,8 @@ def check_file(app: str, path: Path, check_remux: bool = False) -> list[str]:
             )
             continue
 
-        expected = table.get(normalize(spec_name))
+        key = normalize(spec_name)
+        expected = table.get(key)
         if expected is None:
             # Unknown label — range check above is the only constraint.
             continue

--- a/tests/test_validate_source_specifications.py
+++ b/tests/test_validate_source_specifications.py
@@ -38,20 +38,63 @@ class RemuxValidationTests(unittest.TestCase):
 
         self.assertEqual(errors, [])
 
-    def test_rejects_remux_as_radarr_source(self):
+    def test_accepts_not_remux_modifier_value_5(self):
         errors = self.check_specs(
             [
                 {
-                    "name": "Not REMUX",
-                    "implementation": "SourceSpecification",
+                    "name": "Not Remux",
+                    "implementation": "QualityModifierSpecification",
                     "fields": {"value": 5},
                 }
             ]
         )
 
-        self.assertEqual(len(errors), 1)
-        self.assertIn("use Bluray source value 9", errors[0])
-        self.assertIn("QualityModifierSpecification value 5", errors[0])
+        self.assertEqual(errors, [])
+
+    def test_accepts_mixed_sources_with_bluray_and_remux(self):
+        errors = self.check_specs(
+            [
+                {
+                    "name": "WEB-DL",
+                    "implementation": "SourceSpecification",
+                    "fields": {"value": 7},
+                },
+                {
+                    "name": "WEBRip",
+                    "implementation": "SourceSpecification",
+                    "fields": {"value": 8},
+                },
+                {
+                    "name": "Bluray",
+                    "implementation": "SourceSpecification",
+                    "fields": {"value": 9},
+                },
+                {
+                    "name": "Remux",
+                    "implementation": "QualityModifierSpecification",
+                    "fields": {"value": 5},
+                },
+            ]
+        )
+
+        self.assertEqual(errors, [])
+
+    def test_rejects_remux_as_radarr_source(self):
+        for name in ("Remux", "Not REMUX", "Bluray Remux", "BLURAYREMUX"):
+            with self.subTest(name=name):
+                errors = self.check_specs(
+                    [
+                        {
+                            "name": name,
+                            "implementation": "SourceSpecification",
+                            "fields": {"value": 5},
+                        }
+                    ]
+                )
+
+                self.assertEqual(len(errors), 1)
+                self.assertIn("use Bluray source value 9", errors[0])
+                self.assertIn("QualityModifierSpecification value 5", errors[0])
 
     def test_rejects_wrong_radarr_remux_modifier_value(self):
         errors = self.check_specs(
@@ -66,6 +109,20 @@ class RemuxValidationTests(unittest.TestCase):
 
         self.assertEqual(len(errors), 1)
         self.assertIn("expected 5 for Radarr Remux", errors[0])
+
+    def test_remux_modifier_is_ignored_when_check_disabled(self):
+        errors = self.check_specs(
+            [
+                {
+                    "name": "Not Remux",
+                    "implementation": "QualityModifierSpecification",
+                    "fields": {"value": 4},
+                }
+            ],
+            check_remux=False,
+        )
+
+        self.assertEqual(errors, [])
 
     def test_sonarr_remux_remains_a_source(self):
         errors = self.check_specs(

--- a/tests/test_validate_source_specifications.py
+++ b/tests/test_validate_source_specifications.py
@@ -1,0 +1,86 @@
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).parents[1] / "scripts" / "validate-source-specifications.py"
+SPEC = importlib.util.spec_from_file_location("validate_source_specifications", SCRIPT)
+if SPEC is None or SPEC.loader is None:
+    raise RuntimeError(f"Unable to load validator from {SCRIPT}")
+VALIDATOR = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(VALIDATOR)
+
+
+class RemuxValidationTests(unittest.TestCase):
+    def check_specs(self, specifications, app="radarr", check_remux=True):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "test.json"
+            path.write_text(json.dumps({"specifications": specifications}), encoding="utf-8")
+            return VALIDATOR.check_file(app, path, check_remux=check_remux)
+
+    def test_accepts_bluray_source_with_remux_modifier(self):
+        errors = self.check_specs(
+            [
+                {
+                    "name": "Bluray",
+                    "implementation": "SourceSpecification",
+                    "fields": {"value": 9},
+                },
+                {
+                    "name": "Remux",
+                    "implementation": "QualityModifierSpecification",
+                    "fields": {"value": 5},
+                },
+            ]
+        )
+
+        self.assertEqual(errors, [])
+
+    def test_rejects_remux_as_radarr_source(self):
+        errors = self.check_specs(
+            [
+                {
+                    "name": "Not REMUX",
+                    "implementation": "SourceSpecification",
+                    "fields": {"value": 5},
+                }
+            ]
+        )
+
+        self.assertEqual(len(errors), 1)
+        self.assertIn("use Bluray source value 9", errors[0])
+        self.assertIn("QualityModifierSpecification value 5", errors[0])
+
+    def test_rejects_wrong_radarr_remux_modifier_value(self):
+        errors = self.check_specs(
+            [
+                {
+                    "name": "Not Remux",
+                    "implementation": "QualityModifierSpecification",
+                    "fields": {"value": 4},
+                }
+            ]
+        )
+
+        self.assertEqual(len(errors), 1)
+        self.assertIn("expected 5 for Radarr Remux", errors[0])
+
+    def test_sonarr_remux_remains_a_source(self):
+        errors = self.check_specs(
+            [
+                {
+                    "name": "Remux",
+                    "implementation": "SourceSpecification",
+                    "fields": {"value": 7},
+                }
+            ],
+            app="sonarr",
+        )
+
+        self.assertEqual(errors, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Purpose

Prevent new or modified Radarr Custom Formats from encoding Remux as a `SourceSpecification`. Radarr uses Bluray source value `9` with Remux represented by `QualityModifierSpecification` value `5`.

## Approach

- Extend the existing source validator with explicit Radarr Remux source and modifier checks.
- Run the new rule only against Radarr CF JSON changed by the push or pull request, avoiding unrelated cleanup of pre-existing files.
- Keep Sonarr Remux handling unchanged as `SourceSpecification` value `7`.
- Add regression tests for valid Radarr and Sonarr definitions plus invalid Radarr source and modifier values.
- Include validator and test changes in the Custom Format validation workflow paths.

## Open Questions and Pre-Merge TODOs

None.

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).

## AI disclosure

This pull request was created with AI assistance.

## Summary by Sourcery

Enforce correct Radarr Remux semantics in custom format validation and CI without altering existing Sonarr behavior.

New Features:
- Add validation rules ensuring Radarr Remux is encoded as Bluray source value 9 with QualityModifierSpecification value 5 and not as a source specification.
- Introduce CLI support for validating only changed Radarr custom format files for Remux semantics via a dedicated argument.

Enhancements:
- Extend the source validation script to cover both source and quality-modifier semantics and to provide clearer error messaging.
- Integrate new unit tests for Radarr and Sonarr Remux handling into the validation workflow.

CI:
- Update the custom format validation GitHub Actions workflow to run the new unit tests, validate Remux semantics only on changed Radarr CF files, and fetch full git history for diff-based checks.

Tests:
- Add unit tests covering valid Radarr Bluray+Remux combinations, invalid Radarr Remux encodings, and Sonarr Remux remaining as a source specification.