### PR TITLE
feat(starr): Add streaming service FAND (Fandango) to miscellaneous streaming services

### DIFF
--- a/docs/Radarr/Radarr-collection-of-custom-formats.md
+++ b/docs/Radarr/Radarr-collection-of-custom-formats.md
@@ -1456,7 +1456,7 @@ We've made 3 guides related to this.
 
 ---
 
-#### Fand
+#### FAND
 
 <sub>Fandango</sub>
 

--- a/docs/Radarr/Radarr-collection-of-custom-formats.md
+++ b/docs/Radarr/Radarr-collection-of-custom-formats.md
@@ -82,6 +82,7 @@ We've made 3 guides related to this.
 | [Canal+](#cnlp)         | [ITVX](#itvx)         | [VRV](#vrv)              |
 | [CBC](#cbc)             | [MY5](#my5)           |                          |
 | [Crave](#crav)          | [NOW](#now)           |                          |
+| [Fandango](#fand)       |                       |                          |
 | [OViD](#ovid)           |                       |                          |
 | [Star+](#strp)          |                       |                          |
 
@@ -1449,6 +1450,24 @@ We've made 3 guides related to this.
 
     ```json
     [[% filter indent(width=4) %]][[% include 'json/radarr/cf/crav.json' %]][[% endfilter %]]
+    ```
+
+<sub><sup>[TOP](#index)</sup></sub>
+
+---
+
+#### Fand
+
+<sub>Fandango</sub>
+
+??? question "Description - [Click to show/hide]"
+
+    {! include-markdown "../../includes/cf-descriptions/fand.md" !}
+
+??? example "JSON - [Click to show/hide]"
+
+    ```json
+    [[% filter indent(width=4) %]][[% include 'json/radarr/cf/fand.json' %]][[% endfilter %]]
     ```
 
 <sub><sup>[TOP](#index)</sup></sub>

--- a/docs/Sonarr/sonarr-collection-of-custom-formats.md
+++ b/docs/Sonarr/sonarr-collection-of-custom-formats.md
@@ -79,7 +79,8 @@ Special thanks to everyone who has helped in the creation and testing of these C
 | [CBC](#cbc)             | [BBC iPlayer](#ip)    |                                             |
 | [Crave](#crav)          | [ITVX](#itvx)         |                                             |
 | [Discovery+](#dscp)     | [MY5](#my5)           |                                             |
-| [OViD](#ovid)           | [NOW](#now)           |                                             |
+| [Fandango](#fand)       | [NOW](#now)           |                                             |
+| [OViD](#ovid)           |                       |                                             |
 | [Quibi](#qibi)          |                       |                                             |
 | [Star+](#strp)          |                       |                                             |
 | [YouTube Red](#red)     |                       |                                             |
@@ -1527,6 +1528,24 @@ Special thanks to everyone who has helped in the creation and testing of these C
 
     ```json
     [[% filter indent(width=4) %]][[% include 'json/sonarr/cf/dscp.json' %]][[% endfilter %]]
+    ```
+
+<sub><sup>[TOP](#index)</sup></sub>
+
+---
+
+#### FAND
+
+<sub>Fandango</sub>
+
+??? question "Description - [Click to show/hide]"
+
+    {! include-markdown "../../includes/cf-descriptions/fand.md" !}
+
+??? example "JSON - [Click to show/hide]"
+
+    ```json
+    [[% filter indent(width=4) %]][[% include 'json/sonarr/cf/fand.json' %]][[% endfilter %]]
     ```
 
 <sub><sup>[TOP](#index)</sup></sub>

--- a/docs/json/radarr/cf-groups/streaming-services-miscellaneous.json
+++ b/docs/json/radarr/cf-groups/streaming-services-miscellaneous.json
@@ -24,6 +24,11 @@
             "required": false
         },
         {
+            "name": "FAND",
+            "trash_id": "6c6af63910e3e4e8ff32a85102a94c11",
+            "required": false
+        },
+        {
             "name": "OViD",
             "trash_id": "fbca986396c5e695ef7b2def3c755d01",
             "required": false

--- a/docs/json/radarr/cf/cnlp.json
+++ b/docs/json/radarr/cf/cnlp.json
@@ -1,8 +1,5 @@
 {
   "trash_id": "1f9dfb4b8d9cae1f6dc0099547d53513",
-  "trash_scores": {
-    "default": 10
-  },
   "name": "CNLP",
   "includeCustomFormatWhenRenaming": true,
   "specifications": [

--- a/docs/json/radarr/cf/fand.json
+++ b/docs/json/radarr/cf/fand.json
@@ -1,0 +1,34 @@
+{
+  "trash_id": "6c6af63910e3e4e8ff32a85102a94c11",
+  "name": "FAND",
+  "includeCustomFormatWhenRenaming": true,
+  "specifications": [
+    {
+      "name": "FAND",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(FAND)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)"
+      }
+    },
+    {
+      "name": "WEBDL",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 7
+      }
+    },
+    {
+      "name": "WEBRIP",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 8
+      }
+    }
+  ]
+}

--- a/docs/json/sonarr/cf-groups/streaming-services-miscellaneous.json
+++ b/docs/json/sonarr/cf-groups/streaming-services-miscellaneous.json
@@ -29,6 +29,11 @@
             "required": false
         },
         {
+            "name": "FAND",
+            "trash_id": "1f233ed024e7c35cf50fbd739a82de4b",
+            "required": false
+        },
+        {
             "name": "OViD",
             "trash_id": "fb1a91cdc0f26f7ca0696e0e95274645",
             "required": false

--- a/docs/json/sonarr/cf/cnlp.json
+++ b/docs/json/sonarr/cf/cnlp.json
@@ -1,7 +1,7 @@
 {
   "trash_id": "543b0fb529e6b102837b8a9facdd82fb",
   "trash_scores": {
-    "default": 10
+    "default": 75
   },
   "name": "CNLP",
   "includeCustomFormatWhenRenaming": true,

--- a/docs/json/sonarr/cf/fand.json
+++ b/docs/json/sonarr/cf/fand.json
@@ -1,0 +1,37 @@
+{
+  "trash_id": "1f233ed024e7c35cf50fbd739a82de4b",
+  "trash_scores": {
+    "default": 75
+  },
+  "name": "FAND",
+  "includeCustomFormatWhenRenaming": true,
+  "specifications": [
+    {
+      "name": "Fandango",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(fand)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)"
+      }
+    },
+    {
+      "name": "WEBDL",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 3
+      }
+    },
+    {
+      "name": "WEBRIP",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 4
+      }
+    }
+  ]
+}

--- a/includes/cf-descriptions/fand.md
+++ b/includes/cf-descriptions/fand.md
@@ -1,0 +1,7 @@
+<!-- markdownlint-disable MD036 MD041-->
+**Fandango (FAND)**
+
+Fandango is an American video-on-demand streaming service, originally founded as Vudu in 2004. It was acquired by Walmart in 2010, then sold to Fandango Media in 2020, and has since been rebranded from Vudu to Fandango at Home, and finally to simply Fandango in 2026. It offers over 150,000 movies and TV shows available to rent or buy, including new releases in up to 4K UHD with Dolby Vision HDR, as well as a selection of free ad-supported titles with no subscription required.
+
+For more information, visit the [Fandango Wikipedia page](https://en.wikipedia.org/wiki/Fandango_(streaming_service)){:target="_blank" rel="noopener noreferrer"}.
+<!-- markdownlint-enable MD036 MD041-->


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->

Add streaming service FAND (Fandango) to miscellaneous streaming services

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

Add streaming service FAND (Fandango) to miscellaneous streaming services

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Add Fandango (FAND) as a documented miscellaneous streaming service custom format in both Sonarr and Radarr, including its JSON definitions and shared description.

New Features:
- Add Fandango (FAND) as a miscellaneous streaming service custom format for Sonarr.
- Add Fandango (FAND) as a miscellaneous streaming service custom format for Radarr.

Enhancements:
- Update Sonarr and Radarr custom format index tables to list Fandango among miscellaneous streaming services.

Documentation:
- Add shared description documentation for the Fandango (FAND) streaming service custom format.