### PR TITLE
fix(starr): CF `TrueHD Atmos` and `TrueHD` to prevent false positives with RlsGrps that only mention TrueHD but are actually TrueHD Atmos

### DIFF
--- a/docs/json/radarr/cf/truehd-atmos.json
+++ b/docs/json/radarr/cf/truehd-atmos.json
@@ -26,7 +26,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\b(ATMOS|CtrlHD|W4NK3R|DON)(\\b|\\d)"
+        "value": "\\b(ATMOS|CtrlHD|W4NK3R|HQMUX|DON)(\\b|\\d)"
       }
     },
     {
@@ -39,7 +39,7 @@
       }
     },
     {
-      "name": "Not Dolby Digital Plus ",
+      "name": "Not Dolby Digital Plus",
       "implementation": "ReleaseTitleSpecification",
       "negate": true,
       "required": true,
@@ -72,6 +72,15 @@
       "required": true,
       "fields": {
         "value": "\\bFLAC(\\b|\\d)"
+      }
+    },
+    {
+      "name": "Not 5.1 Surround",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": true,
+      "required": true,
+      "fields": {
+        "value": "[^0-9]5[ .][0-1]\\b"
       }
     }
   ]

--- a/docs/json/radarr/cf/truehd.json
+++ b/docs/json/radarr/cf/truehd.json
@@ -30,6 +30,15 @@
       }
     },
     {
+      "name": "Not Atmos Group (non-5.1)",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": true,
+      "required": true,
+      "fields": {
+        "value": "^(?!.*[^0-9]5[ .][0-1]\\b).*\\b(HQMUX|W4NK3R|DON|CtrlHD)\\b"
+      }
+    },
+    {
       "name": "Not Dolby Digital Plus",
       "implementation": "ReleaseTitleSpecification",
       "negate": true,
@@ -63,15 +72,6 @@
       "required": true,
       "fields": {
         "value": "\\bDD[^a-z+]|(?<!e-)\\b(ac-?3)\\b"
-      }
-    },
-    {
-      "name": "Not RlsGrp (TrueHD only)",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": true,
-      "required": true,
-      "fields": {
-        "value": "\\b(CtrlHD|W4NK3R|DON)\\b"
       }
     }
   ]

--- a/docs/json/sonarr/cf/truehd-atmos.json
+++ b/docs/json/sonarr/cf/truehd-atmos.json
@@ -12,7 +12,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "True[ .-]?HD"
+        "value": "True[ .-]?HD|W4NK3R|HQMUX"
       }
     },
     {
@@ -21,7 +21,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\bATMOS(\\b|\\d)"
+        "value": "\\b(ATMOS|CtrlHD|W4NK3R|HQMUX|DON)(\\b|\\d)"
       }
     },
     {
@@ -67,6 +67,15 @@
       "required": true,
       "fields": {
         "value": "\\bFLAC(\\b|\\d)"
+      }
+    },
+    {
+      "name": "Not 5.1 Surround",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": true,
+      "required": true,
+      "fields": {
+        "value": "[^0-9]5[ .][0-1]\\b"
       }
     }
   ]

--- a/docs/json/sonarr/cf/truehd-atmos.json
+++ b/docs/json/sonarr/cf/truehd-atmos.json
@@ -34,7 +34,7 @@
       }
     },
     {
-      "name": "Not Dolby Digital Plus ",
+      "name": "Not Dolby Digital Plus",
       "implementation": "ReleaseTitleSpecification",
       "negate": true,
       "required": true,

--- a/docs/json/sonarr/cf/truehd.json
+++ b/docs/json/sonarr/cf/truehd.json
@@ -25,6 +25,15 @@
       }
     },
     {
+      "name": "Not Atmos Group (non-5.1)",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": true,
+      "required": true,
+      "fields": {
+        "value": "^(?!.*[^0-9]5[ .][0-1]\\b).*\\b(HQMUX|W4NK3R|DON|CtrlHD)\\b"
+      }
+    },
+    {
       "name": "Not Dolby Digital Plus",
       "implementation": "ReleaseTitleSpecification",
       "negate": true,


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->

For the Custom Formats `TrueHD Atmos` and `TrueHD`, we added a workaround to match RlsGrps that only mention TrueHD but actually contain TrueHD Atmos. But we noticed some false positives with releases that mention TrueHD and are also only TrueHD.

After some research, we found out that:
- TrueHD Atmos releases are 7.1 and never 5.1.
- TrueHD exists as 5.1 and 7.1.

With this info, we created a workaround that should minimize false positives

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

Created a workaround that should minimize false positives

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Refine TrueHD and TrueHD Atmos custom formats to better distinguish between standard TrueHD and TrueHD Atmos releases in Radarr and Sonarr.

Bug Fixes:
- Adjust TrueHD Atmos custom formats to avoid matching plain TrueHD 5.1/7.1 releases as Atmos.
- Tighten TrueHD custom formats to reduce false positives when releases only mention TrueHD but are actually Atmos.