### PR TITLE
fix(sonarr): Corrected reference from Radarr to Sonarr

### DIFF
--- a/docs/Sonarr/sonarr-setup-quality-profiles.md
+++ b/docs/Sonarr/sonarr-setup-quality-profiles.md
@@ -234,7 +234,7 @@ The following custom format groups should be combined with the Quality Profiles 
 
 ??? tip "Proper and Repacks - [Click to show/hide]"
 
-    We also suggest that you change the Propers and Repacks settings in Radarr.
+    We also suggest that you change the Propers and Repacks settings in Sonarr.
 
     `Media Management` => `File Management` to `Do Not Prefer` and use the [Repack/Proper](/Sonarr/sonarr-collection-of-custom-formats/#repackproper) Custom Format.
 


### PR DESCRIPTION
# Pull Request

## Purpose

Typo fix. Radarr was most likely referenced as a result of copy paste.

## Approach

Replace `Radarr` reference with `Sonarr`.

## Open Questions and Pre-Merge TODOs

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Documentation:
- Update Sonarr setup quality profiles guide to refer to Sonarr instead of Radarr in the Propers and Repacks settings tip.