### PR TITLE
feat(starr): Add RlsGrp `3L` to the `TrueHD Atmos` Custom Format

### DIFF
--- a/docs/json/radarr/cf/truehd-atmos.json
+++ b/docs/json/radarr/cf/truehd-atmos.json
@@ -26,7 +26,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\b(ATMOS|CtrlHD|W4NK3R|HQMUX|DON)(\\b|\\d)"
+        "value": "\\b(ATMOS|CtrlHD|W4NK3R|HQMUX|DON|3L)(\\b|\\d)"
       }
     },
     {

--- a/docs/json/radarr/cf/truehd.json
+++ b/docs/json/radarr/cf/truehd.json
@@ -35,7 +35,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "^(?!.*[^0-9]5[ .][0-1]\\b).*\\b(HQMUX|W4NK3R|DON|CtrlHD)\\b"
+        "value": "^(?!.*[^0-9]5[ .][0-1]\\b).*\\b(HQMUX|W4NK3R|DON|CtrlHD|3L)\\b"
       }
     },
     {

--- a/docs/json/sonarr/cf/truehd-atmos.json
+++ b/docs/json/sonarr/cf/truehd-atmos.json
@@ -21,7 +21,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\b(ATMOS|CtrlHD|W4NK3R|HQMUX|DON)(\\b|\\d)"
+        "value": "\\b(ATMOS|CtrlHD|W4NK3R|HQMUX|DON|3L)(\\b|\\d)"
       }
     },
     {

--- a/docs/json/sonarr/cf/truehd.json
+++ b/docs/json/sonarr/cf/truehd.json
@@ -30,7 +30,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "^(?!.*[^0-9]5[ .][0-1]\\b).*\\b(HQMUX|W4NK3R|DON|CtrlHD)\\b"
+        "value": "^(?!.*[^0-9]5[ .][0-1]\\b).*\\b(HQMUX|W4NK3R|DON|CtrlHD|3L)\\b"
       }
     },
     {


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->

Releases from RlsGrp 3L only mention TrueHD, but they actually include TrueHD Atmos.
We know that TrueHD Atmos is always 7.1, while TrueHD can be 5.1 or 7.1.
To ensure a TrueHD 5.1 doesn't match TrueHD Atmos, we added a condition that prevents matching on 5.1 audio channels.

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

Added RlsGrp `3L` to the `Atmos` condition of the `TrueHD Atmos` Custom Format
Added RlsGrp `3L` to the `Not Atmos Group (non-5.1)` condition of the `TrueHD` Custom Format to prevent double scoring

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Update TrueHD custom-format matching to accurately classify RlsGrp `3L` Atmos releases while excluding non-Atmos 5.1 audio.

New Features:
- Recognize RlsGrp `3L` releases as `TrueHD Atmos` in Radarr and Sonarr custom formats.

Bug Fixes:
- Prevent `3L` TrueHD 5.1 releases from matching the Atmos format and receiving duplicate scoring.