### PR TITLE
feat(downloaders): Add WebUI API key support for qBittorrent (rebase of #2860)

### DIFF
--- a/includes/downloaders/mover-tuning-end.sh
+++ b/includes/downloaders/mover-tuning-end.sh
@@ -3,12 +3,12 @@ set -euo pipefail # Exit on error, undefined variables, and pipe failures
 
 # =====================================
 # Script: qBittorrent Cache Mover - End
-# Version: 1.3.4
-# Updated: 20260614
+# Version: 1.3.5
+# Updated: 20260817
 # =====================================
 
 # Script version and update check URLs
-readonly SCRIPT_VERSION="1.3.4"
+readonly SCRIPT_VERSION="1.3.5"
 readonly SCRIPT_RAW_URL="https://raw.githubusercontent.com/TRaSH-Guides/Guides/refs/heads/master/includes/downloaders/mover-tuning-end.sh"
 
 # Get the directory where the script is located
@@ -83,6 +83,7 @@ get_instance_details() {
         INSTANCE_HOST="${HOSTS[$index]}"
         INSTANCE_USER="${USERS[$index]}"
         INSTANCE_PASSWORD="${PASSWORDS[$index]}"
+        INSTANCE_API_KEY="${API_KEYS[$index]:-}"
         INSTANCE_CA_BUNDLE="${CA_BUNDLES[$index]:-}"
     else
         # Legacy format: map index to old variables
@@ -91,12 +92,14 @@ get_instance_details() {
             INSTANCE_HOST="${QBIT_HOST_1}"
             INSTANCE_USER="${QBIT_USER_1}"
             INSTANCE_PASSWORD="${QBIT_PASS_1}"
+            INSTANCE_API_KEY="${QBIT_API_KEY_1:-}"
             INSTANCE_CA_BUNDLE="${QBIT_CA_BUNDLE_1:-}"
         elif [[ $index -eq 1 ]]; then
             INSTANCE_NAME="${QBIT_NAME_2}"
             INSTANCE_HOST="${QBIT_HOST_2}"
             INSTANCE_USER="${QBIT_USER_2}"
             INSTANCE_PASSWORD="${QBIT_PASS_2}"
+            INSTANCE_API_KEY="${QBIT_API_KEY_2:-}"
             INSTANCE_CA_BUNDLE="${QBIT_CA_BUNDLE_2:-}"
         else
             error "Invalid instance index: $index"
@@ -391,6 +394,11 @@ validate_config() {
             [[ ${#NAMES[@]} -eq ${#HOSTS[@]} ]] || error "NAMES array length doesn't match HOSTS"
         fi
 
+        # API_KEYS array is optional, but if present should match
+        if [[ -v API_KEYS ]] && [[ ${#API_KEYS[@]} -gt 0 ]]; then
+            [[ ${#API_KEYS[@]} -eq ${#HOSTS[@]} ]] || error "API_KEYS array length doesn't match HOSTS"
+        fi
+
         # CA_BUNDLES array is optional, but if present should match
         if [[ -v CA_BUNDLES ]] && [[ ${#CA_BUNDLES[@]} -gt 0 ]]; then
             [[ ${#CA_BUNDLES[@]} -eq ${#HOSTS[@]} ]] || error "CA_BUNDLES array length doesn't match HOSTS"
@@ -429,7 +437,8 @@ process_qbit_instance() {
     local host="$2"
     local user="$3"
     local password="$4"
-    local ca_bundle="${5:-}"
+    local api_key="${5:-}"
+    local ca_bundle="${6:-}"
 
     log "Processing $name..."
 
@@ -446,20 +455,25 @@ process_qbit_instance() {
         return 1
     fi
 
-    local ca_bundle_args=()
+    local mover_args=(
+        --resume
+        --host "$host"
+        --days_from "$DAYS_FROM"
+        --days_to "$DAYS_TO"
+    )
+
+    if [[ -n "$api_key" ]]; then
+        mover_args+=(--api-key "$api_key")
+    else
+        mover_args+=(--user "$user" --password "$password")
+    fi
+
     if [[ -n "$ca_bundle" ]]; then
-        ca_bundle_args=(--ca-bundle "$ca_bundle")
+        mover_args+=(--ca-bundle "$ca_bundle")
     fi
 
     # Execute mover script
-    if "$python_cmd" "${QBIT_MOVER_PATH}mover.py" \
-        --resume \
-        --host "$host" \
-        --user "$user" \
-        --password "$password" \
-        --days_from "$DAYS_FROM" \
-        --days_to "$DAYS_TO" \
-        "${ca_bundle_args[@]}"; then
+    if "$python_cmd" "${QBIT_MOVER_PATH}mover.py" "${mover_args[@]}"; then
         log "✓ Successfully resumed torrents for $name"
         notify "$name" "Resumed @ $(date +%H:%M:%S)"
         return 0
@@ -495,7 +509,7 @@ main() {
     for ((i=0; i<instance_count; i++)); do
         get_instance_details "$i"
 
-        process_qbit_instance "$INSTANCE_NAME" "$INSTANCE_HOST" "$INSTANCE_USER" "$INSTANCE_PASSWORD" "$INSTANCE_CA_BUNDLE" || ((failed_instances++))
+        process_qbit_instance "$INSTANCE_NAME" "$INSTANCE_HOST" "$INSTANCE_USER" "$INSTANCE_PASSWORD" "$INSTANCE_API_KEY" "$INSTANCE_CA_BUNDLE" || ((failed_instances++))
     done
 
     # Run duplicate finder if enabled

--- a/includes/downloaders/mover-tuning-end.sh
+++ b/includes/downloaders/mover-tuning-end.sh
@@ -3,12 +3,12 @@ set -euo pipefail # Exit on error, undefined variables, and pipe failures
 
 # =====================================
 # Script: qBittorrent Cache Mover - End
-# Version: 1.3.5
+# Version: 1.3.6
 # Updated: 20260909
 # =====================================
 
 # Script version and update check URLs
-readonly SCRIPT_VERSION="1.3.5"
+readonly SCRIPT_VERSION="1.3.6"
 readonly SCRIPT_RAW_URL="https://raw.githubusercontent.com/TRaSH-Guides/Guides/refs/heads/master/includes/downloaders/mover-tuning-end.sh"
 
 # Get the directory where the script is located

--- a/includes/downloaders/mover-tuning-end.sh
+++ b/includes/downloaders/mover-tuning-end.sh
@@ -4,7 +4,7 @@ set -euo pipefail # Exit on error, undefined variables, and pipe failures
 # =====================================
 # Script: qBittorrent Cache Mover - End
 # Version: 1.3.5
-# Updated: 20260817
+# Updated: 20260909
 # =====================================
 
 # Script version and update check URLs

--- a/includes/downloaders/mover-tuning-start.sh
+++ b/includes/downloaders/mover-tuning-start.sh
@@ -3,12 +3,12 @@ set -euo pipefail # Exit on error, undefined variables, and pipe failures
 
 # =======================================
 # Script: qBittorrent Cache Mover - Start
-# Version: 1.3.4
-# Updated: 20260902
+# Version: 1.3.5
+# Updated: 20260909
 # =======================================
 
 # Script version and update check URLs
-readonly SCRIPT_VERSION="1.3.4"
+readonly SCRIPT_VERSION="1.3.5"
 readonly SCRIPT_RAW_URL="https://raw.githubusercontent.com/TRaSH-Guides/Guides/refs/heads/master/includes/downloaders/mover-tuning-start.sh"
 readonly CONFIG_RAW_URL="https://raw.githubusercontent.com/TRaSH-Guides/Guides/refs/heads/master/includes/downloaders/mover-tuning.cfg"
 

--- a/includes/downloaders/mover-tuning-start.sh
+++ b/includes/downloaders/mover-tuning-start.sh
@@ -3,12 +3,12 @@ set -euo pipefail # Exit on error, undefined variables, and pipe failures
 
 # =======================================
 # Script: qBittorrent Cache Mover - Start
-# Version: 1.3.5
+# Version: 1.3.6
 # Updated: 20260909
 # =======================================
 
 # Script version and update check URLs
-readonly SCRIPT_VERSION="1.3.5"
+readonly SCRIPT_VERSION="1.3.6"
 readonly SCRIPT_RAW_URL="https://raw.githubusercontent.com/TRaSH-Guides/Guides/refs/heads/master/includes/downloaders/mover-tuning-start.sh"
 readonly CONFIG_RAW_URL="https://raw.githubusercontent.com/TRaSH-Guides/Guides/refs/heads/master/includes/downloaders/mover-tuning.cfg"
 

--- a/includes/downloaders/mover-tuning-start.sh
+++ b/includes/downloaders/mover-tuning-start.sh
@@ -96,6 +96,7 @@ get_instance_details() {
         INSTANCE_HOST="${HOSTS[$index]}"
         INSTANCE_USER="${USERS[$index]}"
         INSTANCE_PASSWORD="${PASSWORDS[$index]}"
+        INSTANCE_API_KEY="${API_KEYS[$index]:-}"
         INSTANCE_CA_BUNDLE="${CA_BUNDLES[$index]:-}"
     else
         # Legacy format: map index to old variables
@@ -104,12 +105,14 @@ get_instance_details() {
             INSTANCE_HOST="${QBIT_HOST_1}"
             INSTANCE_USER="${QBIT_USER_1}"
             INSTANCE_PASSWORD="${QBIT_PASS_1}"
+            INSTANCE_API_KEY="${QBIT_API_KEY_1:-}"
             INSTANCE_CA_BUNDLE="${QBIT_CA_BUNDLE_1:-}"
         elif [[ $index -eq 1 ]]; then
             INSTANCE_NAME="${QBIT_NAME_2}"
             INSTANCE_HOST="${QBIT_HOST_2}"
             INSTANCE_USER="${QBIT_USER_2}"
             INSTANCE_PASSWORD="${QBIT_PASS_2}"
+            INSTANCE_API_KEY="${QBIT_API_KEY_2:-}"
             INSTANCE_CA_BUNDLE="${QBIT_CA_BUNDLE_2:-}"
         else
             error "Invalid instance index: $index"
@@ -517,6 +520,14 @@ validate_config() {
             fi
         fi
 
+        # API_KEYS array is optional, but if present should match
+        if [[ -v API_KEYS ]] && [[ ${#API_KEYS[@]} -gt 0 ]]; then
+            if [[ ${#API_KEYS[@]} -ne ${#HOSTS[@]} ]]; then
+                notify "Configuration Error" "API_KEYS array length (${#API_KEYS[@]}) doesn't match HOSTS (${#HOSTS[@]})"
+                error "API_KEYS array length doesn't match HOSTS"
+            fi
+        fi
+
         # CA_BUNDLES array is optional, but if present should match
         if [[ -v CA_BUNDLES ]] && [[ ${#CA_BUNDLES[@]} -gt 0 ]]; then
             if [[ ${#CA_BUNDLES[@]} -ne ${#HOSTS[@]} ]]; then
@@ -540,7 +551,7 @@ validate_config() {
 # PROCESS QBITTORRENT INSTANCE
 # ================================
 process_qbit_instance() {
-    local name="$1" host="$2" user="$3" password="$4" ca_bundle="${5:-}"
+    local name="$1" host="$2" user="$3" password="$4" api_key="${5:-}" ca_bundle="${6:-}"
 
     log "Processing $name..."
 
@@ -557,23 +568,29 @@ process_qbit_instance() {
         return 1
     fi
 
-    local ca_bundle_args=()
-    if [[ -n "$ca_bundle" ]]; then
-        ca_bundle_args=(--ca-bundle "$ca_bundle")
+    local mover_args=(
+        --pause
+        --host "$host"
+        --cache-mount "$CACHE_MOUNT"
+        --days_from "$DAYS_FROM"
+        --days_to "$DAYS_TO"
+    )
+
+    if [[ -n "$api_key" ]]; then
+        mover_args+=(--api-key "$api_key")
+    else
+        mover_args+=(--user "$user" --password "$password")
     fi
 
-    # Run mover script
-    if $python_cmd "$MOVER_SCRIPT" \
-        --pause \
-        --host "$host" \
-        --user "$user" \
-        --password "$password" \
-        --cache-mount "$CACHE_MOUNT" \
-        --days_from "$DAYS_FROM" \
-        --days_to "$DAYS_TO" \
-        "${ca_bundle_args[@]}" 2>&1 | while IFS= read -r line; do
+    if [[ -n "$ca_bundle" ]]; then
+        mover_args+=(--ca-bundle "$ca_bundle")
+    fi
+
+    if "$python_cmd" "$MOVER_SCRIPT" "${mover_args[@]}" 2>&1 |
+        while IFS= read -r line; do
             log "  $line"
-        done; then
+        done
+    then
         log "✓ Successfully processed $name"
         notify "$name" "Paused @ $(date +%H:%M:%S)"
         return 0
@@ -636,7 +653,7 @@ main() {
     for ((i=0; i<instance_count; i++)); do
         get_instance_details "$i"
 
-        process_qbit_instance "$INSTANCE_NAME" "$INSTANCE_HOST" "$INSTANCE_USER" "$INSTANCE_PASSWORD" "$INSTANCE_CA_BUNDLE" || ((failed_instances++))
+        process_qbit_instance "$INSTANCE_NAME" "$INSTANCE_HOST" "$INSTANCE_USER" "$INSTANCE_PASSWORD" "$INSTANCE_API_KEY" "$INSTANCE_CA_BUNDLE" || ((failed_instances++))
     done
 
     # Summary

--- a/includes/downloaders/mover-tuning.cfg
+++ b/includes/downloaders/mover-tuning.cfg
@@ -2,7 +2,7 @@
 # <----- Update and version settings ----->
 # =============================================
 
-readonly CONFIG_VERSION="1.3.1" # ONLY UPDATE THE VERSION NUMBER WHEN A CONFIGURATION FILE CHANGE HAS BEEN MADE
+readonly CONFIG_VERSION="1.3.2" # ONLY UPDATE THE VERSION NUMBER WHEN A CONFIGURATION FILE CHANGE HAS BEEN MADE
 readonly ENABLE_VERSION_CHECK=true # Set to false to disable all update checks and notifications (not recommended)
 
 # =============================================
@@ -21,12 +21,15 @@ readonly QBIT_MOVER_PATH="/mnt/user/appdata/qbt-mover/"  # Path to mover.py
 
 # qBittorrent instances
 # Supports unlimited qBittorrent instances
-# Arrays NAMES, HOSTS, USERS and PASSWORDS must all have the same length
-# NAMES array is optional - if omitted, instances will be named "qBit-Instance-1", "qBit-Instance-2", etc.
+# Arrays HOSTS, USERS and PASSWORDS must all have the same length
+# Arrays NAMES, API_KEYS and CA_BUNDLES are optional but if present must also have the same length as HOSTS
+# NAMES array, if omitted, instances will be named "qBit-Instance-1", "qBit-Instance-2", etc.
+# API_KEYS, if specified, will be used instead of USER/PASSWORD for authentication. If both are specified, API_KEYS will take precedence.
 readonly NAMES=("qBit-Movies" "qBit-TV" "qBit-Music")  # qBittorrent instance names
 readonly HOSTS=("192.168.2.200:8088" "192.168.2.200:8811" "192.168.2.200:8822")  # qBittorrent host:port
-readonly USERS=("admin" "admin" "admin")  # qBittorrent usernames
-readonly PASSWORDS=("qbt1-password" "qbt2-password" "qbt3-password")  # qBittorrent passwords
+readonly USERS=("admin" "admin" "")  # qBittorrent usernames
+readonly PASSWORDS=("qbt1-password" "qbt2-password" "")  # qBittorrent passwords
+readonly API_KEYS=("" "qbt_abc" "qbt_xyz")  # qBittorrent WebUI API keys
 readonly CA_BUNDLES=("/mnt/user/appdata/qbt-mover/qbit-movies-ca.crt" "/mnt/user/appdata/qbt-mover/qbit-tv-ca.crt" "")  # Path to CA bundle for SSL with self signed cert
 
 # Docker container management (OPTIONAL)

--- a/includes/downloaders/mover-tuning.cfg
+++ b/includes/downloaders/mover-tuning.cfg
@@ -32,7 +32,7 @@ readonly HOSTS=("192.168.2.200:8088" "192.168.2.200:8811" "192.168.2.200:8822") 
 readonly USERS=("admin" "admin" "")  # qBittorrent usernames
 readonly PASSWORDS=("qbt1-password" "qbt2-password" "")  # qBittorrent passwords
 readonly API_KEYS=("" "qbt_abc" "qbt_xyz")  # qBittorrent WebUI API keys
-readonly CA_BUNDLES=("/mnt/user/appdata/qbt-mover/qbit-movies-ca.crt" "/mnt/user/appdata/qbt-mover/qbit-tv-ca.crt" "")  # Path to CA bundle for SSL with self signed cert
+# readonly CA_BUNDLES=("/mnt/user/appdata/qbt-mover/qbit-movies-ca.crt" "/mnt/user/appdata/qbt-mover/qbit-tv-ca.crt" "")  # Path to CA bundle for SSL with self signed cert
 
 # Docker container management (OPTIONAL)
 # Stop containers before the mover runs and start them again afterwards.

--- a/includes/downloaders/mover-tuning.cfg
+++ b/includes/downloaders/mover-tuning.cfg
@@ -25,6 +25,8 @@ readonly QBIT_MOVER_PATH="/mnt/user/appdata/qbt-mover/"  # Path to mover.py
 # Arrays NAMES, API_KEYS and CA_BUNDLES are optional but if present must also have the same length as HOSTS
 # NAMES array, if omitted, instances will be named "qBit-Instance-1", "qBit-Instance-2", etc.
 # API_KEYS, if specified, will be used instead of USER/PASSWORD for authentication. If both are specified, API_KEYS will take precedence.
+# API keys need qBittorrent 5.2.0+ (Options -> WebUI -> API Key). Use "" for instances that authenticate with USER/PASSWORD.
+# qui users: put the client proxy URL in HOSTS instead (e.g. "qui:7476/proxy/<client-api-key>") and leave API_KEYS empty.
 readonly NAMES=("qBit-Movies" "qBit-TV" "qBit-Music")  # qBittorrent instance names
 readonly HOSTS=("192.168.2.200:8088" "192.168.2.200:8811" "192.168.2.200:8822")  # qBittorrent host:port
 readonly USERS=("admin" "admin" "")  # qBittorrent usernames


### PR DESCRIPTION
# Pull Request

## Purpose

#2860 rebased so it can merge with fixes.

Adds optional API key auth for qBittorrent 5.2+. `API_KEYS` array in the cfg (or `QBIT_API_KEY_1/2` for legacy), checked against `HOSTS`, passed to mover.py as `--api-key` instead of user/password when set. Nothing changes for those using username/password.

## Approach

- hymccord's commit cherry-picked onto master. Only conflict was the `# Updated:` line.
- versions bumped past #2873. start 1.3.6, end 1.3.6, cfg 1.3.2.
- two comment lines in the cfg. Needs qBittorrent 5.2.0+, and qui users put the proxy URL in `HOSTS` not `API_KEYS`.

qbittorrent-api 2026.5.3+ skips the login call when an api key is set and ignores user/password, so passing only `--api-key` is right.

Tested on Unraid 7.3.2, qBittorrent 5.2.3, qbittorrent-api 2026.8.1.

```
key only, user/pass empty              works as intended
wrong key                              fails as it should, Forbidden403 from both scripts
no API_KEYS, user/pass                 works as intended, old path
legacy cfg, QBIT_API_KEY_1             works as intended
mixed, inst 1 user/pass, inst 2 key    works as intended
```

Sourcery's two comments on #2860 don't need changes. The NAMES length check it says is missing is already in start.sh (line 515). Requiring a key or a user/password would break setups using bypass_local_auth or the subnet whitelist, where empty credentials are valid. A bad key already fails for that instance with a clear error.

## Open Questions and Pre-Merge TODOs

- [x] Version clash with #2884 sorted. #2884 takes 1.3.5, this one is now 1.3.6, so anyone who
  already pulled 1.3.5 still gets told about this one. Merge #2884 first and I'll rebase this
  branch on master straight after, so there's nothing to resolve here.

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Support qBittorrent API key authentication while retaining username/password compatibility.

New Features:
- Add optional per-instance qBittorrent WebUI API key authentication, including support for both array-based and legacy configurations.

Enhancements:
- Preserve username/password authentication when no API key is configured and validate API key configuration against configured hosts.

Documentation:
- Document qBittorrent API key requirements, precedence, mixed authentication, and qui proxy configuration.

Chores:
- Bump the mover scripts to version 1.3.6 and the configuration to version 1.3.2.