### PR TITLE
feat(radarr): Move ATELiER from HD Bluray Tier 02 to HD Bluray Tier 01

### DIFF
--- a/docs/json/radarr/cf/hd-bluray-tier-01.json
+++ b/docs/json/radarr/cf/hd-bluray-tier-01.json
@@ -40,6 +40,15 @@
       }
     },
     {
+      "name": "ATELiER",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(ATELiER)$"
+      }
+    },
+    {
       "name": "BBQ",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,

--- a/docs/json/radarr/cf/hd-bluray-tier-02.json
+++ b/docs/json/radarr/cf/hd-bluray-tier-02.json
@@ -40,15 +40,6 @@
       }
     },
     {
-      "name": "ATELiER",
-      "implementation": "ReleaseGroupSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "^(ATELiER)$"
-      }
-    },
-    {
       "name": "EA",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,


### PR DESCRIPTION
## Summary
- Moves release group `ATELiER` from `HD Bluray Tier 02` to `HD Bluray Tier 01` in `docs/json/radarr/cf/`, as discussed in the TRaSH Guides Discord.

## Test plan
- [x] Verify JSON validates and no hashcode duplication
- [x] Confirm docs render correctly (auto-generated from JSON)

## Summary by Sourcery

Enhancements:
- Reclassify the ATELiER release group from HD Bluray Tier 02 to HD Bluray Tier 01 in the Radarr custom format definitions.