### PR TITLE
fix(radarr): CF `LQ (Release Title)` to avoid false positives when matching in file and folder names.

### DIFF
--- a/docs/json/radarr/cf/lq-release-title.json
+++ b/docs/json/radarr/cf/lq-release-title.json
@@ -42,7 +42,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "(?<=\\b[12]\\d{3}\\b.*?)(?<!\\b(web[ ._-]?(dl|rip)?).*?)\\b(EVO)\\b"
+        "value": "(?<!\\bweb[ ._-]?(dl|rip)?\\b.*)-(EVO)\\b"
       }
     },
     {
@@ -87,7 +87,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "(?<=\\b[12]\\d{3}\\b.*?)(?<!\\b(web[ ._-]?(dl|rip)?).*?)\\b(PiRaTeS)\\b"
+        "value": "(?<!\\bweb[ ._-]?(dl|rip)?\\b.*)-(PiRaTeS)\\b"
       }
     },
     {


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->

Fix Custom Format `LQ (Release Title)` to avoid false positives when matching in file and folder names.

The used regex pattern was unreliable because it only checks that a year appears somewhere before the match, not that the match itself is the release group.

The new regex pattern matches directly where a release group name actually sits, which is at the very end of the string, right after the final hyphen.

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

Fix Custom Format `LQ (Release Title)` to avoid false positives when matching in file and folder names.

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Update Radarr custom format configuration for low-quality release titles to improve accuracy of release group detection.

Bug Fixes:
- Adjust the `LQ (Release Title)` custom format pattern to prevent false positives when matching file and folder names in Radarr.

Documentation:
- Update the Radarr custom format JSON definition for `LQ (Release Title)` to reflect the corrected matching pattern.