### PR TITLE
feat(guide-sync): Resolve minor conflict with an SQP

### DIFF
--- a/docs/json/radarr/cf/51-surround.json
+++ b/docs/json/radarr/cf/51-surround.json
@@ -1,7 +1,7 @@
 {
   "trash_id": "77ff61788dfe1097194fd8743d7b4524",
     "trash_scores": {
-    "sqp-4-ma-hybrid": 370
+    "sqp-4-ma-hybrid": 365
   },
   "name": "5.1 Surround",
   "includeCustomFormatWhenRenaming": false,

--- a/docs/json/radarr/cf/71-surround.json
+++ b/docs/json/radarr/cf/71-surround.json
@@ -1,7 +1,7 @@
 {
   "trash_id": "e77382bcfeba57cb83744c9c5449b401",
     "trash_scores": {
-    "sqp-4-ma-hybrid": 375
+    "sqp-4-ma-hybrid": 370
   },
   "name": "7.1 Surround",
   "includeCustomFormatWhenRenaming": false,

--- a/docs/json/radarr/cf/dd.json
+++ b/docs/json/radarr/cf/dd.json
@@ -6,7 +6,7 @@
     "sqp-1-web-1080p": 115,
     "sqp-1-2160p": 115,
     "sqp-1-web-2160p": 115,
-    "sqp-4-ma-hybrid": 630
+    "sqp-4-ma-hybrid": 635
   },
   "name": "DD",
   "includeCustomFormatWhenRenaming": false,

--- a/docs/json/radarr/cf/hallowed.json
+++ b/docs/json/radarr/cf/hallowed.json
@@ -2,7 +2,7 @@
   "trash_id": "7a0d1ad358fee9f5b074af3ef3f9d9ef",
   "trash_scores": {
     "default": 600,
-    "sqp-4-ma-hybrid": 3025
+    "sqp-4-ma-hybrid": 3030
   },
   "name": "hallowed",
   "includeCustomFormatWhenRenaming": false,

--- a/docs/json/radarr/cf/webdl-boost.json
+++ b/docs/json/radarr/cf/webdl-boost.json
@@ -1,7 +1,7 @@
 {
   "trash_id": "8df7fe4569063d39319f07e69707285a",
   "trash_scores": {
-    "sqp-4-ma-hybrid": 3035
+    "sqp-4-ma-hybrid": 3040
   },
   "name": "WEBDL Boost",
   "includeCustomFormatWhenRenaming": false,

--- a/docs/json/radarr/quality-profiles/sqp-4-ma-hybrid.json
+++ b/docs/json/radarr/quality-profiles/sqp-4-ma-hybrid.json
@@ -6,7 +6,7 @@
   "group": 98,
   "upgradeAllowed": true,
   "cutoff": "Bluray|WEB-2160p",
-  "minFormatScore": 3035,
+  "minFormatScore": 3040,
   "cutoffFormatScore": 10000,
   "minUpgradeFormatScore": 1,
   "language": "Original",


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->

Resolve minor conflict with an SQP

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Update Radarr custom format and quality profile JSON definitions to resolve a minor conflict with an existing SQP.

Enhancements:
- Adjust Radarr custom format JSON files related to surround, Dolby Digital, hallowed, and WEB-DL boost audio handling.
- Align the SQP-4 MA Hybrid Radarr quality profile JSON with the updated custom formats to avoid conflicts.