### PR TITLE
feat(radarr): Move ATELiER from Remux Tier 02 to Remux Tier 01

### DIFF
--- a/docs/json/radarr/cf/remux-tier-01.json
+++ b/docs/json/radarr/cf/remux-tier-01.json
@@ -27,6 +27,15 @@
       }
     },
     {
+      "name": "ATELiER",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(ATELiER)$"
+      }
+    },
+    {
       "name": "BiZKiT",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,

--- a/docs/json/radarr/cf/remux-tier-02.json
+++ b/docs/json/radarr/cf/remux-tier-02.json
@@ -18,15 +18,6 @@
       }
     },
     {
-      "name": "ATELiER",
-      "implementation": "ReleaseGroupSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "^(ATELiER)$"
-      }
-    },
-    {
       "name": "NCmt",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,


### PR DESCRIPTION
## Purpose

ATELiER has consistently delivered excellent quality remux releases and meets the Tier 01 bar for release groups: strong reputation, careful source analysis, retail sources only.

## Approach

Moved the `ATELiER` `ReleaseGroupSpecification` entry out of `docs/json/radarr/cf/remux-tier-02.json` and into `docs/json/radarr/cf/remux-tier-01.json`, keeping alphabetical ordering within the tier.

## Open Questions and Pre-Merge TODOs

None.

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).

## AI disclosure

This pull request was created with AI assistance.

## Summary by Sourcery

New Features:
- Update Radarr remux tier configuration to classify ATELiER as a tier 01 release group instead of tier 02.