### PR TITLE
chore(guide): Auto-detect the current SABnzbd version and open a PR

### DIFF
--- a/.github/workflows/update-sabnzbd-wiki-links.yml
+++ b/.github/workflows/update-sabnzbd-wiki-links.yml
@@ -5,11 +5,19 @@ on:
     - cron: "0 6 * * 1"  # Every Monday at 06:00 UTC
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   update-links:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Detect current SABnzbd wiki version
         id: version
@@ -43,10 +51,12 @@ jobs:
           echo "version=$CURRENT" >> "$GITHUB_OUTPUT"
 
       - name: Replace old version numbers in SABnzbd guides
+        env:
+          SAB_VERSION: ${{ steps.version.outputs.version }}
         run: |
           set -euo pipefail
           find docs/Downloaders/SABnzbd -name '*.md' -exec sed -i -E \
-            "s#(sabnzbd\.org/wiki/configuration/)[0-9]+\.[0-9]+#\1${{ steps.version.outputs.version }}#g" {} +
+            "s#(sabnzbd\.org/wiki/configuration/)[0-9]+\.[0-9]+#\1${SAB_VERSION}#g" {} +
 
       - name: Check for changes
         id: diff
@@ -57,7 +67,7 @@ jobs:
             echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
 
-      - uses: peter-evans/create-pull-request@v6
+      - uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         if: steps.diff.outputs.changed == 'true'
         with:
           commit-message: "fix(downloaders): update SABnzbd wiki links"

--- a/.github/workflows/update-sabnzbd-wiki-links.yml
+++ b/.github/workflows/update-sabnzbd-wiki-links.yml
@@ -1,0 +1,47 @@
+name: Update SABnzbd wiki links
+
+on:
+  schedule:
+    - cron: "0 6 * * 1"  # Every Monday at 06:00 UTC
+  workflow_dispatch:
+
+jobs:
+  update-links:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Detect current SABnzbd wiki version
+        id: version
+        run: |
+          CURRENT=$(curl -s https://sabnzbd.org/wiki/configuration/ \
+            | grep -oP 'configuration/\K[0-9]+\.[0-9]+' | head -1)
+          if [ -z "$CURRENT" ]; then
+            echo "Could not detect a version number, stopping." >&2
+            exit 1
+          fi
+          echo "version=$CURRENT" >> "$GITHUB_OUTPUT"
+
+      - name: Replace old version numbers in docs
+        run: |
+          find docs -name '*.md' -exec sed -i -E \
+            "s#(sabnzbd\.org/wiki/configuration/)[0-9]+\.[0-9]+#\1${{ steps.version.outputs.version }}#g" {} +
+
+      - name: Check for changes
+        id: diff
+        run: |
+          if git diff --quiet; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: peter-evans/create-pull-request@v6
+        if: steps.diff.outputs.changed == 'true'
+        with:
+          commit-message: "fix(downloaders): update SABnzbd wiki links"
+          title: "fix(downloaders): update SABnzbd wiki links to v${{ steps.version.outputs.version }}"
+          branch: fix/downloaders-sabnzbd-wiki-links
+          body: >
+            Auto-generated. Review the diff before merging, sabnzbd.org
+            sometimes restructures pages between versions.

--- a/.github/workflows/update-sabnzbd-wiki-links.yml
+++ b/.github/workflows/update-sabnzbd-wiki-links.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Detect current SABnzbd wiki version
         id: version
         run: |
-          CURRENT=$(curl -s https://sabnzbd.org/wiki/configuration/ \
+          CURRENT=$(curl -sS --fail --show-error --max-time 30 --retry 3 --retry-delay 5 https://sabnzbd.org/wiki/configuration/ \
             | grep -oP 'configuration/\K[0-9]+\.[0-9]+' | head -1)
           if [ -z "$CURRENT" ]; then
             echo "Could not detect a version number, stopping." >&2

--- a/.github/workflows/update-sabnzbd-wiki-links.yml
+++ b/.github/workflows/update-sabnzbd-wiki-links.yml
@@ -14,17 +14,38 @@ jobs:
       - name: Detect current SABnzbd wiki version
         id: version
         run: |
-          CURRENT=$(curl -s https://sabnzbd.org/wiki/configuration/ \
-            | grep -oP 'configuration/\K[0-9]+\.[0-9]+' | head -1)
+          set -euo pipefail
+
+          PAGE=$(curl -sS --fail --show-error --max-time 30 --retry 3 --retry-delay 5 \
+            https://sabnzbd.org/wiki/configuration/)
+
+          # Primary: the "Configure" nav link, e.g.
+          # href="https://sabnzbd.org/wiki/configuration/5.1/configure"
+          CURRENT=$(echo "$PAGE" \
+            | grep -oP 'href="https://sabnzbd\.org/wiki/configuration/\K[0-9]+\.[0-9]+(?=/configure")' \
+            | sort -V | tail -1)
+
+          # Fallback: any configuration/X.Y occurrence on the page, highest wins.
           if [ -z "$CURRENT" ]; then
-            echo "Could not detect a version number, stopping." >&2
+            echo "::warning::Primary selector found no match, falling back to a looser pattern."
+            CURRENT=$(echo "$PAGE" \
+              | grep -oP 'configuration/\K[0-9]+\.[0-9]+' \
+              | sort -V | tail -1)
+          fi
+
+          if [ -z "$CURRENT" ]; then
+            echo "::error::Could not detect a SABnzbd wiki version number. The page structure likely changed, both the anchor-based and fallback selectors found nothing. Update the grep pattern in this workflow."
+            echo "--- First 40 lines of the fetched page, for debugging ---"
+            echo "$PAGE" | head -40
             exit 1
           fi
+
           echo "version=$CURRENT" >> "$GITHUB_OUTPUT"
 
-      - name: Replace old version numbers in docs
+      - name: Replace old version numbers in SABnzbd guides
         run: |
-          find docs -name '*.md' -exec sed -i -E \
+          set -euo pipefail
+          find docs/Downloaders/SABnzbd -name '*.md' -exec sed -i -E \
             "s#(sabnzbd\.org/wiki/configuration/)[0-9]+\.[0-9]+#\1${{ steps.version.outputs.version }}#g" {} +
 
       - name: Check for changes


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->

The `SABnzbd - Basic Setup Guide` has direct links to the official `SABnzbd - Wiki`.
The problem is that when the SABnzbd version number changes, the `SABnzbd - Wiki` links also change, resulting in a broken link in the `SABnzbd - Basic Setup Guide`.

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

A small script fetches the SABnzbd wiki index, extracts the version number, and if it doesn't match what's in the TRaSH-Guides, it rewrites the links and opens a PR
It runs every Monday at 06:00 UTC and opens a PR only when the version number actually changes.

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Automate detection and pull-request creation for updated SABnzbd wiki links.

Bug Fixes:
- Automate updates to SABnzbd wiki links when the current wiki version changes.

Enhancements:
- Detect the current SABnzbd wiki version from the official site and update guide references only when needed.

CI:
- Add a scheduled and manually triggerable workflow that creates a pull request for detected SABnzbd wiki link changes.