### PR TITLE
fix(downloaders): Update mover-tuning-start.sh

### DIFF
--- a/includes/downloaders/mover-tuning-start.sh
+++ b/includes/downloaders/mover-tuning-start.sh
@@ -4,7 +4,7 @@ set -euo pipefail # Exit on error, undefined variables, and pipe failures
 # =======================================
 # Script: qBittorrent Cache Mover - Start
 # Version: 1.3.4
-# Updated: 20260827
+# Updated: 20260902
 # =======================================
 
 # Script version and update check URLs
@@ -381,33 +381,52 @@ run_auto_installer() {
         # and the script would never be able to bootstrap its way to a
         # version that supports the flag. pip install --upgrade is idempotent,
         # so just always run it.
-        local pip_upgrade_ok=false
         log "Upgrading pip..."
         if "$venv_python" -m pip install --upgrade pip --quiet; then
             set_ownership "$VENV_PATH"
-            pip_upgrade_ok=true
-            log "✓ Pip is $("$venv_python" -m pip --version | awk '{print $2}')"
         else
-            log "⚠ Warning: Failed to upgrade pip; continuing with existing version ($("$venv_python" -m pip --version | awk '{print $2}'))"
+            log "⚠ Warning: Failed to upgrade pip; continuing with existing version"
         fi
 
+        # A successful upgrade command does NOT guarantee pip is now >= 22.2:
+        # it exits 0 even when no newer pip was available (old interpreter,
+        # pinned/private index, version constraints). Check the resulting
+        # version explicitly rather than trusting the upgrade's exit status.
+        local pip_version supports_dry_run lowest
+        pip_version=$("$venv_python" -m pip --version 2>/dev/null | awk '{print $2}')
+        supports_dry_run=false
+        if [[ -n "$pip_version" ]]; then
+            lowest=$(printf '%s\n' "$pip_version" "22.2" | sort -V | head -n1)
+            [[ "$lowest" == "22.2" ]] && supports_dry_run=true
+        fi
+        log "✓ Pip is $pip_version"
+
         # Install/upgrade qbittorrent-api using the same Python that will run mover.py.
-        # Only trust a --dry-run pre-check when pip was confirmed to upgrade
-        # successfully above (guaranteeing --dry-run support, added in pip
-        # 22.2). If the pip upgrade failed for any reason, don't risk a
-        # --dry-run failure being misread as "up to date" — just run the
-        # actual upgrade, which is a cheap no-op when already current.
+        # Only use the --dry-run pre-check when pip is confirmed >= 22.2. Even
+        # then, capture the dry-run command's own exit status separately from
+        # the grep match — a dry-run failure (e.g. index timeout) must not be
+        # misread as "nothing to upgrade". Any doubt falls back to the actual
+        # (idempotent, cheap-when-current) upgrade instead of skipping it.
         if "$venv_python" -c "import qbittorrentapi" 2>/dev/null; then
             log "✓ qbittorrent-api installed ($("$venv_python" -m pip show qbittorrent-api 2>/dev/null | awk '/Version:/ {print $2}'))"
 
-            if [[ "$pip_upgrade_ok" == true ]] && "$venv_python" -m pip install --dry-run --upgrade qbittorrent-api 2>&1 | grep -q "Would install"; then
-                log "Upgrading qbittorrent-api..."
-                "$venv_python" -m pip install qbittorrent-api --upgrade --quiet || log "⚠ Warning: Failed to upgrade qbittorrent-api"
-                set_ownership "$VENV_PATH"
-                log "✓ qbittorrent-api upgraded"
-            elif [[ "$pip_upgrade_ok" == true ]]; then
-                log "✓ qbittorrent-api is up to date"
-            else
+            local api_upgrade_needed=true dry_run_output dry_run_status
+            if [[ "$supports_dry_run" == true ]]; then
+                dry_run_output=$("$venv_python" -m pip install --dry-run --upgrade qbittorrent-api 2>&1)
+                dry_run_status=$?
+                if [[ $dry_run_status -eq 0 ]]; then
+                    if echo "$dry_run_output" | grep -q "Would install"; then
+                        api_upgrade_needed=true
+                    else
+                        api_upgrade_needed=false
+                        log "✓ qbittorrent-api is up to date"
+                    fi
+                else
+                    log "⚠ Warning: dry-run check failed — upgrading anyway to be safe"
+                fi
+            fi
+
+            if [[ "$api_upgrade_needed" == true ]]; then
                 log "Ensuring qbittorrent-api is up to date..."
                 "$venv_python" -m pip install qbittorrent-api --upgrade --quiet || log "⚠ Warning: Failed to upgrade qbittorrent-api"
                 set_ownership "$VENV_PATH"

--- a/includes/downloaders/mover-tuning-start.sh
+++ b/includes/downloaders/mover-tuning-start.sh
@@ -3,12 +3,12 @@ set -euo pipefail # Exit on error, undefined variables, and pipe failures
 
 # =======================================
 # Script: qBittorrent Cache Mover - Start
-# Version: 1.3.3
-# Updated: 20260614
+# Version: 1.3.4
+# Updated: 20260827
 # =======================================
 
 # Script version and update check URLs
-readonly SCRIPT_VERSION="1.3.3"
+readonly SCRIPT_VERSION="1.3.4"
 readonly SCRIPT_RAW_URL="https://raw.githubusercontent.com/TRaSH-Guides/Guides/refs/heads/master/includes/downloaders/mover-tuning-start.sh"
 readonly CONFIG_RAW_URL="https://raw.githubusercontent.com/TRaSH-Guides/Guides/refs/heads/master/includes/downloaders/mover-tuning.cfg"
 
@@ -376,30 +376,41 @@ run_auto_installer() {
     fi
 
     if "$venv_python" -m pip --version >/dev/null 2>&1; then
-        # Upgrade pip
-        if "$venv_python" -m pip install --dry-run --upgrade pip 2>&1 | grep -q "Would install"; then
-            log "Upgrading pip..."
-            if "$venv_python" -m pip install --upgrade pip --quiet; then
-                set_ownership "$VENV_PATH"
-                log "✓ Pip upgraded to $("$venv_python" -m pip --version | awk '{print $2}')"
-            else
-                log "⚠ Warning: Failed to upgrade pip; continuing with existing version ($("$venv_python" -m pip --version | awk '{print $2}'))"
-            fi
+        # Upgrade pip. No --dry-run pre-check here: --dry-run itself was only
+        # added in pip 22.2, so on an outdated pip the check fails silently
+        # and the script would never be able to bootstrap its way to a
+        # version that supports the flag. pip install --upgrade is idempotent,
+        # so just always run it.
+        local pip_upgrade_ok=false
+        log "Upgrading pip..."
+        if "$venv_python" -m pip install --upgrade pip --quiet; then
+            set_ownership "$VENV_PATH"
+            pip_upgrade_ok=true
+            log "✓ Pip is $("$venv_python" -m pip --version | awk '{print $2}')"
         else
-            log "✓ Pip is up to date ($("$venv_python" -m pip --version | awk '{print $2}'))"
+            log "⚠ Warning: Failed to upgrade pip; continuing with existing version ($("$venv_python" -m pip --version | awk '{print $2}'))"
         fi
 
         # Install/upgrade qbittorrent-api using the same Python that will run mover.py.
+        # Only trust a --dry-run pre-check when pip was confirmed to upgrade
+        # successfully above (guaranteeing --dry-run support, added in pip
+        # 22.2). If the pip upgrade failed for any reason, don't risk a
+        # --dry-run failure being misread as "up to date" — just run the
+        # actual upgrade, which is a cheap no-op when already current.
         if "$venv_python" -c "import qbittorrentapi" 2>/dev/null; then
             log "✓ qbittorrent-api installed ($("$venv_python" -m pip show qbittorrent-api 2>/dev/null | awk '/Version:/ {print $2}'))"
 
-            if "$venv_python" -m pip install --dry-run --upgrade qbittorrent-api 2>&1 | grep -q "Would install"; then
+            if [[ "$pip_upgrade_ok" == true ]] && "$venv_python" -m pip install --dry-run --upgrade qbittorrent-api 2>&1 | grep -q "Would install"; then
                 log "Upgrading qbittorrent-api..."
                 "$venv_python" -m pip install qbittorrent-api --upgrade --quiet || log "⚠ Warning: Failed to upgrade qbittorrent-api"
                 set_ownership "$VENV_PATH"
                 log "✓ qbittorrent-api upgraded"
-            else
+            elif [[ "$pip_upgrade_ok" == true ]]; then
                 log "✓ qbittorrent-api is up to date"
+            else
+                log "Ensuring qbittorrent-api is up to date..."
+                "$venv_python" -m pip install qbittorrent-api --upgrade --quiet || log "⚠ Warning: Failed to upgrade qbittorrent-api"
+                set_ownership "$VENV_PATH"
             fi
         else
             log "Installing qbittorrent-api..."


### PR DESCRIPTION
# Changelog

All notable changes to `mover-tuning-start.sh` are documented here. Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).

## [Unreleased]

### Fixed
- **Stuck qbittorrent-api version on some systems.** The dependency-update check used `pip install --dry-run --upgrade <pkg>` and grepped the output for `Would install` to decide whether an upgrade was needed. `--dry-run` was only added in pip 22.2, so on any venv with an older pip the command failed outright, the grep matched nothing, and the script silently logged "up to date" without ever checking — leaving affected users permanently stuck on their installed version of `qbittorrent-api`.
- **Pip self-upgrade had the same bug, making it self-perpetuating.** The pip version-check itself used the identical `--dry-run` pattern, so an outdated pip could never detect that a pip upgrade was available and bootstrap itself to a version that supports `--dry-run`. This masked the qbittorrent-api issue on affected systems indefinitely.

### Changed
- Pip is now upgraded unconditionally every run (`pip install --upgrade pip --quiet`) instead of being gated behind a `--dry-run` pre-check. This is idempotent and a near-no-op when already current, so it carries no real cost on the common path.
- The qbittorrent-api update check now only trusts `--dry-run` when this run's pip upgrade is confirmed to have succeeded (guaranteeing `--dry-run` support). If the pip upgrade fails for any reason, it falls back to an unconditional `pip install --upgrade` for qbittorrent-api rather than risking another silent false "up to date" — trading a slightly slower fallback path for the failure being caught rather than hidden.

# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Make the cache mover installer reliably maintain pip and qbittorrent-api dependencies across different pip versions and update failures.

Bug Fixes:
- Prevent dependency updates from being silently skipped on systems with older or malfunctioning pip versions.

Enhancements:
- Make pip upgrade attempts unconditional and use version-aware, failure-safe checks before deciding whether qbittorrent-api needs an upgrade.
- Fall back to installing or upgrading qbittorrent-api whenever dependency checks are unavailable or fail.

Chores:
- Bump the mover-tuning-start.sh script version to 1.3.4.