### PR TITLE
feat(starr): Removed RlsGrp `HHWEB` from `WEB Tier 03`

### DIFF
--- a/docs/json/radarr/cf/web-tier-03.json
+++ b/docs/json/radarr/cf/web-tier-03.json
@@ -37,15 +37,6 @@
       }
     },
     {
-      "name": "HHWEB",
-      "implementation": "ReleaseGroupSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "^(HHWEB)$"
-      }
-    },
-    {
       "name": "NINJACENTRAL",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,

--- a/docs/json/sonarr/cf/web-tier-03.json
+++ b/docs/json/sonarr/cf/web-tier-03.json
@@ -36,15 +36,6 @@
       }
     },
     {
-      "name": "HHWEB",
-      "implementation": "ReleaseGroupSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "^(HHWEB)$"
-      }
-    },
-    {
       "name": "NINJACENTRAL",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->

Move `HHWEB` out of `WEB Tier 03` so it is scored the same as other RAW MA WEBDL providers. This also helps users who use the `Asian Tier 03` CF, since that CF prefers `HHWEB` for Asian content.
We're also considering keeping the WEB Tiers mainly for hybrid release groups.

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

Removed RlsGrp `HHWEB` from `WEB Tier 03`

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Enhancements:
- Remove the HHWEB release group from the Radarr and Sonarr WEB Tier 03 custom formats so it is scored consistently with other RAW MA WEBDL providers.