### PR TITLE
fix(sonarr-anime): anchor Anime LQ Groups patterns to release-tag position

### DIFF
--- a/docs/json/sonarr/cf/anime-lq-groups.json
+++ b/docs/json/sonarr/cf/anime-lq-groups.json
@@ -274,7 +274,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "\\[Daddy(Subs)?\\]|-Daddy(Subs)?\\b"
+        "value": "\\[Daddy(Subs)?\\]|-Daddy(Subs)?$"
       }
     },
     {
@@ -679,7 +679,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "\\b(Mites)\\b"
+        "value": "\\[Mites\\]|-Mites$"
       }
     },
     {
@@ -940,7 +940,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "\\[SAD\\]|-SAD\\b"
+        "value": "\\[SAD\\]|-SAD$"
       }
     },
     {


### PR DESCRIPTION
Fixes #2875

## Summary

Three `ReleaseTitleSpecification` patterns in `docs/json/sonarr/cf/anime-lq-groups.json` matched substrings of episode titles instead of release-group tags. With the CF at `-10000` this silently rejected valid imports, e.g.:

- One Piece S12E54 "Brook's Past - Sad Farewell ..." from Kitsune (`-Sad` matched the episode title)
- "Of Mites and Men" from BiA (`\b(Mites)\b` matched the English word)
- "T-Daddy" from NTb (`-Daddy` + word boundary matched the title)

## Changes

Anchor each pattern per the convention already used by the other entries in this file (Ari, Cerberus, Cleo, HR, Kallango, Pantsu, USD, ...):

- `DaddySubs`: `[Daddy(Subs)?]|-Daddy(Subs)?\b` → `[Daddy(Subs)?]|-Daddy(Subs)?$`
- `Mites`: `\b(Mites)\b` → `[Mites]|-Mites$`
- `SAD`: `[SAD]|-SAD\b` → `[SAD]|-SAD$`

Kept as `ReleaseTitleSpecification` per @rg9400's note in #2875 that `ReleaseGroupSpecification` would be too narrow for anime leading-bracket groups. Scope is intentionally narrow (only the three patterns named in the issue); the same review logic likely applies to the matching radarr file — happy to follow up.

## Verification

Python `re` harness against the fixed values: 9 negative samples (the documented colliding episode titles plus edge cases like `-SAD-`, mid-word `Mites`) all no longer match; 10 positive samples (leading `[Group]` tags and trailing `-Group` tags) all match.

- `scripts/validate-custom-formats.py` — passed
- `scripts/validate-source-specifications.py` — passed
- `scripts/validate-quality-profiles.py` — passed
- `python -m unittest discover -s tests` — 7/7 OK

## Summary by Sourcery

Bug Fixes:
- Prevent the Anime LQ Groups custom format from matching group names embedded in episode titles by anchoring the DaddySubs, Mites, and SAD patterns to release-group tag positions.