### PR TITLE
feat(guide-sync): Added for an SQP a CF that includes a collection of curated UHD Blu-ray RlsGrps

### DIFF
--- a/docs/json/radarr/cf-groups/sqp-4-ma-hybrid-optional-release-groups.json
+++ b/docs/json/radarr/cf-groups/sqp-4-ma-hybrid-optional-release-groups.json
@@ -1,32 +1,37 @@
 {
-  "name": "[SQP-4 (MA Hybrid) Optional] Release Groups",
-  "trash_id": "f638e33c933bf0a8067559247953a270",
-  "trash_description": "Collection of optional Release Groups for SQP-4 (MA Hybrid), check written guide for extra information",
-  "custom_formats": [
-    {
-      "name": "FLUX",
-      "trash_id": "e098247bc6652dd88c76644b275260ed",
-      "required": false
-    },
-    {
-      "name": "SiC",
-      "trash_id": "8cd3ac70db7ac318cf9a0e01333940a4",
-      "required": false
-    },
-    {
-      "name": "126811",
-      "trash_id": "9681750c690210f0936faed781bb7f06",
-      "required": false
-    },
-    {
-      "name": "MainFrame",
-      "trash_id": "8016f2f66e751dea613e6b5b94bf633c",
-      "required": false
+    "name": "[SQP-4 (MA Hybrid) Optional] Release Groups",
+    "trash_id": "f638e33c933bf0a8067559247953a270",
+    "trash_description": "Collection of optional Release Groups for SQP-4 (MA Hybrid), check written guide for extra information",
+    "custom_formats": [
+        {
+            "name": "FLUX",
+            "trash_id": "e098247bc6652dd88c76644b275260ed",
+            "required": false
+        },
+        {
+            "name": "SiC",
+            "trash_id": "8cd3ac70db7ac318cf9a0e01333940a4",
+            "required": false
+        },
+        {
+            "name": "126811",
+            "trash_id": "9681750c690210f0936faed781bb7f06",
+            "required": false
+        },
+        {
+            "name": "MainFrame",
+            "trash_id": "8016f2f66e751dea613e6b5b94bf633c",
+            "required": false
+        },
+        {
+            "name": "UHD Bluray RlsGrp (SQP-4 MA)",
+            "trash_id": "c3ecdda99c633e0743627c2cc91566ec",
+            "required": false
+        }
+    ],
+    "quality_profiles": {
+        "include": {
+            "[SQP] SQP-4 (MA Hybrid)": "7526db7ac0a1f764793fb181864d0222"
+        }
     }
-  ],
-  "quality_profiles": {
-    "include": {
-      "[SQP] SQP-4 (MA Hybrid)": "7526db7ac0a1f764793fb181864d0222"
-    }
-  }
 }

--- a/docs/json/radarr/cf-groups/sqp-4-ma-hybrid-optional-sdr.json
+++ b/docs/json/radarr/cf-groups/sqp-4-ma-hybrid-optional-sdr.json
@@ -1,7 +1,7 @@
 {
   "name": "[SQP-4 (MA Hybrid) Optional] SDR",
   "trash_id": "19b55e2ab8b6c05d11858236ef5c93a9",
-  "trash_description": "You have three options for this custom format. Please read the instructions in the written guide on Discord.",
+  "trash_description": "You have two options for this custom format. Please read the instructions in the written guide on Discord.",
   "custom_formats": [
     {
       "name": "SDR",

--- a/docs/json/radarr/cf/mainframe.json
+++ b/docs/json/radarr/cf/mainframe.json
@@ -1,7 +1,7 @@
 {
   "trash_id": "8016f2f66e751dea613e6b5b94bf633c",
   "trash_scores": {
-    "sqp-4-ma-hybrid": 3960
+    "sqp-4-ma-hybrid": 2
   },
   "name": "MainFrame",
   "includeCustomFormatWhenRenaming": false,

--- a/docs/json/radarr/cf/uhd-bluray-rlsgrp-sqp-4-ma.json
+++ b/docs/json/radarr/cf/uhd-bluray-rlsgrp-sqp-4-ma.json
@@ -1,0 +1,109 @@
+{
+  "trash_id": "c3ecdda99c633e0743627c2cc91566ec",
+  "trash_scores": {
+    "sqp-4-ma-hybrid": 3960
+  },
+  "name": "UHD Bluray RlsGrp (SQP-4 MA)",
+  "includeCustomFormatWhenRenaming": false,
+  "specifications": [
+    {
+      "name": "2160p",
+      "implementation": "ResolutionSpecification",
+      "negate": false,
+      "required": true,
+      "fields": {
+        "value": 2160
+      }
+    },
+    {
+      "name": "Not REMUX",
+      "implementation": "QualityModifierSpecification",
+      "negate": true,
+      "required": true,
+      "fields": {
+        "value": 5
+      }
+    },
+    {
+      "name": "Not WEBDL",
+      "implementation": "SourceSpecification",
+      "negate": true,
+      "required": true,
+      "fields": {
+        "value": 7
+      }
+    },
+    {
+      "name": "Not WEBRIP",
+      "implementation": "SourceSpecification",
+      "negate": true,
+      "required": true,
+      "fields": {
+        "value": 8
+      }
+    },
+    {
+      "name": "CtrlHD",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(CtrlHD)$"
+      }
+    },
+    {
+      "name": "DON",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(DON)$"
+      }
+    },
+    {
+      "name": "HiDt",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(HiDt)$"
+      }
+    },
+    {
+      "name": "MainFrame",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(MainFrame)$"
+      }
+    },
+    {
+      "name": "RandomBytes",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(RandomBytes)$"
+      }
+    },
+    {
+      "name": "Softboat",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(Softboat)$"
+      }
+    },
+    {
+      "name": "W4NK3R",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(W4NK3R)$"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->

Added for an SQP a CF that includes a collection of curated UHD Blu-ray RlsGrps

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

Added for an SQP a CF that includes a collection of curated UHD Blu-ray RlsGrps

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Add a new UHD Blu-ray release-group custom format for SQP-4 MA and wire it into existing Radarr custom format configurations.

New Features:
- Introduce a curated UHD Blu-ray release-group custom format for SQP-4 MA profiles.

Enhancements:
- Update Radarr SQP-4 MA hybrid optional custom-format groups and mainframe configuration to reference the new UHD Blu-ray release-group custom format.