### PR TITLE
fix(downloaders): stop set -e  killing the mover scripts on a failed instance or dry-run

### DIFF
--- a/includes/downloaders/mover-tuning-end.sh
+++ b/includes/downloaders/mover-tuning-end.sh
@@ -3,8 +3,8 @@ set -euo pipefail # Exit on error, undefined variables, and pipe failures
 
 # =====================================
 # Script: qBittorrent Cache Mover - End
-# Version: 1.3.4
-# Updated: 20260614
+# Version: 1.3.5
+# Updated: 20260908
 # =====================================
 
 # Script version and update check URLs
@@ -495,7 +495,7 @@ main() {
     for ((i=0; i<instance_count; i++)); do
         get_instance_details "$i"
 
-        process_qbit_instance "$INSTANCE_NAME" "$INSTANCE_HOST" "$INSTANCE_USER" "$INSTANCE_PASSWORD" "$INSTANCE_CA_BUNDLE" || ((failed_instances++))
+        process_qbit_instance "$INSTANCE_NAME" "$INSTANCE_HOST" "$INSTANCE_USER" "$INSTANCE_PASSWORD" "$INSTANCE_CA_BUNDLE" || failed_instances=$((failed_instances + 1))
     done
 
     # Run duplicate finder if enabled

--- a/includes/downloaders/mover-tuning-end.sh
+++ b/includes/downloaders/mover-tuning-end.sh
@@ -8,7 +8,7 @@ set -euo pipefail # Exit on error, undefined variables, and pipe failures
 # =====================================
 
 # Script version and update check URLs
-readonly SCRIPT_VERSION="1.3.4"
+readonly SCRIPT_VERSION="1.3.5"
 readonly SCRIPT_RAW_URL="https://raw.githubusercontent.com/TRaSH-Guides/Guides/refs/heads/master/includes/downloaders/mover-tuning-end.sh"
 
 # Get the directory where the script is located

--- a/includes/downloaders/mover-tuning-start.sh
+++ b/includes/downloaders/mover-tuning-start.sh
@@ -3,8 +3,8 @@ set -euo pipefail # Exit on error, undefined variables, and pipe failures
 
 # =======================================
 # Script: qBittorrent Cache Mover - Start
-# Version: 1.3.4
-# Updated: 20260902
+# Version: 1.3.5
+# Updated: 20260908
 # =======================================
 
 # Script version and update check URLs
@@ -410,10 +410,9 @@ run_auto_installer() {
         if "$venv_python" -c "import qbittorrentapi" 2>/dev/null; then
             log "✓ qbittorrent-api installed ($("$venv_python" -m pip show qbittorrent-api 2>/dev/null | awk '/Version:/ {print $2}'))"
 
-            local api_upgrade_needed=true dry_run_output dry_run_status
+            local api_upgrade_needed=true dry_run_output dry_run_status=0
             if [[ "$supports_dry_run" == true ]]; then
-                dry_run_output=$("$venv_python" -m pip install --dry-run --upgrade qbittorrent-api 2>&1)
-                dry_run_status=$?
+                dry_run_output=$("$venv_python" -m pip install --dry-run --upgrade qbittorrent-api 2>&1) || dry_run_status=$?
                 if [[ $dry_run_status -eq 0 ]]; then
                     if echo "$dry_run_output" | grep -q "Would install"; then
                         api_upgrade_needed=true
@@ -636,7 +635,7 @@ main() {
     for ((i=0; i<instance_count; i++)); do
         get_instance_details "$i"
 
-        process_qbit_instance "$INSTANCE_NAME" "$INSTANCE_HOST" "$INSTANCE_USER" "$INSTANCE_PASSWORD" "$INSTANCE_CA_BUNDLE" || ((failed_instances++))
+        process_qbit_instance "$INSTANCE_NAME" "$INSTANCE_HOST" "$INSTANCE_USER" "$INSTANCE_PASSWORD" "$INSTANCE_CA_BUNDLE" || failed_instances=$((failed_instances + 1))
     done
 
     # Summary

--- a/includes/downloaders/mover-tuning-start.sh
+++ b/includes/downloaders/mover-tuning-start.sh
@@ -8,7 +8,7 @@ set -euo pipefail # Exit on error, undefined variables, and pipe failures
 # =======================================
 
 # Script version and update check URLs
-readonly SCRIPT_VERSION="1.3.4"
+readonly SCRIPT_VERSION="1.3.5"
 readonly SCRIPT_RAW_URL="https://raw.githubusercontent.com/TRaSH-Guides/Guides/refs/heads/master/includes/downloaders/mover-tuning-start.sh"
 readonly CONFIG_RAW_URL="https://raw.githubusercontent.com/TRaSH-Guides/Guides/refs/heads/master/includes/downloaders/mover-tuning.cfg"
 


### PR DESCRIPTION
# Pull Request

## Purpose

Closes #2863.

Two `set -e` traps, one line each.

`start.sh:639` / `end.sh:498` — `((failed_instances++))` returns 1 on the first failure, since the post-increment evaluates to 0. So the counter meant to tolerate a failed instance is what kills the script. In `end.sh` that's one line before the duplicate finder, and torrents stay paused.

`start.sh:413` — `dry_run_output=$(…)` then `dry_run_status=$?`: a failing command substitution aborts before `$?` is read, so the "upgrading anyway" fallback below it can't run and an index timeout takes the before script with it. From #2873.

## Approach

Counter written as an assignment, which always exits 0 — same as `((stop_failed++)) || true` already at `start.sh:624`. Dry-run status read in the `||` position.

Tested on bash 5.3.15 / Unraid 7.3.2. Before, both abort with no output. After:

```
2 failed instances    -> failed=2, summary reached
1 failed + 1 ok       -> failed=1
dry-run fails         -> upgrades anyway
dry-run Would install -> upgrades
dry-run up to date    -> skips
```

Both scripts bumped to 1.3.5.

## Open Questions and Pre-Merge TODOs

None.

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Ensure qBittorrent cache mover scripts tolerate instance and dependency-check failures without terminating prematurely.

Bug Fixes:
- Prevent the mover scripts from aborting when processing failed qBittorrent instances, allowing failure counts and subsequent summaries or duplicate handling to complete.
- Allow the start script to handle failed dependency dry runs and continue with the intended upgrade fallback instead of exiting prematurely.

Chores:
- Bump both mover scripts to version 1.3.5.