### PR TITLE
fix(gha): read SABnzbd wiki version from sabnzbd.github.io _config.yml

### DIFF
--- a/.github/workflows/update-sabnzbd-wiki-links.yml
+++ b/.github/workflows/update-sabnzbd-wiki-links.yml
@@ -24,27 +24,19 @@ jobs:
         run: |
           set -euo pipefail
 
-          PAGE=$(curl -sS --fail --show-error --max-time 30 --retry 3 --retry-delay 5 \
-            https://sabnzbd.org/wiki/configuration/)
+          # sabnzbd.github.io is the wiki's own source of truth. wiki_version is
+          # the X.Y used in /wiki/configuration/<ver>/ links, and reading it is
+          # stable across releases; scraping the rendered page is not.
+          CONFIG=$(curl -sS --fail --show-error --max-time 30 --retry 3 --retry-delay 5 \
+            https://raw.githubusercontent.com/sabnzbd/sabnzbd.github.io/master/_config.yml)
 
-          # Primary: the "Configure" nav link, e.g.
-          # href="https://sabnzbd.org/wiki/configuration/5.1/configure"
-          CURRENT=$(echo "$PAGE" \
-            | grep -oP 'href="https://sabnzbd\.org/wiki/configuration/\K[0-9]+\.[0-9]+(?=/configure")' \
-            | sort -V | tail -1) || true
-
-          # Fallback: any configuration/X.Y occurrence on the page, highest wins.
-          if [ -z "$CURRENT" ]; then
-            echo "::warning::Primary selector found no match, falling back to a looser pattern."
-            CURRENT=$(echo "$PAGE" \
-              | grep -oP 'configuration/\K[0-9]+\.[0-9]+' \
-              | sort -V | tail -1) || true
-          fi
+          CURRENT=$(printf '%s\n' "$CONFIG" \
+            | grep -oP "^wiki_version:[[:space:]]*['\"]?\K[0-9]+\.[0-9]+") || true
 
           if [ -z "$CURRENT" ]; then
-            echo "::error::Could not detect a SABnzbd wiki version number. The page structure likely changed, both the anchor-based and fallback selectors found nothing. Update the grep pattern in this workflow."
-            echo "--- First 40 lines of the fetched page, for debugging ---"
-            echo "$PAGE" | head -40
+            echo "::error::Could not read wiki_version from sabnzbd.github.io _config.yml. The file format may have changed; update the parser in this workflow."
+            echo "--- First 20 lines of _config.yml, for debugging ---"
+            printf '%s\n' "$CONFIG" | head -20
             exit 1
           fi
 

--- a/.github/workflows/update-sabnzbd-wiki-links.yml
+++ b/.github/workflows/update-sabnzbd-wiki-links.yml
@@ -31,7 +31,7 @@ jobs:
             https://raw.githubusercontent.com/sabnzbd/sabnzbd.github.io/master/_config.yml)
 
           CURRENT=$(printf '%s\n' "$CONFIG" \
-            | grep -oP "^wiki_version:[[:space:]]*['\"]?\K[0-9]+\.[0-9]+") || true
+            | grep -oP "^wiki_version:[[:space:]]*['\"]?\K[0-9]+\.[0-9]+" || true)
 
           if [ -z "$CURRENT" ]; then
             echo "::error::Could not read wiki_version from sabnzbd.github.io _config.yml. The file format may have changed; update the parser in this workflow."

--- a/.github/workflows/update-sabnzbd-wiki-links.yml
+++ b/.github/workflows/update-sabnzbd-wiki-links.yml
@@ -31,14 +31,14 @@ jobs:
           # href="https://sabnzbd.org/wiki/configuration/5.1/configure"
           CURRENT=$(echo "$PAGE" \
             | grep -oP 'href="https://sabnzbd\.org/wiki/configuration/\K[0-9]+\.[0-9]+(?=/configure")' \
-            | sort -V | tail -1)
+            | sort -V | tail -1) || true
 
           # Fallback: any configuration/X.Y occurrence on the page, highest wins.
           if [ -z "$CURRENT" ]; then
             echo "::warning::Primary selector found no match, falling back to a looser pattern."
             CURRENT=$(echo "$PAGE" \
               | grep -oP 'configuration/\K[0-9]+\.[0-9]+' \
-              | sort -V | tail -1)
+              | sort -V | tail -1) || true
           fi
 
           if [ -z "$CURRENT" ]; then

--- a/.github/workflows/update-sabnzbd-wiki-links.yml
+++ b/.github/workflows/update-sabnzbd-wiki-links.yml
@@ -11,6 +11,10 @@ permissions:
 jobs:
   update-links:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+    concurrency:
+      group: sabnzbd-wiki-links
+      cancel-in-progress: false
     permissions:
       contents: write
       pull-requests: write
@@ -25,12 +29,15 @@ jobs:
           set -euo pipefail
 
           # wiki_version in the wiki's own _config.yml is the canonical X.Y used in
-          # /wiki/configuration/<ver>/ links. Capture exactly X.Y. With set -euo
-          # pipefail the step fails loudly if the fetch (curl --fail) or the parse
-          # (grep no-match) fails, so no hand-rolled error branches are needed.
+          # /wiki/configuration/<ver>/ links. -m1 guards a duplicate key; the error
+          # branch names which half failed (fetch vs pattern) so a future upstream
+          # format change is obvious in the run log rather than a bare exit 1.
           VERSION=$(curl -fsS --retry 3 --max-time 30 \
             https://raw.githubusercontent.com/sabnzbd/sabnzbd.github.io/master/_config.yml \
-            | grep -oP "^wiki_version:\s*['\"]?\K[0-9]+\.[0-9]+")
+            | grep -oPm1 "^wiki_version:\s*['\"]?\K[0-9]+\.[0-9]+") || {
+              echo "::error::Could not read wiki_version from sabnzbd.github.io/_config.yml (fetch failed, or the X.Y pattern is gone and the file format changed)."
+              exit 1
+            }
 
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/update-sabnzbd-wiki-links.yml
+++ b/.github/workflows/update-sabnzbd-wiki-links.yml
@@ -2,7 +2,7 @@ name: Update SABnzbd wiki links
 
 on:
   schedule:
-    - cron: "0 6 * * 1"  # Every Monday at 06:00 UTC
+    - cron: "0 6 * * 6"  # Every Saturday at 06:00 UTC
   workflow_dispatch:
 
 permissions:
@@ -27,9 +27,15 @@ jobs:
           # sabnzbd.github.io is the wiki's own source of truth. wiki_version is
           # the X.Y used in /wiki/configuration/<ver>/ links, and reading it is
           # stable across releases; scraping the rendered page is not.
-          CONFIG=$(curl -sS --fail --show-error --max-time 30 --retry 3 --retry-delay 5 \
-            https://raw.githubusercontent.com/sabnzbd/sabnzbd.github.io/master/_config.yml)
+          if ! CONFIG=$(curl -sS --fail --show-error --max-time 30 --retry 3 --retry-delay 5 \
+            https://raw.githubusercontent.com/sabnzbd/sabnzbd.github.io/master/_config.yml); then
+            echo "::error::Failed to fetch _config.yml from sabnzbd.github.io (network error or non-200 response, not a parser problem)."
+            exit 1
+          fi
 
+          # wiki_version is the X.Y used in /wiki/configuration/<ver>/ paths and in
+          # the sed replacement below, so capture exactly X.Y (a 3-component or
+          # suffixed value would produce broken /configuration/X.Y.Z links).
           CURRENT=$(printf '%s\n' "$CONFIG" \
             | grep -oP "^wiki_version:[[:space:]]*['\"]?\K[0-9]+\.[0-9]+" || true)
 

--- a/.github/workflows/update-sabnzbd-wiki-links.yml
+++ b/.github/workflows/update-sabnzbd-wiki-links.yml
@@ -24,29 +24,15 @@ jobs:
         run: |
           set -euo pipefail
 
-          # sabnzbd.github.io is the wiki's own source of truth. wiki_version is
-          # the X.Y used in /wiki/configuration/<ver>/ links, and reading it is
-          # stable across releases; scraping the rendered page is not.
-          if ! CONFIG=$(curl -sS --fail --show-error --max-time 30 --retry 3 --retry-delay 5 \
-            https://raw.githubusercontent.com/sabnzbd/sabnzbd.github.io/master/_config.yml); then
-            echo "::error::Failed to fetch _config.yml from sabnzbd.github.io (network error or non-200 response, not a parser problem)."
-            exit 1
-          fi
+          # wiki_version in the wiki's own _config.yml is the canonical X.Y used in
+          # /wiki/configuration/<ver>/ links. Capture exactly X.Y. With set -euo
+          # pipefail the step fails loudly if the fetch (curl --fail) or the parse
+          # (grep no-match) fails, so no hand-rolled error branches are needed.
+          VERSION=$(curl -fsS --retry 3 --max-time 30 \
+            https://raw.githubusercontent.com/sabnzbd/sabnzbd.github.io/master/_config.yml \
+            | grep -oP "^wiki_version:\s*['\"]?\K[0-9]+\.[0-9]+")
 
-          # wiki_version is the X.Y used in /wiki/configuration/<ver>/ paths and in
-          # the sed replacement below, so capture exactly X.Y (a 3-component or
-          # suffixed value would produce broken /configuration/X.Y.Z links).
-          CURRENT=$(printf '%s\n' "$CONFIG" \
-            | grep -oP "^wiki_version:[[:space:]]*['\"]?\K[0-9]+\.[0-9]+" || true)
-
-          if [ -z "$CURRENT" ]; then
-            echo "::error::Could not read wiki_version from sabnzbd.github.io _config.yml. The file format may have changed; update the parser in this workflow."
-            echo "--- First 20 lines of _config.yml, for debugging ---"
-            printf '%s\n' "$CONFIG" | head -20
-            exit 1
-          fi
-
-          echo "version=$CURRENT" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Replace old version numbers in SABnzbd guides
         env:


### PR DESCRIPTION
## What

The **Update SABnzbd wiki links** workflow failed ([run 32385023575](https://github.com/TRaSH-Guides/Guides/actions/runs/32385023575/job/96477299293)): the detection step scraped the rendered `sabnzbd.org/wiki/configuration/` page, and sabnzbd.org restructured it so the selectors no longer matched (and, under `set -euo pipefail`, the no-match aborted the step before its fallback).

## Fix

Read `wiki_version` directly from the wiki's own source of truth, [`sabnzbd.github.io/_config.yml`](https://github.com/sabnzbd/sabnzbd.github.io/blob/master/_config.yml#L5). That field is the canonical `X.Y` the site uses for `/wiki/configuration/<ver>/` links (currently `5.1`) and is stable across releases, unlike the rendered HTML.

## Verified

`curl` the raw `_config.yml` + the new `grep -oP` parser returns `5.1`.

## Summary by Sourcery

Make SABnzbd wiki link updates reliably track the canonical wiki version source.

Bug Fixes:
- Read the SABnzbd wiki version from the canonical `_config.yml` source instead of scraping unstable rendered HTML, preventing workflow failures when the site structure changes.

Enhancements:
- Improve workflow reliability with clearer version-detection errors, execution time limits, and concurrency control.

CI:
- Run the SABnzbd wiki link update workflow every Saturday instead of every Monday.