### PR TITLE
feat(guide-sync): Sorting order fix for the German Anime Profiles and other fixes

### DIFF
--- a/docs/json/radarr/cf/126811.json
+++ b/docs/json/radarr/cf/126811.json
@@ -15,6 +15,24 @@
       "fields": {
         "value": "^(126811)$"
       }
+    },
+    {
+      "name": "Internal",
+      "implementation": "IndexerFlagSpecification",
+      "negate": false,
+      "required": true,
+      "fields": {
+        "value": 32
+      }
+    },
+    {
+      "name": "Not ATMO5/ATM05 Collab",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": true,
+      "required": true,
+      "fields": {
+        "value": "126811.{0,20}ATM[O0]5"
+      }
     }
   ]
 }

--- a/docs/json/radarr/quality-profiles/german-anime-hd-bluray-web.json
+++ b/docs/json/radarr/quality-profiles/german-anime-hd-bluray-web.json
@@ -15,12 +15,12 @@
       "name": "Merged QPs",
       "allowed": true,
       "items": [
-        "WEBRip-720p",
-        "WEBDL-720p",
-        "Bluray-720p",
-        "WEBDL-1080p",
+        "Bluray-1080p",
         "WEBRip-1080p",
-        "Bluray-1080p"
+        "WEBDL-1080p",
+        "Bluray-720p",
+        "WEBDL-720p",
+        "WEBRip-720p"
       ]
     },
     { "name": "Raw-HD", "allowed": false },

--- a/docs/json/sonarr/quality-profiles/german-anime-hd-bluray-web.json
+++ b/docs/json/sonarr/quality-profiles/german-anime-hd-bluray-web.json
@@ -14,12 +14,12 @@
       "name": "Merged QPs",
       "allowed": true,
       "items": [
-        "WEBRip-720p",
-        "WEBDL-720p",
-        "Bluray-720p",
-        "WEBDL-1080p",
+        "Bluray-1080p",
         "WEBRip-1080p",
-        "Bluray-1080p"
+        "WEBDL-1080p",
+        "Bluray-720p",
+        "WEBDL-720p",
+        "WEBRip-720p"
       ]
     },
     { "name": "Bluray-2160p Remux", "allowed": false },


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Please provide a detailed description of why you created this pull request. -->

Sorting order fix for the German Anime Profiles and other fixes

## Approach

<!-- If this pull request is created to solve an issue, please explain how this change addresses the problem. -->

Sorting order fix for the German Anime Profiles and other fixes

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer. -->

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Fix German anime profile ordering and update the associated release configuration.

Bug Fixes:
- Correct German anime quality-profile sorting order across Radarr and Sonarr.

Enhancements:
- Add the updated profile configuration needed to support the German anime release-order fixes.