### PR TITLE
fix(starr): BR-DISK should match 720p full-disc releases

### DIFF
--- a/docs/json/radarr/cf/br-disk.json
+++ b/docs/json/radarr/cf/br-disk.json
@@ -5,7 +5,7 @@
     "german": -35000,
     "german-anime": -35000
   },
-  "trash_regex": "https://regex101.com/r/m6tJzR/1",
+  "trash_regex": "https://regex101.com/r/NnBZx0/1",
   "name": "BR-DISK",
   "includeCustomFormatWhenRenaming": false,
   "specifications": [

--- a/docs/json/radarr/cf/br-disk.json
+++ b/docs/json/radarr/cf/br-disk.json
@@ -5,7 +5,7 @@
     "german": -35000,
     "german-anime": -35000
   },
-  "trash_regex": "https://regex101.com/r/UpA3I7/2",
+  "trash_regex": "https://regex101.com/r/m6tJzR/1",
   "name": "BR-DISK",
   "includeCustomFormatWhenRenaming": false,
   "specifications": [
@@ -15,7 +15,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "^(?!.*\\b((?<!HD[._ -]|HD)DVD|BDRip|720p|MKV|XviD|WMV|d3g|(BD)?REMUX|^(?=.*1080p)(?=.*HEVC)|[xh][-_. ]?26[45]|German.*[DM]L|((?<=\\d{4}).*German.*([DM]L)?)(?=.*\\b(AVC|HEVC|VC[-_. ]?1|MVC|MPEG[-_. ]?2)\\b))\\b)(((?=.*\\b(Blu[-_. ]?ray|BD|HD[-_. ]?DVD)\\b)(?=.*\\b(AVC|HEVC|VC[-_. ]?1|MVC|MPEG[-_. ]?2|BDMV|ISO)\\b))|^((?=.*\\b(((?=.*\\b((.*_)?COMPLETE.*|Dis[ck])\\b)(?=.*(Blu[-_. ]?ray|HD[-_. ]?DVD)))|3D[-_. ]?BD|BR[-_. ]?DISK|Full[-_. ]?Blu[-_. ]?ray|^((?=.*((BD|UHD)[-_. ]?(25|50|66|100|ISO)))))))).*"
+        "value": "^(?!.*\\b((?<!HD[._ -]|HD)DVD|BDRip|MKV|XviD|WMV|d3g|(BD)?REMUX|^(?=.*1080p)(?=.*HEVC)|[xh][-_. ]?26[45]|German.*[DM]L|((?<=\\d{4}).*German.*([DM]L)?)(?=.*\\b(AVC|HEVC|VC[-_. ]?1|MVC|MPEG[-_. ]?2)\\b))\\b)(((?=.*\\b(Blu[-_. ]?ray|BD|HD[-_. ]?DVD)\\b)(?=.*\\b(AVC|HEVC|VC[-_. ]?1|MVC|MPEG[-_. ]?2|BDMV|ISO)\\b))|^((?=.*\\b(((?=.*\\b((.*_)?COMPLETE.*|Dis[ck])\\b)(?=.*(Blu[-_. ]?ray|HD[-_. ]?DVD)))|3D[-_. ]?BD|BR[-_. ]?DISK|Full[-_. ]?Blu[-_. ]?ray|^((?=.*((BD|UHD)[-_. ]?(25|50|66|100|ISO)))))))).*"
       }
     }
   ]

--- a/docs/json/sonarr/cf/br-disk-btn.json
+++ b/docs/json/sonarr/cf/br-disk-btn.json
@@ -3,7 +3,7 @@
   "trash_scores": {
     "default": -10000
   },
-  "trash_regex": "https://regex101.com/r/m6tJzR/1",
+  "trash_regex": "https://regex101.com/r/NnBZx0/1",
   "name": "BR-DISK (BTN)",
   "includeCustomFormatWhenRenaming": false,
   "specifications": [

--- a/docs/json/sonarr/cf/br-disk-btn.json
+++ b/docs/json/sonarr/cf/br-disk-btn.json
@@ -3,7 +3,7 @@
   "trash_scores": {
     "default": -10000
   },
-  "trash_regex": "https://regex101.com/r/UpA3I7/2",
+  "trash_regex": "https://regex101.com/r/m6tJzR/1",
   "name": "BR-DISK (BTN)",
   "includeCustomFormatWhenRenaming": false,
   "specifications": [
@@ -13,7 +13,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "^(?!.*\\b((?<!HD[._ -]|HD)DVD|BDRip|720p|MKV|XviD|WMV|d3g|(BD)?REMUX|^(?=.*1080p)(?=.*HEVC)|[x][-_. ]?26[45]|German.*[DM]L|((?<=\\d{4}).*German.*([DM]L)?)(?=.*\\b(AVC|HEVC|VC[-_. ]?1|MVC|MPEG[-_. ]?2)\\b))\\b)(((?=.*\\b(Blu[-_. ]?ray|BD|HD[-_. ]?DVD)\\b)(?=.*\\b(AVC|HEVC|VC[-_. ]?1|MVC|MPEG[-_. ]?2|BDMV|ISO|H[ ._-]?26[45])\\b))|^((?=.*\\b(((?=.*\\b((.*_)?COMPLETE.*|Dis[ck])\\b)(?=.*(Blu[-_. ]?ray|HD[-_. ]?DVD)))|3D[-_. ]?BD|BR[-_. ]?DISK|Full[-_. ]?Blu[-_. ]?ray|^((?=.*((BD|UHD)[-_. ]?(25|50|66|100|ISO)))))))).*"
+        "value": "^(?!.*\\b((?<!HD[._ -]|HD)DVD|BDRip|MKV|XviD|WMV|d3g|(BD)?REMUX|^(?=.*1080p)(?=.*HEVC)|[x][-_. ]?26[45]|German.*[DM]L|((?<=\\d{4}).*German.*([DM]L)?)(?=.*\\b(AVC|HEVC|VC[-_. ]?1|MVC|MPEG[-_. ]?2)\\b))\\b)(((?=.*\\b(Blu[-_. ]?ray|BD|HD[-_. ]?DVD)\\b)(?=.*\\b(AVC|HEVC|VC[-_. ]?1|MVC|MPEG[-_. ]?2|BDMV|ISO|H[ ._-]?26[45])\\b))|^((?=.*\\b(((?=.*\\b((.*_)?COMPLETE.*|Dis[ck])\\b)(?=.*(Blu[-_. ]?ray|HD[-_. ]?DVD)))|3D[-_. ]?BD|BR[-_. ]?DISK|Full[-_. ]?Blu[-_. ]?ray|^((?=.*((BD|UHD)[-_. ]?(25|50|66|100|ISO)))))))).*"
       }
     }
   ]

--- a/docs/json/sonarr/cf/br-disk.json
+++ b/docs/json/sonarr/cf/br-disk.json
@@ -5,7 +5,7 @@
     "german": -35000,
     "german-anime": -35000
   },
-  "trash_regex": "https://regex101.com/r/m6tJzR/1",
+  "trash_regex": "https://regex101.com/r/NnBZx0/1",
   "name": "BR-DISK",
   "includeCustomFormatWhenRenaming": false,
   "specifications": [

--- a/docs/json/sonarr/cf/br-disk.json
+++ b/docs/json/sonarr/cf/br-disk.json
@@ -5,7 +5,7 @@
     "german": -35000,
     "german-anime": -35000
   },
-  "trash_regex": "https://regex101.com/r/UpA3I7/2",
+  "trash_regex": "https://regex101.com/r/m6tJzR/1",
   "name": "BR-DISK",
   "includeCustomFormatWhenRenaming": false,
   "specifications": [
@@ -15,7 +15,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "^(?!.*\\b((?<!HD[._ -]|HD)DVD|BDRip|720p|MKV|XviD|WMV|d3g|(BD)?REMUX|^(?=.*1080p)(?=.*HEVC)|[xh][-_. ]?26[45]|German.*[DM]L|((?<=\\d{4}).*German.*([DM]L)?)(?=.*\\b(AVC|HEVC|VC[-_. ]?1|MVC|MPEG[-_. ]?2)\\b))\\b)(((?=.*\\b(Blu[-_. ]?ray|BD|HD[-_. ]?DVD)\\b)(?=.*\\b(AVC|HEVC|VC[-_. ]?1|MVC|MPEG[-_. ]?2|BDMV|ISO)\\b))|^((?=.*\\b(((?=.*\\b((.*_)?COMPLETE.*|Dis[ck])\\b)(?=.*(Blu[-_. ]?ray|HD[-_. ]?DVD)))|3D[-_. ]?BD|BR[-_. ]?DISK|Full[-_. ]?Blu[-_. ]?ray|^((?=.*((BD|UHD)[-_. ]?(25|50|66|100|ISO)))))))).*"
+        "value": "^(?!.*\\b((?<!HD[._ -]|HD)DVD|BDRip|MKV|XviD|WMV|d3g|(BD)?REMUX|^(?=.*1080p)(?=.*HEVC)|[xh][-_. ]?26[45]|German.*[DM]L|((?<=\\d{4}).*German.*([DM]L)?)(?=.*\\b(AVC|HEVC|VC[-_. ]?1|MVC|MPEG[-_. ]?2)\\b))\\b)(((?=.*\\b(Blu[-_. ]?ray|BD|HD[-_. ]?DVD)\\b)(?=.*\\b(AVC|HEVC|VC[-_. ]?1|MVC|MPEG[-_. ]?2|BDMV|ISO)\\b))|^((?=.*\\b(((?=.*\\b((.*_)?COMPLETE.*|Dis[ck])\\b)(?=.*(Blu[-_. ]?ray|HD[-_. ]?DVD)))|3D[-_. ]?BD|BR[-_. ]?DISK|Full[-_. ]?Blu[-_. ]?ray|^((?=.*((BD|UHD)[-_. ]?(25|50|66|100|ISO)))))))).*"
       }
     }
   ]


### PR DESCRIPTION
# Pull Request

## Purpose

`BR-DISK` (Sonarr and Radarr) and `BR-DISK (BTN)` never match a full-disc release whose title carries `720p`, because `720p` sits in the regex's leading negative lookahead. Blu-ray discs can be authored at 720p, and at least one tracker names disc sets that way, for example `Series S01 720p Blu-ray AVC DTS-HD MA 2.0-RlsGrp` (a 288 GB BDMV folder set). Sonarr parses that as `Bluray-720p`, the CF stays silent, and with a positive audio score the pack is grabbed and then fails to import.

## Approach

Remove the `720p` alternative from the negative lookahead in all three definitions. Nothing else changes:

- 720p encodes remain unmatched through the existing `x264`/`x265`, `BDRip`, `MKV` and `REMUX` exemptions.
- The change is consistent with how the CF already treats `1080p Blu-ray AVC` titles as discs.
- All 23 existing regex101 test cases keep their result; sixteen 720p cases were added, anonymised per the guidelines (ten disc-set patterns across AVC, VC-1 and MPEG-2 that now match, plus x264, REMUX, BDRip and WEB-DL titles that must not).

regex101 (.NET flavour, all cases): https://regex101.com/r/NnBZx0/1

## Open Questions and Pre-Merge TODOs

- [ ] If `720p` was added in #1578 for a false-positive case I could not find, I am happy to narrow this to a lookahead that only exempts `720p` when an encode marker is also present.

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).

## AI disclosure

This pull request was created with AI assistance.

## Summary by Sourcery

Bug Fixes:
- Allow the Radarr and Sonarr BR-DISK custom formats to match full-disc Blu-ray releases labeled 720p without changing matching behavior for encoded or remuxed releases.
