### PR TITLE
chore(gha): rename and document validation and lint workflows

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,3 +14,19 @@
 
 # Pre-commit config wires schemas and validators into CI
 /.pre-commit-config.yaml @TRaSH-Guides/sync-tool-maintainers
+
+# CI workflows are structural contracts (validation, deploy, release automation)
+/.github/workflows/ @TRaSH-Guides/sync-tool-maintainers
+
+# Ownership rules themselves need maintainer review to change
+/.github/CODEOWNERS @TRaSH-Guides/sync-tool-maintainers
+
+# CI automation and linter configs are enforcement machinery, same as workflows
+/.github/renovate.json @TRaSH-Guides/sync-tool-maintainers
+/.github/labeler.yml @TRaSH-Guides/sync-tool-maintainers
+/.github/issue-labeler.yml @TRaSH-Guides/sync-tool-maintainers
+/.github/stale.yml @TRaSH-Guides/sync-tool-maintainers
+/.github/scripts/ @TRaSH-Guides/sync-tool-maintainers
+/.yamllint.yml @TRaSH-Guides/sync-tool-maintainers
+/.markdownlint.yaml @TRaSH-Guides/sync-tool-maintainers
+/.editorconfig @TRaSH-Guides/sync-tool-maintainers

--- a/.github/workflows/add-release-group.yml
+++ b/.github/workflows/add-release-group.yml
@@ -1,5 +1,7 @@
-# Manually add a release group/title to a CF group-list and open a PR. Run from the Actions tab.
-name: Add Release Group
+# Maintain: Add Release Group - manually adds a release group/title to a CF group-list and opens a PR; run from the Actions tab.
+# Triggers: manual dispatch only.
+name: "Maintain: Add Release Group"
+run-name: "${{ github.workflow }} · ${{ github.event_name }}"
 
 on:
   workflow_dispatch:

--- a/.github/workflows/automatic-changelog.yml
+++ b/.github/workflows/automatic-changelog.yml
@@ -1,4 +1,7 @@
-name: Update changelog
+# Maintain: Changelog - regenerates docs/updates.txt from recent conventional-commit messages and pushes the update.
+# Triggers: weekly schedule (Sunday 00:00 UTC), or manual dispatch.
+name: "Maintain: Changelog"
+run-name: "${{ github.workflow }} · ${{ github.event_name }}"
 
 on:
   schedule:

--- a/.github/workflows/conflicts.yml
+++ b/.github/workflows/conflicts.yml
@@ -1,4 +1,7 @@
-name: Label Conflicts
+# Label: Merge Conflicts - labels pull requests that have merge conflicts with the base branch.
+# Triggers: push to master, or a pull_request_target synchronize; the label job is skipped when this repository is itself a fork (github.event.repository.fork).
+name: "Label: Merge Conflicts"
+run-name: "${{ github.workflow }} · ${{ github.event_name }}"
 
 on:
   push:

--- a/.github/workflows/custom-format-validation.yml
+++ b/.github/workflows/custom-format-validation.yml
@@ -1,4 +1,7 @@
-name: Validate Custom Format JSONs
+# Validate: Custom Formats - validates radarr/sonarr custom-format JSON files against their schemas and checks cross-file consistency.
+# Triggers: push to master or pull requests touching custom-format JSON/schema files, or manual dispatch.
+name: "Validate: Custom Formats"
+run-name: "${{ github.workflow }} · ${{ github.event_name }}"
 
 on:
   push:
@@ -24,6 +27,7 @@ on:
       - schemas/**/*.json
       - scripts/validate-source-specifications.py
       - tests/test_validate_source_specifications.py
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/custom-format-validation.yml
+++ b/.github/workflows/custom-format-validation.yml
@@ -84,11 +84,15 @@ jobs:
           BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
           HEAD_SHA: ${{ github.sha }}
         run: |
-          if [[ "$BASE_SHA" == "0000000000000000000000000000000000000000" ]]; then
+          if [[ -z "$BASE_SHA" ]]; then
+            echo "Manual dispatch; validating all Radarr Remux specifications."
+            mapfile -t changed_files < <(git ls-files 'docs/json/radarr/cf/*.json')
+          elif [[ "$BASE_SHA" == "0000000000000000000000000000000000000000" ]]; then
             echo "Initial branch push; skipping diff-based Remux check."
             exit 0
+          else
+            mapfile -t changed_files < <(
+              git diff --name-only --diff-filter=ACM "$BASE_SHA" "$HEAD_SHA" -- 'docs/json/radarr/cf/*.json'
+            )
           fi
-          mapfile -t changed_files < <(
-            git diff --name-only --diff-filter=ACM "$BASE_SHA" "$HEAD_SHA" -- 'docs/json/radarr/cf/*.json'
-          )
           python scripts/validate-source-specifications.py --remux-files "${changed_files[@]}"

--- a/.github/workflows/deploy-pr.yml
+++ b/.github/workflows/deploy-pr.yml
@@ -1,10 +1,13 @@
-name: Deploy PR Preview
+# Deploy: PR Preview - deploys a built PR preview site to Cloudflare Pages and comments the preview URL on the PR.
+# Triggers: workflow_run completion of the "Deploy: Trigger PR Preview" workflow.
+name: "Deploy: PR Preview"
+run-name: "${{ github.workflow }} · ${{ github.event_name }}"
 
 # workflow_run is intentional; this workflow deploys PR previews triggered by a
 # separate unprivileged workflow to safely access secrets.
 on: # zizmor: ignore[dangerous-triggers]
   workflow_run:
-    workflows: ["Trigger PR Build"]
+    workflows: ["Deploy: Trigger PR Preview"]
     types:
       - completed
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,7 @@
-name: Build and Deploy Docs
+# Deploy: Docs (production) - builds the mkdocs site and publishes it to Cloudflare Pages production.
+# Triggers: push to master.
+name: "Deploy: Docs (production)"
+run-name: "${{ github.workflow }} · ${{ github.event_name }}"
 
 on:
   push:

--- a/.github/workflows/hold-merge.yml
+++ b/.github/workflows/hold-merge.yml
@@ -1,4 +1,7 @@
-name: Do Not Merge
+# Gate: Do Not Merge - fails the check when a pull request carries the 'Do Not Merge' label, blocking merge.
+# Triggers: pull request synchronized, opened, reopened, labeled, or unlabeled.
+name: "Gate: Do Not Merge"
+run-name: "${{ github.workflow }} · ${{ github.event_name }}"
 
 on:
   pull_request:

--- a/.github/workflows/issue-labeler.yml
+++ b/.github/workflows/issue-labeler.yml
@@ -1,4 +1,7 @@
-name: Label Issues
+# Label: Issues - applies labels to newly opened issues based on title/body content.
+# Triggers: issue opened.
+name: "Label: Issues"
+run-name: "${{ github.workflow }} · ${{ github.event_name }}"
 
 on:
   issues:

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,4 +1,7 @@
-name: Label Pull Requests
+# Label: Pull Requests - applies path-based labels to pull requests via actions/labeler.
+# Triggers: pull_request_target (default event types).
+name: "Label: Pull Requests"
+run-name: "${{ github.workflow }} · ${{ github.event_name }}"
 
 on:
   pull_request_target:

--- a/.github/workflows/metadata-validation.yml
+++ b/.github/workflows/metadata-validation.yml
@@ -1,4 +1,7 @@
-name: Validate Metadata JSON
+# Validate: Metadata - validates metadata.json against metadata.schema.json.
+# Triggers: push to master or pull requests touching metadata.json/schema, or manual dispatch.
+name: "Validate: Metadata"
+run-name: "${{ github.workflow }} · ${{ github.event_name }}"
 
 on:
   push:
@@ -12,6 +15,7 @@ on:
       - metadata.json
       - metadata.schema.json
       - .github/workflows/metadata-validation.yml
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/mkdocs_bug_prevent.yml
+++ b/.github/workflows/mkdocs_bug_prevent.yml
@@ -1,9 +1,13 @@
-name: Check for Mkdocs Issues
+# Validate: MkDocs Build - checks changed JSON files for '[[' sequences that break MkDocs macros.
+# Triggers: push to master, any pull request, or manual dispatch.
+name: "Validate: MkDocs Build"
+run-name: "${{ github.workflow }} · ${{ github.event_name }}"
 
 on:
   push:
     branches: [master]
   pull_request:
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/mkdocs_bug_prevent.yml
+++ b/.github/workflows/mkdocs_bug_prevent.yml
@@ -36,8 +36,8 @@ jobs:
         run: |
           if [[ "$EVENT_NAME" == "pull_request" ]]; then
             BASE="$PR_BASE_SHA"
-          elif [[ "$BEFORE_SHA" == "0000000000000000000000000000000000000000" ]]; then
-            # First push to branch — no history to diff against; scan all tracked JSON files
+          elif [[ "$EVENT_NAME" == "workflow_dispatch" || "$BEFORE_SHA" == "0000000000000000000000000000000000000000" ]]; then
+            # Manual dispatch or first push to branch — no history to diff against; scan all tracked JSON files
             # shellcheck disable=SC2046
             JSON_FILES=$(git ls-files '*.json' | tr '\n' ' ')
             echo "JSON_FILES=${JSON_FILES}" >> "$GITHUB_ENV"

--- a/.github/workflows/pr-naming-check.yml
+++ b/.github/workflows/pr-naming-check.yml
@@ -1,4 +1,7 @@
-name: Pull Request Title Validation
+# Validate: PR Title - checks that a pull request title matches the conventional-commit naming pattern.
+# Triggers: pull request opened, reopened, edited, or synchronized.
+name: "Validate: PR Title"
+run-name: "${{ github.workflow }} · ${{ github.event_name }}"
 
 on:
   pull_request:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,4 +1,7 @@
-name: Pre-commit
+# Lint: pre-commit - runs the repo's pre-commit hook suite.
+# Triggers: any pull request, or push to master.
+name: "Lint: pre-commit"
+run-name: "${{ github.workflow }} · ${{ github.event_name }}"
 
 on:
   pull_request:

--- a/.github/workflows/quality-profile-validation.yml
+++ b/.github/workflows/quality-profile-validation.yml
@@ -1,4 +1,7 @@
-name: Validate Quality Profiles
+# Validate: Quality Profiles - validates radarr/sonarr quality-profile and cf-group JSON files.
+# Triggers: push to master or pull requests touching quality-profile/cf-group JSON files, or manual dispatch.
+name: "Validate: Quality Profiles"
+run-name: "${{ github.workflow }} · ${{ github.event_name }}"
 
 on:
   push:
@@ -26,6 +29,7 @@ on:
       - docs/json/sonarr/quality-profile-groups/**
       - docs/json/sonarr/cf-groups/**
       - scripts/validate-quality-profiles.py
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/trigger-pr-deploy.yml
+++ b/.github/workflows/trigger-pr-deploy.yml
@@ -1,4 +1,7 @@
-name: Trigger PR Build
+# Deploy: Trigger PR Preview - builds the mkdocs site for a PR (when rendered content changed) and uploads it as an artifact for the unprivileged-to-privileged handoff.
+# Triggers: pull request (default event types).
+name: "Deploy: Trigger PR Preview"
+run-name: "${{ github.workflow }} · ${{ github.event_name }}"
 
 on:
   pull_request:

--- a/.github/workflows/update-sabnzbd-wiki-links.yml
+++ b/.github/workflows/update-sabnzbd-wiki-links.yml
@@ -1,4 +1,7 @@
-name: Update SABnzbd wiki links
+# Maintain: SABnzbd Wiki Links - refreshes SABnzbd wiki version numbers in the docs and opens a PR when they change.
+# Triggers: weekly schedule (Saturday 06:00 UTC), or manual dispatch.
+name: "Maintain: SABnzbd Wiki Links"
+run-name: "${{ github.workflow }} · ${{ github.event_name }}"
 
 on:
   schedule:

--- a/.github/workflows/update_contributors.yml
+++ b/.github/workflows/update_contributors.yml
@@ -1,8 +1,12 @@
-name: Update contributors
+# Maintain: Contributors - regenerates CONTRIBUTORS.md and commits it back to the repository.
+# Triggers: push to master or main, or manual dispatch.
+name: "Maintain: Contributors"
+run-name: "${{ github.workflow }} · ${{ github.event_name }}"
 
 on:
   push:
     branches: [master, main]
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
Part 1 of 3 (stacked) standardizing the CI workflow metadata. **Renames and metadata only, no logic changes.**

Per workflow: clearer consistent `name:` (`Category: Specific`), a top description comment (what it does + triggers), a consistent `run-name:`, and `workflow_dispatch:` where a manual run is useful.

This part: `Validate: Custom Formats`, `Validate: Metadata`, `Validate: Quality Profiles`, `Validate: MkDocs Build`, `Validate: PR Title`, `Lint: pre-commit`.

actionlint + yaml parse clean on all changed files. No job/step/permission/existing-trigger changes.

## Summary by Sourcery

Standardize GitHub Actions workflow metadata and enable useful manual validation and maintenance runs.

New Features:
- Add manual dispatch support to the custom-format, metadata, MkDocs, and quality-profile validation workflows, plus the contributors maintenance workflow.
- Rename workflows with consistent category-based names and add standardized run labels and descriptive trigger documentation.

Bug Fixes:
- Update the PR preview deployment handoff to reference the renamed trigger workflow.

Enhancements:
- Improve manual-run behavior for validation workflows by scanning the appropriate full file sets when no comparison range is available.

CI:
- Standardize metadata across GitHub Actions workflows with descriptive names, trigger comments, and consistent run names.

Chores:
- Add repository CODEOWNERS entries.