### PR TITLE
feat(starr): Add RlsGrp `OldT` to `Bad Dual Groups`

### DIFF
--- a/docs/json/radarr/cf/bad-dual-groups.json
+++ b/docs/json/radarr/cf/bad-dual-groups.json
@@ -174,6 +174,15 @@
       }
     },
     {
+      "name": "OldT",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(OldT)$"
+      }
+    },
+    {
       "name": "ONLYMOViE",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,

--- a/docs/json/sonarr/cf/bad-dual-groups.json
+++ b/docs/json/sonarr/cf/bad-dual-groups.json
@@ -173,6 +173,15 @@
       }
     },
     {
+      "name": "OldT",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(OldT)$"
+      }
+    },
+    {
       "name": "PD",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->

Adds RlsGrp `OldT` to `Bad Dual Groups` because their multi-language releases do not set the original audio language as the first/default audio track.

Their releases consistently list audio tracks alphabetically for both shows and movies instead of sorting them by language priority. As a result, languages like Arabic or Czech may appear first even when they are not the original language.

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

Added RlsGrp `OldT` to `Bad Dual Groups` for both Radarr and Sonarr.

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

New Features:
- Treat OldT as a bad dual-audio release group in both Radarr and Sonarr profiles.